### PR TITLE
Add HIDE_RESTRICTED_ACCESS option to supress access errors.

### DIFF
--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -27,6 +27,11 @@ except ImportError:
     HIDE_RESTRICTED_COMMANDS = False
 
 try:
+    from config import HIDE_RESTRICTED_ACCESS
+except ImportError:
+    HIDE_RESTRICTED_ACCESS = False
+
+try:
     from config import BOT_PREFIX_OPTIONAL_ON_CHAT
 except ImportError:
     BOT_PREFIX_OPTIONAL_ON_CHAT = False
@@ -357,12 +362,13 @@ class Backend(object):
 
         logging.info("received command = %s matching [%s] with parameters [%s]" % (command, cmd, args))
 
-        if cmd:
-            access, accessError = self.checkCommandAccess(mess, cmd)
-            if not access:
+        access, accessError = self.checkCommandAccess(mess, cmd)
+        if not access:
+            if not HIDE_RESTRICTED_ACCESS:
                 self.send_simple_reply(mess, accessError)
-                return False                           
+            return False
 
+        if cmd:
             f = self.commands[cmd]
 
             if f._err_command_admin_only and BOT_ASYNC:

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -175,6 +175,10 @@ BOT_PREFIX = '!'
 # the help output.
 #HIDE_RESTRICTED_COMMANDS = False
 
+# Uncomment and set this to True to ignore commands from users that have no
+# access for these instead of replying with error message.
+#HIDE_RESTRICTED_ACCESS = False
+
 # A list of commands which should be responded to in private, even if
 # the command was given in a MUC. For example:
 # DIVERT_TO_PRIVATE = ('help', 'about', 'status')


### PR DESCRIPTION
Use-case is restricted-access bots in populated channels, so that bot A may ignore "!cmd" message from user M (intended for another bot or user) without polluting channel with error messages.

Might also be seen as a security feature, masquerading bot presence, hiding precise error messages and not revealing which (potentially exploitable) commands the bot has (e.g. "!asd" will say "access denied" or be ignored instead of "no command !asd"), but admittedly, that's not the point of the change.
