### PR TITLE
Optional, but still working bot prefix on chat

### DIFF
--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -308,7 +308,7 @@ class Backend(object):
             surpress_cmd_not_found = True
         elif not text.startswith(BOT_PREFIX):
             return True
-        else:
+        if text.startswith(BOT_PREFIX):
             text = text[len(BOT_PREFIX):]
 
         text_split = text.strip().split(' ')


### PR DESCRIPTION
Currently, err ignores legitimate commands in a one-on-one chat issued using the primary bot prefix if BOT_PREFIX_OPTIONAL_ON_CHAT is True. This commit fixes that.

(Note that there's a very narrow edge case that's still broken here: e.g. if the bot prefix is `foo` and I have a command called `foobar`, then `foobar` will be reduced to `bar` before processing the command, and will result in a failed lookup. However, this is an extremely narrow edge case, as it only happens with the primary bot prefix and when someone has overlapping prefixes and command names. I suggest ignoring that.)
