### PR TITLE
repos: Add err-githubhook.

### DIFF
--- a/errbot/repos.py
+++ b/errbot/repos.py
@@ -126,4 +126,8 @@ KNOWN_PUBLIC_REPOS = {
         'https://github.com/daenney/err-dnsnative.git',
         "Provides common DNS utilities functionality using Python libraries"
     ),
+    'err-githubhook': (
+        'https://github.com/daenney/err-githubhook.git',
+        "Webhooks endpoint supporting the majority of Github Webhook Events"
+    ),
 }


### PR DESCRIPTION
This is a new plugin supporting the majority of Github Webhook events (eventually, right now we support the most useful ones).

It has the nice feature that you can route events from one repository to one or multiple MUC's and decide which type of events should be forwarded to what MUC regardless of what events Github actually sends. This allows you to have a MUC which receives all activity for a repository but only forward a subset, like pull requests, to another channel.
