### PR TITLE
Correctly join rooms on Python 2

### DIFF
--- a/errbot/builtins/chatRoom.py
+++ b/errbot/builtins/chatRoom.py
@@ -19,7 +19,7 @@ class ChatRoom(BotPlugin):
             self.connected = True
             for room in CHATROOM_PRESENCE:
                 logging.info('Join room ' + room)
-                if isinstance(room, str):
+                if isinstance(room, basestring):
                     self.join_room(room, CHATROOM_FN)
                 else:
                     self.join_room(room[0], password=room[1])


### PR DESCRIPTION
When running under Python 2, the 3to2 tool would change the type used in
an isinstance() call to determine if the room it was parsing from the
CHATROOM_PRESENCE was a string (non-passworded room) or something else
(assuming an iterable containing room,password).

Changing the explicit str to basestring will ensure both byte strings
and unicode strings are accepted, which will give the desired behaviour
on Python 2 and 3.

Fixes #117
