### PR TITLE
Run each test in a new bot thread

### DIFF
--- a/errbot/backends/test.py
+++ b/errbot/backends/test.py
@@ -108,15 +108,7 @@ class FullStackTest(unittest.TestCase):
     """
     bot_thread = None
 
-    def setUp(self):
-        zapQueues()
-
-    def tearDown(self):
-        zapQueues()
-
-    #noinspection PyTypeChecker
-    @classmethod
-    def setUpClass(cls, extra_test_file=None):
+    def setUp(self, extra_test_file=None):
         # reset logging to console
         logging.basicConfig(format='%(levelname)s:%(message)s')
         console = logging.StreamHandler()
@@ -127,16 +119,16 @@ class FullStackTest(unittest.TestCase):
         if extra_test_file:
             import config
             config.BOT_EXTRA_PLUGIN_DIR = sep.join(abspath(extra_test_file).split(sep)[:-2])
-        cls.bot_thread = Thread(target=main, name='Test Bot Thread', args=(TestBackend, logger))
-        cls.bot_thread.setDaemon(True)
-        cls.bot_thread.start()
+        self.bot_thread = Thread(target=main, name='Test Bot Thread', args=(TestBackend, logger))
+        self.bot_thread.setDaemon(True)
+        self.bot_thread.start()
 
-    @classmethod
-    def tearDownClass(cls):
+    def tearDown(self):
         pushMessage(QUIT_MESSAGE)
-        cls.bot_thread.join()
+        self.bot_thread.join()
         reset_app()  # empty the bottle ... hips!
         logging.info("Main bot thread quits")
+        zapQueues()
 
     def assertCommand(self, command, response, timeout=5):
         pushMessage(command)

--- a/tests/commands_tests.py
+++ b/tests/commands_tests.py
@@ -64,7 +64,7 @@ class TestCommands(FullStackTest):
 
     def test_logtail(self):
         pushMessage('!log tail')
-        self.assertIn('INFO', popMessage())
+        self.assertIn('DEBUG', popMessage())
 
     def test_history(self):
         from errbot.holder import bot

--- a/tests/webhooks_tests.py
+++ b/tests/webhooks_tests.py
@@ -22,10 +22,10 @@ def webserver_ready(host, port):
 
 
 class TestWebhooks(FullStackTest):
-    @classmethod
-    def setUpClass(cls, extra_test_file=None):
+
+    def setUp(self, extra_test_file=None):
         plugin_dir = os.path.dirname(os.path.realpath(__file__)) + os.sep + 'webhooks_tests'
-        super(TestWebhooks, cls).setUpClass(extra_test_file=plugin_dir)
+        super(TestWebhooks, TestWebhooks).setUp(self, extra_test_file=plugin_dir)
 
         pushMessage("!config Webserver {'HOST': 'localhost', 'PORT': 3141, 'SSL':  None}")
         popMessage()


### PR DESCRIPTION
This provides more isolation and makes it a lot easier to debug
problems, as all captured logging pertains to one test and one test
only.

This makes our tests run for quite a bit longer, which is a downside,
however this was invaluable to me in figuring out what was wrong
with the webhooks tests. It also provides safety against one set of
tests influencing another by altering the running bot's environment.

Closes #124
