### PR TITLE
Only run 3to2 during actual install steps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
 
     # under python2 if we want to make a source distribution,
     # don't pre-convert the sources, leave them as py3.
-    if PY2 and 'sdist' not in sys.argv:
+    if PY2 and 'install' in sys.argv or 'develop' in sys.argv:
         convert_to_python2()
 
     setup(


### PR DESCRIPTION
While installing, tools like pip first call `setup.py egg_info`,
followed by `setup.py install`. With the previous behaviour, this would
cause the sources to be run through 3to2 twice.

As a result of this, some parts of the code became mangled up, see for
example issues #232.

Another benefit of this change is that install time is reduced somewhat,
since a typical install will now only run 3to2 once instead of twice.

Fixes #232 
