### PR TITLE
Allow any length of BOT_PREFIX 

### DIFF
--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -216,7 +216,7 @@ class Backend(object):
         if not text.startswith(BOT_PREFIX):
             return True
 
-        text = text[1:]
+        text = text[len(BOT_PREFIX):]
         text_split = text.strip().split(' ')
 
         cmd = None


### PR DESCRIPTION
As mentioned in issue #85, allow any length of BOT_PREFIX

(note, this only concerns the length and none of the other features mentioned such as an optional separator)
