### PR TITLE
Split up test runs

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
 import sys
+import os
+from glob import glob
 from setup import PY3, py2_root
+
+# Set nose verbosity level to verbose by default
+os.environ['NOSE_VERBOSE'] = os.environ.get('NOSE_VERBOSE', "2")
 
 try:
     import nose
@@ -17,9 +22,23 @@ except ImportError:
 if not PY3:  # hack the path system to take the python 2 converted sources
     print('Changing root to ' + py2_root)
     print('Sys path ' + ', '.join(sys.path))
-    if nose.run('tests', argv=['-w', py2_root]):
-        exit(0)  # no error
+    argv=['-w', py2_root]
 else:
-    if nose.run('tests'):
-        exit(0)  # no error
-exit(-99)  # a test did not pass
+    argv=None
+
+# Webhooks tests fail when run together with the other tests, but pass correctly
+# when run in isolation. We work around this issue by running each set of tests
+# separately. It's an ugly hack, but it works.
+testsuites = glob('tests/*.py')
+testresults = []
+
+for testsuite in testsuites:
+    print("\nRunning tests from {}\n".format(testsuite))
+    testresults.append(nose.run(defaultTest=testsuite, argv=argv))
+
+if False in testresults:
+    print("\nSome tests failed to pass!")
+    exit(-99)   # a test did not pass
+else:
+    print("\nAll tests have successfully passed")
+    exit(0)  # no error


### PR DESCRIPTION
For some inexplicable reason, the webhooks tests were consistently failing
when run as part of the whole testsuite, but passing fine when running only
tests/webhooks_tests.py on their own. Although ugly, by splitting these up
and calling each file with tests in it's own nose.run(), we can work around
this issue and have working tests again.
