### PR TITLE
Import irc.connection within the try

### DIFF
--- a/errbot/backends/irc.py
+++ b/errbot/backends/irc.py
@@ -2,12 +2,12 @@ from __future__ import absolute_import
 import logging
 import sys
 import config
-import irc.connection
 from errbot.backends.base import Message, build_message, build_text_html_message_pair
 from errbot.errBot import ErrBot
 from errbot.utils import RateLimited
 
 try:
+    import irc.connection
     from irc.bot import SingleServerIRCBot
 except ImportError as _:
     logging.exception("Could not start the IRC backend")


### PR DESCRIPTION
There is a try/except block to protect against not having irc
installed - but there is an import that happens before that.
Move the import.
