### PR TITLE
Fix for issue #68: UnicodeDecodeError on !apropos

### DIFF
--- a/errbot/errBot.py
+++ b/errbot/errBot.py
@@ -425,7 +425,7 @@ class ErrBot(Backend, StoreMixin):
             usage += '\n'.join(sorted([
             '\t' + BOT_PREFIX + '%s: %s' % (name.replace('_', ' ', 1), (command.__doc__ or
                                 '(undocumented)').strip().split('\n', 1)[0])
-            for (name, command) in clazz_commands[clazz] if args is not None and command.__doc__ is not None and args.lower() in command.__doc__.lower() and name != 'help' and not command._err_command_hidden
+            for (name, command) in clazz_commands[clazz] if args is not None and command.__doc__ is not None and args.lower() in command.__doc__.lower().decode('utf-8', 'ignore') and name != 'help' and not command._err_command_hidden
             ]))
         usage += '\n\n'
 


### PR DESCRIPTION
I believe decoding the modules' docstrings before trying to use them is the correct
way to fix this issue, please correct me if there's a better way/place to do this
