### PR TITLE
Implement feature request from #74: respond with private msg to !help

### DIFF
--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -10,6 +10,12 @@ from errbot.templating import tenv
 import traceback
 from errbot.utils import get_jid_from_message, utf8
 from config import BOT_ADMINS, BOT_ASYNC, BOT_PREFIX
+try:
+    from config import DIVERT_TO_PRIVATE
+except ImportError:
+    DIVERT_TO_PRIVATE = ()
+    logging.warning("DIVERT_TO_PRIVATE is missing in config")
+    pass
 
 if BOT_ASYNC:
     from errbot.bundled.threadpool import ThreadPool, WorkRequest
@@ -261,7 +267,7 @@ class Backend(object):
                 if reply:
                     if len(reply) > self.MESSAGE_SIZE_LIMIT:
                         reply = reply[:self.MESSAGE_SIZE_LIMIT - len(self.MESSAGE_SIZE_ERROR_MESSAGE)] + self.MESSAGE_SIZE_ERROR_MESSAGE
-                    self.send_simple_reply(mess, reply)
+                    self.send_simple_reply(mess, reply, cmd in DIVERT_TO_PRIVATE)
 
             f = self.commands[cmd]
 

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -78,3 +78,8 @@ REVERSE_CHATROOM_RELAY = {}
 # If you use HipChat, make sure to exactly match the fullname you set for the bot user
 CHATROOM_FN = 'bot'
 
+# DIVERT_TO_PRIVATE
+# An iterable of commands which should be responded to in private, even if the command was given
+# in a MUC. For example: DIVERT_TO_PRIVATE = ('help', 'about', 'status')
+DIVERT_TO_PRIVATE = ()
+


### PR DESCRIPTION
These commits adds a new config option, DIVERT_TO_PRIVATE. Commands listed
here will have their response returned as a private message, even if the
command was given inside of a MUC
