### PR TITLE
New version section in .plug file.

### DIFF
--- a/docs/user_guide/plugin_development/index.rst
+++ b/docs/user_guide/plugin_development/index.rst
@@ -22,4 +22,5 @@ with sets of recipes on a range of topics describing how to handle more advanced
   webhooks
   testing
   logging
+  plugin_compatibility_settings
   backend_specifics

--- a/docs/user_guide/plugin_development/plugin_compatibility_settings.rst
+++ b/docs/user_guide/plugin_development/plugin_compatibility_settings.rst
@@ -1,0 +1,71 @@
+Plugin compatibility settings
+=============================
+
+
+Python compatibility
+--------------------
+
+Your plugin might not be compatible with Python 2 or Python 3.
+In order to prevent users to install them under an incompatible environment,
+you can add a **Python** section to your plug file:
+
+.. code-block:: ini
+
+    [Core]
+    Name = MyPlugin
+    Module = myplugin
+
+    [Documentation]
+    Description = my plugin
+
+    [Python]
+    Version=2+
+
+The possible choices for **Version** are:
+
+- 2 : only compatible with Python 2
+- 3 : only compatible with Python 3
+- 2+: compatible with both
+
+Of there is no Python section, your plugin will be restricted to Python 2 for backward compatibility.
+
+
+Errbot compatibility
+--------------------
+
+Sometimes when your plugin breaks under a specific version of Errbot, you
+might want to warn the user of your plugin and not load it.
+
+
+You can do it by adding an **Errbot** section to your plug file like this:
+
+.. code-block:: ini
+
+    [Core]
+    Name = MyPlugin
+    Module = myplugin
+
+    [Documentation]
+    Description = my plugin
+
+    [Errbot]
+    Min=2.4.0
+    Max=2.6.0
+
+If the **Errbot** section is omitted, it defaults to "compatible with any version".
+
+If the **Min** option is omitted, there is no minimum version enforced.
+
+If the **Max** option is omitted, there is no maximum version enforced.
+
+Versions need to be a 3 dotted one (ie 2.4 is not allowed but 2.4.0 is). And it understands
+those suffixes:
+
+- "-beta"
+- "-rc1"
+- "-rc2"
+- etc.
+
+For example: 2.4.0-rc1
+
+note: -beta1 or -rc are illegal. Only rc can get a numerical suffix.

--- a/errbot/botplugin.py
+++ b/errbot/botplugin.py
@@ -166,6 +166,7 @@ class BotPlugin(BotPluginBase):
     @property
     def min_err_version(self) -> str:
         """
+        DEPRECATED: see :doc:`/user_guide/plugin_development/plugin_compatibility_settings.html`
         If your plugin has a minimum version of err it needs to be on in order to run,
         please override accordingly this method, returning a string with the dotted
         minimum version. It MUST be in a 3 dotted numbers format or None
@@ -177,6 +178,7 @@ class BotPlugin(BotPluginBase):
     @property
     def max_err_version(self) -> str:
         """
+        DEPRECATED: see :doc:`/user_guide/plugin_development/plugin_compatibility_settings.html`
         If your plugin has a maximal version of err it needs to be on in order to run,
         please override accordingly this method, returning a string with the dotted
         maximal version. It MUST be in a 3 dotted numbers format or None

--- a/errbot/core_plugins/chatRoom.py
+++ b/errbot/core_plugins/chatRoom.py
@@ -3,7 +3,6 @@ import logging
 
 from errbot import BotPlugin, botcmd, SeparatorArgParser, ShlexArgParser
 from errbot.backends.base import RoomNotJoinedError
-from errbot.version import VERSION
 from errbot.utils import compat_str, PY3
 
 # 2to3 hack
@@ -17,8 +16,6 @@ log.debug("LOADING CHATROOM")
 
 
 class ChatRoom(BotPlugin):
-    min_err_version = VERSION  # don't copy paste that for your plugin, it is just because it is a bundled plugin !
-    max_err_version = VERSION
 
     connected = False
 

--- a/errbot/core_plugins/health.py
+++ b/errbot/core_plugins/health.py
@@ -4,14 +4,11 @@ import signal
 from datetime import datetime
 
 from errbot import BotPlugin, botcmd
-from errbot.version import VERSION
 from errbot.plugin_manager import global_restart
 from errbot.utils import format_timedelta
 
 
 class Health(BotPlugin):
-    min_err_version = VERSION  # don't copy paste that for your plugin, it is just because it is a bundled plugin !
-    max_err_version = VERSION
 
     @botcmd(template='status')
     def status(self, mess, args):

--- a/errbot/core_plugins/help.py
+++ b/errbot/core_plugins/help.py
@@ -4,9 +4,6 @@ from errbot.utils import get_class_that_defined_method
 
 
 class Help(BotPlugin):
-    min_err_version = VERSION  # don't copy paste that for your plugin, it is just because it is a bundled plugin !
-    max_err_version = VERSION
-
     MSG_HELP_TAIL = 'Type help <command name> to get more info ' \
                     'about that specific command.'
     MSG_HELP_UNDEFINED_COMMAND = 'That command is not defined.'

--- a/errbot/core_plugins/plugins.py
+++ b/errbot/core_plugins/plugins.py
@@ -6,7 +6,6 @@ from pprint import pformat
 import shutil
 
 from errbot import BotPlugin, botcmd
-from errbot.version import VERSION
 from errbot.repos import KNOWN_PUBLIC_REPOS
 from errbot.rendering import md_escape
 from errbot.utils import which
@@ -14,8 +13,6 @@ from errbot.plugin_manager import check_dependencies, global_restart, PluginConf
 
 
 class Plugins(BotPlugin):
-    min_err_version = VERSION  # don't copy paste that for your plugin, it is just because it is a bundled plugin !
-    max_err_version = VERSION
 
     @botcmd(admin_only=True)
     def repos_install(self, mess, args):

--- a/errbot/core_plugins/utils.py
+++ b/errbot/core_plugins/utils.py
@@ -1,13 +1,10 @@
 from os import path
 
 from errbot import BotPlugin, botcmd
-from errbot.version import VERSION
 from errbot.utils import tail
 
 
 class Utils(BotPlugin):
-    min_err_version = VERSION  # don't copy paste that for your plugin, it is just because it is a bundled plugin !
-    max_err_version = VERSION
 
     # noinspection PyUnusedLocal
     @botcmd

--- a/errbot/core_plugins/vcheck.py
+++ b/errbot/core_plugins/vcheck.py
@@ -2,7 +2,6 @@ from urllib.request import urlopen
 from urllib.error import HTTPError, URLError
 
 from errbot import BotPlugin
-from errbot.version import VERSION
 from errbot.utils import version2array
 
 HOME = 'http://version.errbot.io/'
@@ -11,8 +10,6 @@ installed_version = version2array(VERSION)
 
 
 class VersionChecker(BotPlugin):
-    min_err_version = VERSION  # don't copy paste that for your plugin, it is just because it is a bundled plugin !
-    max_err_version = VERSION
 
     connected = False
     activated = False

--- a/errbot/core_plugins/webserver.py
+++ b/errbot/core_plugins/webserver.py
@@ -6,7 +6,6 @@ from random import random
 from webtest import TestApp
 
 from errbot import botcmd, BotPlugin, webhook
-from errbot.version import VERSION
 from errbot.utils import PY3
 from errbot.core_plugins.wsview import bottle_app
 from errbot.bundled.rocket import Rocket
@@ -67,8 +66,6 @@ def make_ssl_certificate(key_path, cert_path):
 
 
 class Webserver(BotPlugin):
-    min_err_version = VERSION  # don't copy paste that for your plugin, it is just because it is a bundled plugin !
-    max_err_version = VERSION
 
     def __init__(self, bot):
         self.webserver = None

--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -146,7 +146,7 @@ def check_errbot_plug_section(name: str, config: ConfigParser) -> bool:
     """ Checks if we have the correct Errbot version.
     Returns true if the plugin is loadable """
 
-     # Errbot version check
+    # Errbot version check
     try:
 
         try:

--- a/tests/plugin_management_tests.py
+++ b/tests/plugin_management_tests.py
@@ -8,6 +8,7 @@ from errbot.utils import find_roots, find_roots_with_extra
 
 CORE_PLUGINS = plugin_manager.CORE_PLUGINS
 
+
 def touch(name):
     with open(name, 'a'):
         os.utime(name, None)

--- a/tests/plugin_management_tests.py
+++ b/tests/plugin_management_tests.py
@@ -1,9 +1,12 @@
 import os
 import unittest
 import tempfile
-from errbot.plugin_manager import check_dependencies, CORE_PLUGINS
+from configparser import ConfigParser
+
+from errbot import plugin_manager
 from errbot.utils import find_roots, find_roots_with_extra
 
+CORE_PLUGINS = plugin_manager.CORE_PLUGINS
 
 def touch(name):
     with open(name, 'a'):
@@ -12,7 +15,7 @@ def touch(name):
 
 class TestPluginManagement(unittest.TestCase):
     def test_check_dependencies(self):
-        response, deps = check_dependencies(str(os.path.dirname(__file__)) + os.path.sep + 'assets')
+        response, deps = plugin_manager.check_dependencies(str(os.path.dirname(__file__)) + os.path.sep + 'assets')
         self.assertIn('impossible_requirement', response)
         self.assertEqual(['impossible_requirement'], deps)
 
@@ -50,3 +53,55 @@ class TestPluginManagement(unittest.TestCase):
         os.mkdir(a)
         touch(os.path.join(a, 'toto.plug'))
         self.assertEquals(find_roots_with_extra(CORE_PLUGINS, root), [CORE_PLUGINS])
+
+    def test_errbot_version_check(self):
+        real_version = plugin_manager.VERSION
+
+        too_high_min_1 = ConfigParser()
+        too_high_min_1.add_section('Errbot')
+        too_high_min_1.set('Errbot', 'Min', '1.6.0')
+
+        too_high_min_2 = ConfigParser()
+        too_high_min_2.add_section('Errbot')
+        too_high_min_2.set('Errbot', 'Min', '1.6.0')
+        too_high_min_2.set('Errbot', 'Max', '2.0.0')
+
+        too_low_max_1 = ConfigParser()
+        too_low_max_1.add_section('Errbot')
+        too_low_max_1.set('Errbot', 'Max', '1.0.1-beta')
+
+        too_low_max_2 = ConfigParser()
+        too_low_max_2.add_section('Errbot')
+        too_low_max_2.set('Errbot', 'Min', '0.9.0-rc2')
+        too_low_max_2.set('Errbot', 'Max', '1.0.1-beta')
+
+        ok1 = ConfigParser()  # no section
+
+        ok2 = ConfigParser()
+        ok2.add_section('Errbot')  # empty section
+
+        ok3 = ConfigParser()
+        ok3.add_section('Errbot')
+        ok3.set('Errbot', 'Min', '1.4.0')
+
+        ok4 = ConfigParser()
+        ok4.add_section('Errbot')
+        ok4.set('Errbot', 'Max', '1.5.2')
+
+        ok5 = ConfigParser()
+        ok5.add_section('Errbot')
+        ok5 .set('Errbot', 'Min', '1.2.1')
+        ok5 .set('Errbot', 'Max', '1.6.1-rc1')
+
+        try:
+            plugin_manager.VERSION = '1.5.2'
+            for config in (too_high_min_1,
+                           too_high_min_2,
+                           too_low_max_1,
+                           too_low_max_2):
+                self.assertFalse(plugin_manager.check_errbot_plug_section('should_fail', config))
+
+            for config in (ok1, ok2, ok3, ok4, ok5):
+                self.assertTrue(plugin_manager.check_errbot_plug_section('should_work', config))
+        finally:
+            plugin_manager.VERSION = real_version


### PR DESCRIPTION
This deprecated but still support the old vay.

The new section has the format:
[Errbot]
Min=x.y.z-blah
Max=X.Y.Z-blah

If no section exists, assume that any version of errbot is compatible.
Min or Max can also be individually omited which simply relax the
constrain.