### PR TITLE
Remove '.' from MSG_ERROR_OCCURRED

### DIFF
--- a/errbot/errBot.py
+++ b/errbot/errBot.py
@@ -65,7 +65,7 @@ class ErrBot(Backend, BotPluginManager):
     """ ErrBot is the layer of Err that takes care of the plugin management and dispatching
     """
     __errdoc__ = """ Commands related to the bot administration """
-    MSG_ERROR_OCCURRED = 'Computer says nooo. See logs for details.'
+    MSG_ERROR_OCCURRED = 'Computer says nooo. See logs for details'
     MSG_UNKNOWN_COMMAND = 'Unknown command: "%(command)s". '
     startup_time = datetime.now()
 


### PR DESCRIPTION
The resulting message in chat was 'See log for details.:' which is
grammatically incorrect.

Thank you @gbin for the quick reply on the first PR!