### PR TITLE
Add bind address and IPv6 enable to irc backend

### DIFF
--- a/errbot/backends/irc.py
+++ b/errbot/backends/irc.py
@@ -296,9 +296,9 @@ class IRCConnection(SingleServerIRCBot):
             connection_factory_kwargs['bind_address'] = self.bind_address
         if self.use_ipv6:
             connection_factory_kwargs['ipv6'] = True
-            
+
         connection_factory = irc.connection.Factory(**connection_factory_kwargs)
-        
+
         self.connection.connect(*args, connect_factory=connection_factory, **kwargs)
 
     def on_welcome(self, _, e):

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -130,7 +130,13 @@ BOT_IDENTITY = {
     # 'server' : 'irc.freenode.net',
     # 'port': 6667,                  # optional
     # 'ssl': False,                  # optional
+    # 'ipv6': False,                 # optional
     # 'nickserv_password': None,     # optional
+    ## Optional: Specify an IP address or hostname (vhost), and a
+    ## port, to use when making the connection. Leave port at 0
+    ## if you have no source port preference.
+    ##    example: 'bind_address': ('my-errbot.io', 0)
+    # 'bind_address': ('localhost', 0),
 }
 
 # Set the admins of your bot. Only these users will have access


### PR DESCRIPTION
Hand-tested the following cases:

* IPv4 connection
* IPv4 bind_address
* IPv4 SSL
* IPv4 SSL + bind_address
* IPv6 versions of all the above with a couple different bind_addresses. IPv6 is a vhoster's dream.

Didn't update/write any tests, because there were no existing tests for the IRC backend.