### PR TITLE
Issue with test mode and config.py imports

### DIFF
--- a/scripts/err.py
+++ b/scripts/err.py
@@ -22,9 +22,6 @@ import argparse
 from time import sleep
 import daemon
 
-# Sets a minimal logging on the console for the critical config errors
-from errbot.testmode import patch_jabberbot
-
 logging.basicConfig(format='%(levelname)s:%(message)s')
 logger = logging.getLogger('')
 logger.setLevel(logging.INFO)
@@ -103,6 +100,8 @@ if __name__ == "__main__":
             main()
 
     if args['test']:
+        # Sets a minimal logging on the console for the critical config errors
+        from errbot.testmode import patch_jabberbot
         patch_jabberbot()
 
     main()


### PR DESCRIPTION
...quires config, moved to test conditional

Import should come after the test argument validated because the tests require config.

See error:

``` bash
$ err.py -t
Traceback (most recent call last):
  File "/Users/glenbot/.virtualenv/botness/bin/err.py", line 26, in <module>
    from errbot.testmode import patch_jabberbot
  File "/Users/glenbot/.virtualenv/botness/lib/python2.7/site-packages/errbot/testmode.py", line 2, in <module>
    import config
ImportError: No module named config
```
