### PR TITLE
Better message recipient setting in XMPP MUC responses

### DIFF
--- a/tests/base_backend_tests.py
+++ b/tests/base_backend_tests.py
@@ -124,7 +124,7 @@ class TestBase(unittest.TestCase):
         m.setTo("to@todomain.net/toresource")
         resp = dummy.build_reply(m, "Response")
 
-        self.assertEqual(str(resp.getTo()), "from@fromdomain.net")
+        self.assertEqual(str(resp.getTo()), "from@fromdomain.net/fromresource")
         self.assertEqual(str(resp.getFrom()), "err@localhost/err")
         self.assertEqual(str(resp.getBody()), "Response")
 


### PR DESCRIPTION
There are currently two issues when responding to messages in group
chats which are fixed by this commit.

1) Responding to commands fails when somebody has a MUC nickname
of the form something@somewhere.tld, as described in #241. The fix
is to strip the resource part in the case of MUC responses, so they
properly go to the room itself.

2) Responding to commands fails when somebody private-messages the
bot from within a MUC, which causes messages to be sent to the
so-called "occupant JID" (see XEP-0045). In this case, the sender
JID was being incorrectly detected because getStripped() was being
used.

This is fine for regular private messages, where getStripped()
would return the JID with the resource part removed. In the case of
private messages from these MUC chats however, the resource part actually
describes which user the response has to go to so stripping it off
causes messages to become unroutable. The fix here is to stop using
getStripped() in this case so that the resource is retained.

Additionally, get_jid_from_message() was setting resource as returned
by mess.getMuckNick(), rather than mess.getMuckNick().resource so the
actual resource was getting lost.

Fixes #241.
