### PR TITLE
Added a raw option for the webhook API.

### DIFF
--- a/errbot/decorators.py
+++ b/errbot/decorators.py
@@ -111,6 +111,10 @@ def webhook(*args, **kwargs):
     :param form_param: The key who's contents will be passed to your method's `payload`
         parameter. This is used for example when using the `application/x-www-form-urlencoded`
         mimetype.
+    :param raw: Boolean to overrides the request decoding (including form_param) and
+        passes the raw http request to your method's `payload`.
+        The passed type in payload will provide the BaseRequest interface as defined here : 
+        http://bottlepy.org/docs/dev/api.html#bottle.BaseRequest
 
     This decorator should be applied to methods of :class:`~errbot.botplugin.BotPlugin`
     classes to turn them into webhooks which can be reached on Err's built-in webserver.
@@ -123,11 +127,11 @@ def webhook(*args, **kwargs):
             pass
     """
 
-    def decorate(func, uri_rule, methods=('POST', 'GET'), form_param=None):
+    def decorate(func, uri_rule, methods=('POST', 'GET'), form_param=None, raw=False):
         logging.info("webhooks:  Bind %s to %s" % (uri_rule, func.__name__))
 
         for verb in methods:
-            bottle_app.route(uri_rule, verb, callback=WebView(func, form_param), name=func.__name__ + '_' + verb)
+            bottle_app.route(uri_rule, verb, callback=WebView(func, form_param, raw), name=func.__name__ + '_' + verb)
         return func
 
     if isinstance(args[0], str) or (PY2 and isinstance(args[0], basestring)):

--- a/tests/webhooks_tests.py
+++ b/tests/webhooks_tests.py
@@ -61,6 +61,10 @@ class TestWebhooks(FullStackTest):
         form = {'form': JSONOBJECT}
         self.assertEquals(requests.post('http://localhost:3141/custom_form/', data=form).text, repr(json.loads(JSONOBJECT)))
 
+    def test_webhooks_with_raw_request(self):
+        form = {'form': JSONOBJECT}
+        self.assertEquals(requests.post('http://localhost:3141/raw/', data=form).text, "<class 'bottle.LocalRequest'>")
+
     def test_generate_certificate_creates_usable_cert(self):
         key_path = os.sep.join((BOT_DATA_DIR, "webserver_key.pem"))
         cert_path = os.sep.join((BOT_DATA_DIR, "webserver_certificate.pem"))

--- a/tests/webhooks_tests/webtest.py
+++ b/tests/webhooks_tests/webtest.py
@@ -24,3 +24,8 @@ class WebTest(BotPlugin):
     def webhook4(self, payload):
         logging.debug(str(payload))
         return str(payload)
+
+    @webhook(r'/raw/', raw=True)
+    def webhook5(self, payload):
+        logging.debug(str(payload))
+        return str(type(payload))


### PR DESCRIPTION
This option allows you to get the raw callback request.
It is useful as an escape hatch when the base usecase is not enough.
For example when you need to parse headers or url parameters from the
incoming request.
