### PR TITLE
Fix "irc" module naming conflict with python-2.7

### DIFF
--- a/errbot/backends/irc.py
+++ b/errbot/backends/irc.py
@@ -8,19 +8,31 @@ from utils import RateLimited
 try:
     from irc.bot import SingleServerIRCBot
 except ImportError as _:
-    logging.exception("Could not start the IRC backend")
-    logging.fatal("""
-    If you intend to use the IRC backend please install the python irc package:
-    -> On debian-like systems
-    sudo apt-get install python-software-properties
-    sudo apt-get update
-    sudo apt-get install python-irc
-    -> On Gentoo
-    sudo emerge -av dev-python/irc
-    -> Generic
-    pip install irc
-    """)
-    sys.exit(-1)
+    SingleServerIRCBot = None
+    if sys.version_info.major < 3:
+        try:
+            import imp
+            args = imp.find_module('irc')
+            mod = imp.load_module('irc', *args)
+            args = imp.find_module('bot', mod.__path__)
+            mod = imp.load_module('irc.bot', *args)
+            SingleServerIRCBot = mod.SingleServerIRCBot
+        except ImportError:
+            pass
+    if not SingleServerIRCBot:
+        logging.exception("Could not start the IRC backend")
+        logging.fatal("""
+        If you intend to use the IRC backend please install the python irc package:
+        -> On debian-like systems
+        sudo apt-get install python-software-properties
+        sudo apt-get update
+        sudo apt-get install python-irc
+        -> On Gentoo
+        sudo emerge -av dev-python/irc
+        -> Generic
+        pip install irc
+        """)
+        sys.exit(-1)
 
 
 class IRCConnection(SingleServerIRCBot):


### PR DESCRIPTION
Using "from irc import ..." in module named "irc" causes python-2.7 to try to re-use `__module__` in that import, and not look it up in sys.path.

Fix is to force such lookup via "imp.find_module".
Any ImportError (either missing "imp" or other "irc" modules) should be treated same as before, causing a fatal error.

Error before fix looks like this:

```
...
ERROR:root:Could not start the IRC backend
Traceback (most recent call last):
  File ".../errbot/backends/irc.py", line 9, in <module>
    from irc.bot import SingleServerIRCBot
ImportError: No module named bot
...
```

sys.modules still doesn't have "irc" in it, but `import irc; print irc` shows errbot submodule, not top-level "irc" - python2 seem to assume that it's the same "irc" magically.

One caveat is that err.py doesn't seem to run here (after either system-wide or --user install) without modifying PYTHONPATH - e.g. `PYTHONPATH=/usr/lib/python/site-packages/errbot: err.py` - otherwise you get `ImportError: No module named utils` on stuff like `from utils import RateLimited`.

I didn't check if it's 3to2 to blame here or if that is expected to work with python3 (can't imagine why - iirc absolute imports are norm there), but maybe related, yet I don't think it should be - top-level "irc" module doesn't get shadowed by "backends.irc" there.
