### PR TITLE
Added full TOX room support.

### DIFF
--- a/errbot/botplugin.py
+++ b/errbot/botplugin.py
@@ -23,6 +23,15 @@ class BotPluginBase(StoreMixin):
         self.current_timers = []
         super(BotPluginBase, self).__init__()
 
+    @property
+    def mode(self):
+        """
+        Get the current active backend.
+
+        :return: the mode like 'tox', 'xmpp' etc...
+        """
+        return holder.bot.mode
+
     def activate(self):
         """
             Override if you want to do something at initialization phase (don't forget to
@@ -265,19 +274,6 @@ class BotPlugin(BotPluginBase):
             :param room:
                 An instance of :class:`~errbot.backends.base.MUCRoom`
                 representing the room for which the topic changed.
-        """
-        pass
-
-    def callback_presence(self, presence):
-        """
-            Triggered on every presence change event.
-
-            Override to get a notification when a contact changes its presence
-            status.
-
-            :param presence:
-                An instance of :class:`~errbot.backends.base.Presence`
-                representing the presence that was received.
         """
         pass
 

--- a/errbot/builtins/chatRoom.py
+++ b/errbot/builtins/chatRoom.py
@@ -57,11 +57,20 @@ class ChatRoom(BotPlugin):
 
         Examples (IRC):
         !room create #example-room
+
+        Example (TOX): (no room name at creation)
+        !room create
         """
-        if len(args) < 1:
-            return "Please tell me which chatroom to create."
-        self.query_room(args[0]).create()
-        return "Created the room {}".format(args[0])
+        if self.mode == 'tox':
+            if len(args) != 0:
+                return "You cannot specify a chatgroup name on TOX."
+            room = self.query_room(None)
+        else:
+            if len(args) < 1:
+                return "Please tell me which chatroom to create."
+            room = self.query_room(args[0])
+        room.create()
+        return "Created the room {}".format(room)
 
     @botcmd()
     def room_join(self, message, args):


### PR DESCRIPTION
This implements MUCRoom.
Tested:
- Create
- invite from user
- invite from bot
- leave
- occupants
- get/set title

Note you need : https://github.com/aitjcize/PyTox/pull/34 for now as PyTox implementation is late.

Some things are weird because TOX supports anonymous Rooms and you
cannot join a room with beeing invited.

Another gotcha: this is weird to invite somebody because you need to
know what is the roaster number of the contact.
