### PR TITLE
IRC Backend now transmits to appropriately

### DIFF
--- a/errbot/backends/irc.py
+++ b/errbot/backends/irc.py
@@ -55,8 +55,9 @@ class IRCConnection(IRCClient, object):
         else:
             typ = 'groupchat'
         logging.debug('IRC message received from %s [%s]' % (fr, line))
-        msg = Message(line, typ=typ)
-        msg.setFrom(fr) # already a compatible format
+        msg = Message(unicode(line, 'replace'), typ=typ)
+        msg.setFrom(unicode(fr, 'replace')) # already a compatible format
+        msg.setTo(unicode(params[0], 'replace'))
         self.callback.callback_message(self, msg)
 
 


### PR DESCRIPTION
This change also casts strings from IRC to unicode for the body, to and
from field to appease TimeMachine and Whoosh's need for unicode strings.

Closes #93
