### PR TITLE
Replace references to gbin/err with errbotio/errbot

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,7 +7,7 @@ SPHINXBUILD   = sphinx-build
 SPHINXAPIDOC  = sphinx-apidoc
 PAPER         =
 BUILDDIR      = _build
-PAGESURL      = git@github.com:gbin/err.git
+PAGESURL      = git@github.com:errbotio/errbot.git
 PAGESDIR      = _gh-pages
 EXTRADIR      = _extra
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -70,12 +70,12 @@ Getting help
 
 For general help with Err, we'd prefer you post in our `Google Plus community`_.
 
-.. _GitHub: https://github.com/gbin/err
-.. _fork: https://github.com/gbin/err/fork
+.. _GitHub: https://github.com/errbotio/errbot
+.. _fork: https://github.com/errbotio/errbot/fork
 .. _`pull request`: https://help.github.com/articles/using-pull-requests
 .. _branch: http://git-scm.com/book/en/Git-Branching
 .. _Sphinx: http://sphinx-doc.org/
-.. _docs: https://github.com/gbin/err/tree/master/docs/
-.. _repos.py: https://github.com/gbin/err/blob/master/errbot/repos.py
-.. _`issue tracker`: https://github.com/gbin/err/issues/
+.. _docs: https://github.com/errbotio/errbot/tree/master/docs/
+.. _repos.py: https://github.com/errbotio/errbot/blob/master/errbot/repos.py
+.. _`issue tracker`: https://github.com/errbotio/errbot/issues/
 .. _`Google Plus community`: https://plus.google.com/communities/117050256560830486288

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -10,9 +10,9 @@ Currently, the following networks are supported:
   * IRC
   * Slack_
   * Telegram_
-  * Tox_ (maintained `separately <https://github.com/gbin/err-backend-tox>`__)
-  * Gitter_ (maintained `separately <https://github.com/gbin/err-backend-gitter>`__)
-  * CampFire_ (maintained `separately <https://github.com/gbin/err-backend-campfire>`__)
+  * Tox_ (maintained `separately <https://github.com/errbotio/err-backend-tox>`__)
+  * Gitter_ (maintained `separately <https://github.com/errbotio/err-backend-gitter>`__)
+  * CampFire_ (maintained `separately <https://github.com/errbotio/err-backend-campfire>`__)
 
 Core features
 ^^^^^^^^^^^^^
@@ -65,4 +65,4 @@ Extensive plugin framework
 .. _sleekxmpp: http://sleekxmpp.com/
 .. _irc: https://pypi.python.org/pypi/irc/
 .. _six: https://pypi.python.org/pypi/six/
-.. _`logged to Sentry`: https://github.com/gbin/err/wiki/Logging-with-Sentry
+.. _`logged to Sentry`: https://github.com/errbotio/errbot/wiki/Logging-with-Sentry

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -138,6 +138,6 @@ Err is free software, available under the GPL-3 license. Please refer to the
 :download:`full license text <gpl-3.0.txt>` for more details.
 
 .. _`Google plus community`: https://plus.google.com/b/101905029512356212669/communities/117050256560830486288
-.. _`GitHub page`: http://github.com/gbin/err/
-.. _`plugin list`: https://github.com/gbin/err/wiki
-.. _`open an issue`: https://github.com/gbin/err/issues
+.. _`GitHub page`: http://github.com/errbotio/errbot/
+.. _`plugin list`: https://github.com/errbotio/errbot/wiki
+.. _`open an issue`: https://github.com/errbotio/errbot/issues

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -32,13 +32,13 @@ import logging
 # 'Graphic'  - in a GUI window
 
 # Commercial backends:
-# 'Campfire' - see https://campfirenow.com/ (follow instructions from https://github.com/gbin/err-backend-campfire)
+# 'Campfire' - see https://campfirenow.com/ (follow instructions from https://github.com/errbotio/err-backend-campfire)
 # 'Hipchat'  - see https://www.hipchat.com/
 # 'Slack'    - see https://slack.com/
-# 'Gitter'   - see https://gitter.im/ (follow instructions from https://github.com/gbin/err-backend-gitter)
+# 'Gitter'   - see https://gitter.im/ (follow instructions from https://github.com/errbotio/err-backend-gitter)
 
 # Open protocols:
-# 'TOX'      - see https://tox.im/ (follow instructions from https://github.com/gbin/err-backend-tox)
+# 'TOX'      - see https://tox.im/ (follow instructions from https://github.com/errbotio/err-backend-tox)
 # 'IRC'      - for classic IRC or bridged services like https://gitter.im
 # 'XMPP'     - the Extensible Messaging and Presence Protocol (https://xmpp.org/)
 # 'Telegram' - cloud-based mobile and desktop messaging app with a focus

--- a/errbot/errBot.py
+++ b/errbot/errBot.py
@@ -413,7 +413,7 @@ class ErrBot(Backend, BotPluginManager):
         if template_name:
             return tenv().get_template(template_name + '.md').render(**template_parameters)
 
-        # Reply should be all text at this point (See https://github.com/gbin/err/issues/96)
+        # Reply should be all text at this point (See https://github.com/errbotio/errbot/issues/96)
         return str(template_parameters)
 
     def _execute_and_send(self, cmd, args, match, mess, template_name=None):

--- a/errbot/py2conv.py
+++ b/errbot/py2conv.py
@@ -8,7 +8,7 @@ py_version = sys.version_info[:2]
 
 lib3to2_input_sources = ["errbot", "scripts", "tests"]
 # Avoid running config templates through lib3to2. For background info,
-# see https://github.com/gbin/err/issues/339
+# see https://github.com/errbotio/errbot/issues/339
 lib3to2_exclude = glob(os.path.join("errbot", "config-*.py"))
 PY2 = py_version[0] == 2
 

--- a/errbot/repos.py
+++ b/errbot/repos.py
@@ -3,35 +3,35 @@
 
 KNOWN_PUBLIC_REPOS = {
     'err-timemachine': (
-        'https://github.com/gbin/err-timemachine.git',
+        'https://github.com/errbotio/err-timemachine.git',
         'Log, index and search in message history'
     ),
     'err-gitbot': (
-        'https://github.com/gbin/err-gitbot.git',
+        'https://github.com/errbotio/err-gitbot.git',
         'a plugin that watchs your git repositories and shout in chatroom the last commits'
     ),
     'err-dictbot': (
-        'https://github.com/gbin/err-dictbot.git',
+        'https://github.com/errbotio/err-dictbot.git',
         'a plugin that gives you the definition of a word'
     ),
     'err-pollbot': (
-        'https://github.com/gbin/err-pollbot.git',
+        'https://github.com/errbotio/err-pollbot.git',
         'a voting plugin'
     ),
     'err-imagebot': (
-        'https://github.com/gbin/err-imagebot.git',
+        'https://github.com/errbotio/err-imagebot.git',
         'query google image, stockphotos, xkcd, dilbert, posters ... '
     ),
     'err-stalkerbot': (
-        'https://github.com/gbin/err-stalkerbot.git',
+        'https://github.com/errbotio/err-stalkerbot.git',
         'a bot that tell you the last time he saw somebody'
     ),
     'err-codebot': (
-        'https://github.com/gbin/err-codebot.git',
+        'https://github.com/errbotio/err-codebot.git',
         'can make the bot execute code snippet in C, CPP and Python'
     ),
     'err-tv': (
-        'https://github.com/gbin/err-tv.git',
+        'https://github.com/errbotio/err-tv.git',
         'a plugin that gives you all you need to know about your favorite tv show, next airdate, status etc ...'
     ),
     'err-weatherbot': (
@@ -39,27 +39,27 @@ KNOWN_PUBLIC_REPOS = {
         'query the local weather'
     ),
     'err-coderwall': (
-        'https://github.com/gbin/err-coderwall.git',
+        'https://github.com/errbotio/err-coderwall.git',
         'query users on coderwall'
     ),
     'err-nettools': (
-        'https://github.com/gbin/err-nettools.git',
+        'https://github.com/errbotio/err-nettools.git',
         'various network query utilities'
     ),
     'err-time': (
-        'https://github.com/gbin/err-time.git',
+        'https://github.com/errbotio/err-time.git',
         'gives the current time at a given place'
     ),
     'err-elizabot': (
-        'https://github.com/gbin/err-elizabot.git',
+        'https://github.com/errbotio/err-elizabot.git',
         'a classic electronic shrink'
     ),
     'err-calcbot': (
-        'https://github.com/gbin/err-calcbot.git',
+        'https://github.com/errbotio/err-calcbot.git',
         'a smart calculator, unit converter and math solver'
     ),
     'err-pypi': (
-        'https://github.com/gbin/err-pypi.git',
+        'https://github.com/errbotio/err-pypi.git',
         'some commands to query pypi'
     ),
     'err-reviewboard': (
@@ -75,11 +75,11 @@ KNOWN_PUBLIC_REPOS = {
         'An Err chatbot serving up Die Hard lines during the time of miracles..'
     ),
     'err-devops_borat': (
-        'https://github.com/gbin/err-devops_borat.git',
+        'https://github.com/errbotio/err-devops_borat.git',
         'random funny quotes about software development'
     ),
     'err-social': (
-        'https://github.com/gbin/err-social.git',
+        'https://github.com/errbotio/err-social.git',
         'For the moment a Google plus bridge'
     ),
     'err-rssfeed': (
@@ -91,7 +91,7 @@ KNOWN_PUBLIC_REPOS = {
         'Google Translate plugin for the err bot'
     ),
     'err-tourney': (
-        'https://github.com/gbin/err-tourney.git',
+        'https://github.com/errbotio/err-tourney.git',
         'a ranking and tournament system for err'
     ),
     'err-music': (
@@ -119,7 +119,7 @@ KNOWN_PUBLIC_REPOS = {
         'Output a random line of Goethe\'s "Faust" in sentence context (in German).'
     ),
     'err-sedbot': (
-        'https://github.com/gbin/err-sedbot.git',
+        'https://github.com/errbotio/err-sedbot.git',
         'errbot plugin for executing simple sed substitute commands'
     ),
     'err-dnsnative': (

--- a/tests/commands_tests.py
+++ b/tests/commands_tests.py
@@ -90,7 +90,7 @@ class TestCommands(FullStackTest):
         self.assertCommand('!history', 'uptime')
 
     def test_plugin_cycle(self):
-        self.assertCommand('!repos install git://github.com/gbin/err-helloworld.git',
+        self.assertCommand('!repos install git://github.com/errbotio/err-helloworld.git',
                            'err-helloworld',
                            60)
         self.assertIn('reload', self.bot.pop_message())
@@ -128,7 +128,7 @@ class TestCommands(FullStackTest):
         self.assertIn('Command "hello" not found', self.bot.pop_message())
 
     def test_backup(self):
-        self.bot.push_message('!repos install git://github.com/gbin/err-helloworld.git')
+        self.bot.push_message('!repos install git://github.com/errbotio/err-helloworld.git')
         self.assertIn('err-helloworld', self.bot.pop_message(timeout=60))
         self.assertIn('reload', self.bot.pop_message())
         self.bot.push_message('!backup')

--- a/tools/blacklisted.txt
+++ b/tools/blacklisted.txt
@@ -1,4 +1,4 @@
-gbin/err
+errbotio/errbot
 kongluoxing/TomBot
 TheArchives/Inter
 Offbeatmammal/jsErrLog
@@ -80,7 +80,7 @@ yunojuno/python-errordite
 yllar/plugin.video.err.ee
 wchnicholas/NGSTagErrCorrect
 manoharan-lab/flyvbjerg-std-err
-gbin/err-plugins-tester
+errbotio/errbot-plugins-tester
 andreskaasik/plugin.video.err
 ianzapolsky/art_err_day
 willyrv/msmc-phasing-err


### PR DESCRIPTION
Tests are currently failing because `gbin/err-helloworld` vanished. This updates all references to make the tests pass again.