### PR TITLE
Pretty-print output of the !config command

### DIFF
--- a/errbot/errBot.py
+++ b/errbot/errBot.py
@@ -25,6 +25,7 @@ import subprocess
 
 from tarfile import TarFile
 from urllib.request import urlopen
+from pprint import pformat
 
 from errbot import botcmd, PY2
 from errbot.backends.base import Backend, HIDE_RESTRICTED_COMMANDS
@@ -654,10 +655,13 @@ class ErrBot(Backend, StoreMixin):
 
         if len(args) == 1:
             current_config = self.get_plugin_configuration(plugin_name)
+            response = ("Default configuration for this plugin (you can copy and paste "
+                        "this directly as a command):\n{prefix}config {plugin_name} \n{config}").format(
+                        prefix=self.prefix, plugin_name=plugin_name, config=pformat(template_obj))
             if current_config:
-                return 'Copy paste and adapt one of the following:\nDefault Config: ' + self.prefix + 'config %s %s\nCurrent Config: !config %s %s' % (
-                    plugin_name, repr(template_obj), plugin_name, repr(current_config))
-            return 'Copy paste and adapt of the following:\n' + self.prefix + 'config %s %s' % (plugin_name, repr(template_obj))
+                response += "\n\nCurrent configuration:\n{prefix}config {plugin_name} \n{config}".format(
+                            prefix=self.prefix, plugin_name=plugin_name, config=pformat(current_config))
+            return response
 
         #noinspection PyBroadException
         try:

--- a/tests/commands_tests.py
+++ b/tests/commands_tests.py
@@ -38,13 +38,17 @@ class TestCommands(FullStackTest):
         self.assertIn('Done', popMessage())
 
         pushMessage('!config Webserver')
-        self.assertIn('Copy paste and adapt', popMessage())
+        m = popMessage()
+        self.assertIn('Default configuration for this plugin (you can copy and paste this directly as a command)', m)
+        self.assertNotIn('Current configuration', m)
 
         pushMessage("!config Webserver {'HOST': 'localhost', 'PORT': 3141, 'SSL':  None}")
         self.assertIn('Plugin configuration done.', popMessage())
 
         pushMessage('!config Webserver')
-        self.assertIn('localhost', popMessage())
+        m = popMessage()
+        self.assertIn('Current configuration', m)
+        self.assertIn('localhost', m)
 
         pushMessage('!export configs')
         configs = popMessage()


### PR DESCRIPTION
This makes it easier for people to adjust configuration items, especially in the case of plugins with a lot of configuration options.
