### PR TITLE
Make command prefix configurable

### DIFF
--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -9,7 +9,7 @@ from errbot.utils import get_sender_username, xhtml2txt
 from errbot.templating import tenv
 import traceback
 from errbot.utils import get_jid_from_message, utf8
-from config import BOT_ADMINS, BOT_ASYNC
+from config import BOT_ADMINS, BOT_ASYNC, BOT_PREFIX
 
 if BOT_ASYNC:
     from errbot.bundled.threadpool import ThreadPool, WorkRequest
@@ -116,7 +116,7 @@ class Backend(object):
     MESSAGE_SIZE_LIMIT = 10000 # the default one from hipchat
     MESSAGE_SIZE_ERROR_MESSAGE = '|<- SNIP ! Message too long.'
     MSG_UNKNOWN_COMMAND = 'Unknown command: "%(command)s". '\
-                          'Type "!help" for available commands.'
+                          'Type "' + BOT_PREFIX + 'help" for available commands.'
     MSG_HELP_TAIL = 'Type help <command name> to get more info '\
                     'about that specific command.'
     MSG_HELP_UNDEFINED_COMMAND = 'That command is not defined.'
@@ -191,7 +191,7 @@ class Backend(object):
         # txt will be None
         if not text: return False
 
-        if not text.startswith('!'):
+        if not text.startswith(BOT_PREFIX):
             return True
 
         text = text[1:]
@@ -214,7 +214,7 @@ class Backend(object):
                 if len(text_split) > 1:
                     args = ' '.join(text_split[1:])
 
-        if command == '!': # we did "!!" so recall the last command
+        if command == BOT_PREFIX: # we did "!!" so recall the last command
             if len(self.cmd_history):
                 cmd, args = self.cmd_history[-1]
             else:
@@ -302,7 +302,7 @@ class Backend(object):
             matches.extend(difflib.get_close_matches(full_cmd, ununderscore_keys))
         matches = set(matches)
         if matches:
-            return part1 + '\n\nDid you mean "!' + '" or "!'.join(matches) + '" ?'
+            return part1 + '\n\nDid you mean "' + BOT_PREFIX + ('" or "' + BOT_PREFIX).join(matches) + '" ?'
         else:
             return part1
 
@@ -360,7 +360,7 @@ class Backend(object):
                 description = 'Available commands:'
 
             usage = '\n'.join(sorted([
-            '!%s: %s' % (name, (command.__doc__ or
+            BOT_PREFIX + '%s: %s' % (name, (command.__doc__ or
                                 '(undocumented)').strip().split('\n', 1)[0])
             for (name, command) in self.commands.iteritems()\
             if name != 'help'\
@@ -386,7 +386,7 @@ class Backend(object):
         l = len(self.cmd_history)
         for i in range(0, l):
             c = self.cmd_history[i]
-            answer.append('%2i:!%s %s' % (l - i, c[0], c[1]))
+            answer.append('%2i:%s%s %s' % (l - i, BOT_PREFIX, c[0], c[1]))
         return '\n'.join(answer)
 
     def send(self, user, text, in_reply_to=None, message_type='chat'):

--- a/errbot/backends/graphic.py
+++ b/errbot/backends/graphic.py
@@ -23,7 +23,7 @@ except ImportError:
 
 import os
 import config
-from config import BOT_DATA_DIR
+from config import BOT_DATA_DIR, BOT_PREFIX
 import errbot
 from errbot.backends.base import Connection, Message
 from errbot.errBot import ErrBot
@@ -38,7 +38,7 @@ class CommandBox(QtGui.QLineEdit, object):
         self.history = history
         self.reset_history()
         super(CommandBox, self).__init__()
-        completer = QCompleter(['!' + name for name in commands])
+        completer = QCompleter([BOT_PREFIX + name for name in commands])
         completer.setCaseSensitivity(Qt.CaseInsensitive)
         self.setCompleter(completer)
 
@@ -48,12 +48,12 @@ class CommandBox(QtGui.QLineEdit, object):
         if key == Qt.Key_Up:
             if self.history_index > 0:
                 self.history_index -= 1
-                self.setText('!%s %s' % self.history[self.history_index])
+                self.setText(BOT_PREFIX + '%s %s' % self.history[self.history_index])
                 return
         elif key == Qt.Key_Down:
             if self.history_index < len(self.history) - 1:
                 self.history_index += 1
-                self.setText('!%s %s' % self.history[self.history_index])
+                self.setText(BOT_PREFIX + '%s %s' % self.history[self.history_index])
                 return
         super(CommandBox, self).keyPressEvent(*args, **kwargs)
         if key == QtCore.Qt.Key_Return:

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -46,6 +46,11 @@ BOT_ADMINS = ('gbin@localhost',) # only those JIDs will have access to admin com
 BOT_DATA_DIR = '/var/lib/err' # Point this to a writeable directory by the system user running the bot
 BOT_EXTRA_PLUGIN_DIR = None # Add this directory to the plugin discovery (useful to develop a new plugin locally)
 
+# Prefix used for commands. Note that in help strings, you should still use the
+# default '!'. If the prefix is changed from the default, the help strings will
+# be automatically adjusted.
+BOT_PREFIX = '!'
+
 # ---- Chatrooms configuration (used by the chatroom plugin)
 # it is a standard python file so you can reuse variables...
 # For example: _TEST_ROOM = 'test@conference.localhost


### PR DESCRIPTION
As per issue #62, this makes it possible to configure the command prefix to something other than the default of !.

As you suggested, it auto-replaces that in any help strings for commands. This is limited to those that come from the doc string for the command method itself. I don't know if it's possible, or desirable, to intercept every message coming out of the plugin and do the same. On one hand, it might say "Please try the !other" command instead, which would want replacing. On the other, it might say "Ok!" which would not.

Another point to note is that the way I've added the config means you're forced to add it to your existing config when you upgrade, even if you're sticking with the default. I don't know if there's a way of avoiding that.
