### PR TITLE
Strip XHTML/XML formatting in all irc messages.

### DIFF
--- a/errbot/backends/irc.py
+++ b/errbot/backends/irc.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 import config
-from errbot.backends.base import Message, build_message
+from errbot.backends.base import Message, build_message, build_text_html_message_pair
 from errbot.errBot import ErrBot
 from utils import RateLimited
 
@@ -56,7 +56,7 @@ class IRCConnection(SingleServerIRCBot):
             to = mess.getTo().resource
         else:
             to = mess.getTo().node
-        for line in mess.getBody().split('\n'):
+        for line in build_text_html_message_pair(mess.getBody())[0].split('\n'):
             msg_func(to, line)
 
     @RateLimited(config.__dict__.get('IRC_PRIVATE_RATE', 1))


### PR DESCRIPTION
Not sure if I did it right, as it currently will strip any html-like things that might be there intentionally (but in unescaped form? is it even possible?).

E.g. !repos gives this to IRC channel:

```
[17:05:46]<err> <!-- look here to see what is supported : http://xmpp.org/extensions/xep-0071.html -->
[17:05:46]<err> <html xmlns="http://jabber.org/protocol/xhtml-im">
[17:05:46]<err> <body>
[17:05:46]<err> <div style="font-family: monospace">
[17:05:46]<err> <p style='margin-top: 0; margin-bottom: 0;'>Repos (P = Private repo, * = installed):</p>
[17:05:46]<err> <p style='margin-top: 0; margin-bottom: 0; white-space:pre;'>
[17:05:46]<err> [<span style='font-weight:bold;'>  </span>] err-calcbot      a smart calculator, unit converter and math solver<br/>
[17:05:46]<err> [<span style='font-weight:bold;'>  </span>] err-codebot      can make the bot execute code snippet in C, CPP and Python<br/>
...
```

Which is kinda awful for readability.

With fix, text is cleaned of markup - only valid one, and escaped non-markup entities should be unescaped, iiuc:

```
[17:07:34]<err> Repos (P = Private repo, * = installed):
[17:07:34]<err> [  ] err-calcbot      a smart calculator, unit converter and math solver
[17:07:34]<err> [  ] err-codebot      can make the bot execute code snippet in C, CPP and Python
...
```

Can `Message.getBody()` return a valid `<tag>stuff</tag>` markup in unescaped (e.g. `&lt;tag&gt;stuff&lt;/tag&gt;`, or its xml equivalent) form from some plugin?

If so, might be not a perfect solution, but cheap easy fixes can be either to escape everything not marked as xhtml (if that's a thing) or make it configurable, shifting a bit of a burden onto user.
