### PR TITLE
Fix replaces the call to XEP_0045.getRoomForm with XEP_0045.getRoomConfig

### DIFF
--- a/errbot/backends/xmpp.py
+++ b/errbot/backends/xmpp.py
@@ -78,7 +78,7 @@ class XMPPConnection(Connection):
         self.client = ClientXMPP(jid, password, plugin_config={'feature_mechanisms': XMPP_FEATURE_MECHANISMS})
         self.client.register_plugin('xep_0030')  # Service Discovery
         self.client.register_plugin('xep_0045')  # Multi-User Chat
-        self.client.register_plugin('old_0004')  # Multi-User Chat backward compability (necessary for join room)
+        self.client.register_plugin('xep_0004')  # Multi-User Chat backward compability (necessary for join room)
         self.client.register_plugin('xep_0199')  # XMPP Ping
         self.client.register_plugin('xep_0203')  # XMPP Delayed messages
         self.client.register_plugin('xep_0249')  # XMPP direct MUC invites
@@ -128,7 +128,7 @@ class XMPPConnection(Connection):
                     username,
                     password=password,
                     wait=True)
-        form = muc.getRoomForm(room)
+        form = muc.getRoomConfig(room)
         if form:
             muc.configureRoom(room, form)
         else:


### PR DESCRIPTION
The latter uses the api present in xep_0004 plugin. The method
getRoomForm used the old version of the plugin. Apart from that
the functionality of this two methods was for all practical reasons
identical.

It seems that the plugins are capable of loading their own
dependencies.
In case of xep_0045 it is xep_0004. When I removed the line from err,
nothing happened. However, leaving the line in place for the sake of
explicitness. (And because at the moment I don't know if some part
of the bot uses it directly.)

Fixes #233 and #234.
