### PR TITLE
Fixing attribute error 

### DIFF
--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -386,7 +386,8 @@ class Backend(object):
     def send(self, user, text, in_reply_to=None, message_type='chat'):
         """Sends a simple message to the specified user."""
         mess = self.build_message(text)
-        mess.setTo(user.getStripped())
+        user = user.getStripped()
+        mess.setTo(user)
 
         if in_reply_to:
             mess.setType(in_reply_to.getType())


### PR DESCRIPTION
2012-08-28 12:30:50,944 ERROR crashed in callback_message 'str' object has no attribute 'getStripped'
Traceback (most recent call last):
  File "<string>", line 57, in callback_message
  File "/usr/local/lib/python2.7/dist-packages/errbot/botplugin.py", line 176, in send
    return holder.bot.send(user, text, in_reply_to, message_type)
  File "/usr/local/lib/python2.7/dist-packages/errbot/backends/base.py", line 381, in send
    mess.setTo(user.getStripped())
AttributeError: 'str' object has no attribute 'getStripped'
