### PR TITLE
Properly close shelf upon restart

### DIFF
--- a/errbot/errBot.py
+++ b/errbot/errBot.py
@@ -272,6 +272,7 @@ class ErrBot(Backend, StoreMixin):
         """ restart the bot """
         self.send(mess.getFrom(), "Deactivating all the plugins...")
         deactivate_all_plugins()
+        self.shutdown()
         self.send(mess.getFrom(), "Restarting")
         global_restart()
         return "I'm restarting..."


### PR DESCRIPTION
This fixes some data loss (plugins, repos, etc.), as shelves
are only written back to file if they're explicitly closed.
