### PR TITLE
Added repo for err-stopwatch

### DIFF
--- a/errbot/repos.py
+++ b/errbot/repos.py
@@ -142,4 +142,8 @@ KNOWN_PUBLIC_REPOS = {
         'https://github.com/sarlalian/err-shellexec.git',
         'Allow users to run specifc shell scripts from chat.'
     ),
+    'err-stopwatch': (
+        'https://github.com/taoistmath/err-stopwatch.git',
+        'Plugin to track elapsed time. Can track multiple timers simultaneously.'
+    ),
 }


### PR DESCRIPTION
Stopwatch plugin to track elapsed time. Can track multiple timers simultaneously. Currently using to track time for deployment and regression testing.