### PR TITLE
Allow configuration of SleekXMPP's whitespace_keepalive_interval

### DIFF
--- a/errbot/backends/xmpp.py
+++ b/errbot/backends/xmpp.py
@@ -28,6 +28,10 @@ try:
     from config import XMPP_FEATURE_MECHANISMS
 except ImportError:
     XMPP_FEATURE_MECHANISMS = {}
+try:
+    from config import XMPP_KEEPALIVE_INTERVAL
+except ImportError:
+    XMPP_KEEPALIVE_INTERVAL = None
 
 
 def verify_gtalk_cert(xmpp_client):
@@ -66,6 +70,10 @@ class XMPPConnection(Connection):
         self.client.register_plugin('xep_0199')  # XMPP Ping
         self.client.register_plugin('xep_0203')  # XMPP Delayed messages
         self.client.register_plugin('xep_0249')  # XMPP direct MUC invites
+
+        if XMPP_KEEPALIVE_INTERVAL is not None:
+            self.client.whitespace_keepalive = True  # Just in case SleekXMPP's default changes to False in the future
+            self.client.whitespace_keepalive_interval = XMPP_KEEPALIVE_INTERVAL
 
         self.client.add_event_handler("session_start", self.session_start)
         self.client.add_event_handler("ssl_invalid_cert", self.ssl_invalid_cert)

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -206,6 +206,19 @@ REVERSE_CHATROOM_RELAY = {}
 # To use only unencrypted plain auth:
 #XMPP_FEATURE_MECHANISMS =  {'use_mech': 'PLAIN', 'unencrypted_plain': True, 'encrypted_plain': False}
 
+# Modify the default keep-alive interval. By default, Err will send
+# some whitespace to the XMPP server every 300 seconds to keep the TCP
+# connection alive. On some servers, or when running Err from behind
+# a NAT router, the default might not be fast enough and you will need
+# to set it to a lower value. 
+#
+# It has been reported that HipChat also times out without setting this
+# to a lower value (60 seems to work well with HipChat)
+#
+# If you're having issues with your bot getting constantly disconnected,
+# try to gradually lower this value until it no longer happens.
+#XMPP_KEEP_ALIVE_INTERVAL = 300
+
 # Message rate limiting for the IRC backend.
 # Rate limiter for regular channel messages, set to None to disable limits.
 #IRC_CHANNEL_RATE = 1

--- a/errbot/repos.py
+++ b/errbot/repos.py
@@ -31,6 +31,5 @@ KNOWN_PUBLIC_REPOS = {
     'err-insult': ('git://github.com/xnaveira/err-insult.git', 'Hubot insult plugin clone for Err bot'),
     'err-markovbot': ('git://github.com/MaxWagner/err-markovbot.git', 'Markov chain bot that supports db generation from url, file or string'),
     'err-faustbot': ('git://github.com/Scaatis/err-faustbot.git', "Output a random line of Goethe's \"Faust\" in sentence context (in German)."),
-    'err-sedbot': ('git://github.com/gbin/err-sedbot.git', "errbot plugin for executing simple sed substitute commands"),
-    'err-agressive-keepalive': ('git://github.com/zoni/err-agressive-keepalive.git', "A plugin which sends additional keep-alive messages every 30 seconds."),
+    'err-sedbot': ('git://github.com/gbin/err-sedbot.git', "errbot plugin for executing simple sed substitute commands")
 }


### PR DESCRIPTION
Some servers/networking setups may require more agressive keep-alives to be
sent. This exposes SleekXMPP's configuration of this behaviour by exposing
it as an optional configuration item (XMPP_KEEPALIVE_INTERVAL).

This also makes err-agressive-keepalive obsolete again, so it has been
removed from repos.py.

Closes #154
