### PR TITLE
Add tox.ini for optional use of tox to manage test suite on Py2 and Py3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ nohup.out
 /dist
 /err.egg-info*
 /config-*.egg
+/.tox
 config_campfire.py
 config_hipchat.py
 config_irc.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py27, py33
+[testenv]
+deps = -r{toxinidir}/requirements.txt
+       nose
+       webtest
+commands={toxinidir}/run_tests.py
+


### PR DESCRIPTION
Added a tox.ini so that it's a bit easier to run the test suite on Py2 and Py3 quickly. Seems to work quite well and should help catch issues now that Err works nicely with both.
