### PR TITLE
Add pyasn1 requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ sleekxmpp
 yapsy
 configparser
 config
+pyasn1
+pyasn1-modules


### PR DESCRIPTION
pyasn1 and pyasn1-modules are required by sleekxmpp for certificate
validation. Although technically it runs fine without them (It'll give a warning in the logs during runtime about not being able to do certificate validation), I think it's best to have these specifically required to ensure certificate validation is always possible.

If we don't, I think half our user-base never notices the warning and has no idea certificates aren't being validated, which would be bad.
