### PR TITLE
Warn when missing 'webtest' package (needed for tests)

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -2,7 +2,11 @@
 import sys
 from setup import PY3, py2_root
 
-import nose
+try:
+    import nose
+except ImportError:
+    sys.stderr.write("Tests require the 'nose' package which you are currently missing.\nYou can install nose with `pip install nose`.\n")
+    sys.exit(1)
 
 try:
     import webtest


### PR DESCRIPTION
webtest isn't in requirements.txt because it's only required to run the
tests. This commit will make run_tests.py try to import it and fail with
a helpful error message in case it fails.
