### PR TITLE
Fix messed up display of status and repos commands

### DIFF
--- a/errbot/templates/repos.html
+++ b/errbot/templates/repos.html
@@ -1,12 +1,14 @@
 {% extends "base.html" %}
 {% macro status(installed, public) -%}
-    [<span style='font-weight:bold;'>{% if installed %}*{% else %} {% endif %}{% if public %}P{% else %} {% endif %}</span>]
+[<span style='font-weight:bold;'>{% if installed %}*{% else %} {% endif %}{% if public %}P{% else %} {% endif %}</span>]
 {%- endmacro %}
 {% block body %}
 <div style="font-family: monospace">
 <p style='margin-top: 0; margin-bottom: 0;'>Repos (P = Private repo, * = installed):</p>
+<p style='margin-top: 0; margin-bottom: 0; white-space:pre;'>
 {% for installed, public, name, desc in repos %}
-    <p style='margin-top: 0; margin-bottom: 0; white-space:pre;'>{{status(installed, public)}} {{ name }} {{desc}}</p>
+{{status(installed, public)}} {{ name }} {{desc}}<br/>
 {% endfor %}
+</p>
 </div>
 {% endblock %}

--- a/errbot/templates/status.html
+++ b/errbot/templates/status.html
@@ -4,13 +4,13 @@
 {%- endmacro %}
 {% block body %}
 <div style="font-family: monospace">
-<p style='margin-top: 0; margin-bottom: 0; font-weight:bold'>Yes I am alive... </p>
-<p style='margin-top: 0; margin-bottom: 0;'>With those plugins ({{status('L')}}=Loaded, {{status('E')}}=Error, {{status('B')}}=Blacklisted/Unloaded), {{status('C')}}=Needs to be configured) :</p>
+<p style='margin-top: 0; margin-bottom: 0;'><span style='font-weight:bold;'>Yes I am alive...</span><br/>
+With those plugins ({{status('L')}}=Loaded, {{status('E')}}=Error, {{status('B')}}=Blacklisted/Unloaded), {{status('C')}}=Needs to be configured) :<br/>
 {% for state, name in plugins_statuses %}
-    <p style='margin-top: 0; margin-bottom: 0;'>[{{status(state)}}] {{ name }}</p>
-{% endfor %}
-<p style='margin-top: 10px; margin-bottom: 0;'>
-   Load {{loads[0]}}, {{loads[1]}}, {{loads[2]}}<br/>
-   GC 0->{{gc[0]}} 1->{{gc[1]}} 2->{{gc[2]}}</p>
+[{{status(state)}}] {{ name }}<br/>
+{% endfor %}</p>
+<p style='margin-top: 10px; margin-bottom: 0; margin-left:15px;'>
+Load {{loads[0]}}, {{loads[1]}}, {{loads[2]}}<br/>
+GC 0->{{gc[0]}} 1->{{gc[1]}} 2->{{gc[2]}}</p>
 </div>
 {% endblock %}


### PR DESCRIPTION
This occurred in pidgin pre 3. Now both pidgin 2 and 3
render the command outputs nicely. Other clients may be
affected too, especially adium, since it shares the same
renderer (as far as I know).

Before:
![Screenshot from 2013-04-07 16:00:20](https://f.cloud.github.com/assets/796437/348850/6efb16a6-9f8c-11e2-8d51-34e4ea8b64be.png)
After:
![Screenshot from 2013-04-07 16:04:48](https://f.cloud.github.com/assets/796437/348851/73d6b2c0-9f8c-11e2-8667-e22ed736b40f.png)
