### PR TITLE
MANIFESTS: include tests/ directory.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,4 @@ include errbot/builtins/templates/*.html
 include errbot/builtins/web-static/*.html
 include errbot/builtins/web-static/*.js
 include errbot/builtins/web-static/stylesheets/*.css
+recursive-include tests *.py


### PR DESCRIPTION
This fixes the installation issues on Python 2. We were trying to convert sources in the tests/ dir without them actually being there.

Relates to #179.

I'm now however hitting installation issues with six which comes in as a dependency from other projects. Could people try this out, see what happens for them?

We can also solve this issue by removing the tests directory from `src_dirs`.
