### PR TITLE
Allow non-standard hipchat server

### DIFF
--- a/errbot/backends/hipchat.py
+++ b/errbot/backends/hipchat.py
@@ -381,6 +381,7 @@ class HipchatBackend(XMPPBackend):
             ca_cert=self.ca_cert,
             token=self.api_token,
             endpoint=self.api_endpoint,
+            server=self.server
         )
 
     @property


### PR DESCRIPTION
Pass in server specified in the config to allow connection to a hosted hipchat server