### PR TITLE
Handle disconnect events

### DIFF
--- a/errbot/backends/xmpp.py
+++ b/errbot/backends/xmpp.py
@@ -134,6 +134,7 @@ class XMPPBackend(ErrBot):
         return XMPPConnection(self.jid, self.password)
 
     def incoming_message(self, xmppmsg):
+        """Callback for message events"""
         msg = Message(xmppmsg['body'])
         if 'html' in xmppmsg.keys():
             msg.setHTML(xmppmsg['html'])
@@ -145,10 +146,12 @@ class XMPPBackend(ErrBot):
         self.callback_message(self.conn, msg)
 
     def connected(self, data):
-        self.connect_callback()  # notify that the connection occured
+        """Callback for connection events"""
+        self.connect_callback()
 
     def disconnected(self, data):
-        self.disconnect_callback()  # notify plugins that the disconnect occurred
+        """Callback for disconnection events"""
+        self.disconnect_callback()
 
     def serve_forever(self):
         self.connect()  # be sure we are "connected" before the first command


### PR DESCRIPTION
Prior to this, disconnect events weren't getting picked up on properly
which resulted in plugins not getting shut down and re-activated on reconnection.

Additionally, it was also causing already loaded commands to be reloaded again,
resulting in clashes like the following:
"XMPPBackend.reload clashes with XMPPBackend.reload so it has been renamed
xmppbackend-reload"

This adds a listener for the disconnected event from sleekxmpp and triggers
disconnect_callback() when received, ensure a proper unload/reload of plugins.

Additionally, I also changed a few lines of comments to docstrings to be a little cleaner.
