### PR TITLE
Don't try to close a shelf when self.shelf doesn't exist

### DIFF
--- a/errbot/botplugin.py
+++ b/errbot/botplugin.py
@@ -44,7 +44,8 @@ class BotPluginBase(StoreMixin):
             for timer in self.current_timers:
                 timer.cancel()
 
-        self.close_storage()
+        if self.shelf is not None:
+            self.close_storage()
         holder.bot.remove_commands_from(self)
         self.is_activated = False
 

--- a/errbot/storage.py
+++ b/errbot/storage.py
@@ -10,17 +10,20 @@ class StoreMixin(MutableMapping):
      This class handle the basic needs of bot plugins and core like loading, unloading and creating a storage
     """
 
+    shelf = None
+
     def open_storage(self, path):
+        if self.shelf is not None:
+            raise Exception("Storage is already open")
         logging.info("Try to open db file %s" % path)
         self.shelf = shelve.DbfilenameShelf(path, protocol=2)
         logging.debug('Opened shelf of %s' % self.__class__.__name__)
 
     def close_storage(self):
-        if not hasattr(self, 'shelf'):
-            # One possible cause for this is a plugin's activate method triggering an exception
-            logging.debug("Cannot close storage of %s because the shelf doesn't exist." % self.__class__.__name__)
-            return
+        if self.shelf is None:
+            raise Exception("Cannot close storage when it isn't open")
         self.shelf.close()
+        self.shelf = None
         logging.debug('Closed shelf of %s' % self.__class__.__name__)
 
     # those are the minimal things to behave like a dictionary with the UserDict.DictMixin


### PR DESCRIPTION
This may happen if a plugin fails in it's activation stage
