### PR TITLE
Add err-markovbot to built-in list of plugins

### DIFF
--- a/errbot/repos.py
+++ b/errbot/repos.py
@@ -29,4 +29,5 @@ KNOWN_PUBLIC_REPOS = {
     'err-mailwatch': ('git://github.com/zoni/err-mailwatch.git', 'Watch IMAP servers for new mails'),
     'err-dnsutils': ('git://github.com/zoni/err-dnsutils.git', 'Run common DNS utils: host, dig, nslookup'),
     'err-insult': ('git://github.com/xnaveira/err-insult.git', 'Hubot insult plugin clone for Err bot'),
+    'err-markovbot': ('git://github.com/MaxWagner/err-markovbot.git', 'Markov chain bot that supports db generation from url, file or string')
 }


### PR DESCRIPTION
err-markovbot is (oh surprise) a markov chain (by me) bot you can
see at https://github.com/MaxWagner/err-markovbot
Because no chatbot is complete without a markov chain.

If you need a body of text to try it out with, I can suggest http://trollbu.de/monkeyscript
