### PR TITLE
trivial fix debug information for all plugins

### DIFF
--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -181,7 +181,7 @@ def update_plugin_places(list):
 
 
 def get_all_plugins():
-    logging.debug("All plugins: %s" % simplePluginManager.getAllPlugins())
+    logging.debug("All plugins: %s" % ', '.join([plug.name for plug in simplePluginManager.getAllPlugins()]))
     return simplePluginManager.getAllPlugins()
 
 


### PR DESCRIPTION
Now all plugins debug info will display like below:  

```
DEBUG:root:All plugins: [<yapsy.PluginInfo.PluginInfo object at 0x104eae310>, <yapsy.PluginInfo.PluginInfo object at 0x104d0ead0>, <yapsy.PluginInfo.PluginInfo object at 0x104d0e8d0>]
```

I think it is a little unreadable. So I modify this one line, and result will be like:  

```
DEBUG:root:All plugins: ChatRoom, Webserver, VersionChecker
```

I know the better way is to add `__repr__` method in the Plugin class to show list string, but it needs to be modified in **YAPSY** lib.
