### PR TITLE
Allow re_botcmd to return all matches in a message

### DIFF
--- a/docs/user_guide/plugin_development/botcommands.rst
+++ b/docs/user_guide/plugin_development/botcommands.rst
@@ -60,6 +60,12 @@ In both cases, your method will receive the message object same as with a regula
 :func:`~errbot.decorators.botcmd`, but instead of an `args` parameter, it takes
 a `match` parameter which will receive an :class:`re.MatchObject`.
 
+.. note::
+    By default, only the first occurrence of a match is returned, even if it can
+    match multiple parts of the message. If you specify `matchall=True`, you will
+    instead get a list of :class:`re.MatchObject` items, containing all the
+    non-overlapping matches that were found in the message.
+
 
 With a bot prefix
 ~~~~~~~~~~~~~~~~~

--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -916,7 +916,10 @@ class Backend(object):
                             if not self.re_commands[k]._err_command_prefix_required}
 
             for name, func in commands.items():
-                match = func._err_command_re_pattern.search(text)
+                if func._err_command_matchall:
+                    match = list(func._err_command_re_pattern.finditer(text))
+                else:
+                    match = func._err_command_re_pattern.search(text)
                 if match:
                     logging.debug("Matching '{}' against '{}' produced a match"
                                   .format(text, func._err_command_re_pattern.pattern))

--- a/errbot/decorators.py
+++ b/errbot/decorators.py
@@ -58,6 +58,9 @@ def re_botcmd(*args, **kwargs):
     :param flags: The `flags` parameter which should be passed to :func:`re.compile()`. This
         allows the expression's behaviour to be modified, such as making it case-insensitive
         for example.
+    :param matchall: By default, only the first match of the regular expression is returned
+        (as a `re.MatchObject`). When *matchall* is `True`, all non-overlapping matches are
+        returned (as a list of `re.MatchObject` items).
     :param prefixed: Requires user input to start with a bot prefix in order for the pattern
         to be applied when `True` (the default).
     :param hidden: Prevents the command from being shown by the built-in help command when `True`.
@@ -81,12 +84,13 @@ def re_botcmd(*args, **kwargs):
     user's input.
     """
 
-    def decorate(func, pattern, flags=0, prefixed=True, hidden=False, name=None, admin_only=False, historize=True,
-                 template=None):
+    def decorate(func, pattern, flags=0, matchall=False, prefixed=True, hidden=False, name=None, admin_only=False,
+                 historize=True, template=None):
         if not hasattr(func, '_err_command'):  # don't override generated functions
             setattr(func, '_err_command', True)
             setattr(func, '_err_re_command', True)
             setattr(func, '_err_command_re_pattern', re.compile(pattern, flags=flags))
+            setattr(func, '_err_command_matchall', matchall)
             setattr(func, '_err_command_prefix_required', prefixed)
             setattr(func, '_err_command_hidden', hidden)
             setattr(func, '_err_command_name', name or func.__name__)

--- a/tests/base_backend_tests.py
+++ b/tests/base_backend_tests.py
@@ -64,6 +64,10 @@ class DummyBackend(Backend):
     def double_regex_command_two(self, mess, match):
         return "two"
 
+    @re_botcmd(pattern=r'match_here', matchall=True)
+    def regex_command_with_matchall(self, mess, matches):
+        return len(matches)
+
     @botcmd
     def return_args_as_str(self, mess, args):
         return "".join(args)
@@ -353,6 +357,10 @@ class BotCmds(unittest.TestCase):
         self.dummy.callback_message(self.makemessage(
             "Err This command also allows extra text in front - regex command with capture group: Captured text"))
         self.assertEquals("Captured text", self.dummy.pop_message().body)
+        self.dummy.callback_message(self.makemessage("!match_here"))
+        self.assertEquals("1", self.dummy.pop_message().body)
+        self.dummy.callback_message(self.makemessage("!match_here match_here match_here"))
+        self.assertEquals("3", self.dummy.pop_message().body)
 
     def test_regex_commands_can_overlap(self):
         self.dummy.callback_message(self.makemessage("!matched by two commands"))


### PR DESCRIPTION
This adds a new parameter, `matchall`, to the `re_botcmd` decorator
which will make Err return all non-overlapping matches of the regex
instead of just returning the first match it finds.
