### PR TITLE
Splice '.' when adding ':' to MSG_ERROR_OCCURRED

### DIFF
--- a/errbot/errBot.py
+++ b/errbot/errBot.py
@@ -444,7 +444,7 @@ class ErrBot(Backend, BotPluginManager):
             log.exception('An error happened while processing '
                           'a message ("%s"): %s"' %
                           (mess.body, tb))
-            self.send_simple_reply(mess, self.MSG_ERROR_OCCURRED + ':\n %s' % e, private)
+            self.send_simple_reply(mess, self.MSG_ERROR_OCCURRED[:-1] + ':\n %s' % e, private)
 
     def unknown_command(self, _, cmd, args):
         """ Override the default unknown command behavior


### PR DESCRIPTION
The resulting message in chat was `See log for details.:` which is
grammatically incorrect. Other strings have periods, so to remain
consistent it made sense to splice the message before sending.

![image](https://cloud.githubusercontent.com/assets/985061/11670094/0ad9218e-9dce-11e5-9f5e-c21238400e34.png)