### PR TITLE
Fix MUC login: Support tuple & add username

### DIFF
--- a/errbot/builtins/chatRoom.py
+++ b/errbot/builtins/chatRoom.py
@@ -25,11 +25,12 @@ class ChatRoom(BotPlugin):
         if not self.connected:
             self.connected = True
             for room in CHATROOM_PRESENCE:
-                logging.info('Join room ' + room)
                 if isinstance(room, basestring):
+                    logging.info('Join room ' + room +' as user '+ CHATROOM_FN)
                     self.join_room(room, CHATROOM_FN)
                 else:
-                    self.join_room(room[0], password=room[1])
+                    logging.info(u'Join room ' + room[0] +' as user '+ CHATROOM_FN)
+                    self.join_room(room[0], username=CHATROOM_FN, password=room[1])
 
     def deactivate(self):
         self.connected = False


### PR DESCRIPTION
In order to enable MUC for XMPP I needed to tweak `callback_connect`:
- `logging` fails if we have to deal with a tuple
  The values need to be accessed by index if we have a tuple
- add parameter `username` in `join_room` with a name

Otherwise the connection can not be established.

Tested with python2.7 by building with `python setup.py install` and connecting to two MUC via XMPP successfully.
