### PR TITLE
[WIP] Feature/plugin registry

### DIFF
--- a/errbot/core_plugins/plugins.py
+++ b/errbot/core_plugins/plugins.py
@@ -45,7 +45,21 @@ class Plugins(BotPlugin):
         """
         if not args.strip():
             return "You should have a repo name as argument"
-        repos = self._bot.get(self._bot.REPOS, {})
+        repos = {}
+        _installed = self._bot.get_installed_plugin_repos()
+
+        # Fix to migrate exiting plugins into new format
+        for short_name, url in _installed.items():
+            name = ('/'.join(url.split('/')[-2:])).replace('.git', '')
+
+            t_installed = {name: {
+                'path': url,
+                'documentation': 'Unavilable',
+                'python': None,
+                'avatar_url': None,
+                }
+            }
+            repos.update(t_installed)
         if args not in repos:
             return "This repo is not installed check with " + self._bot.prefix + "repos the list of installed ones"
 
@@ -127,7 +141,22 @@ class Plugins(BotPlugin):
                     'your system to be able to install git based plugins.')
 
         directories = set()
-        repos = self._bot.get(self._bot.REPOS, {})
+        repos = {}
+        _installed = self._bot.get_installed_plugin_repos()
+
+        # Fix to migrate exiting plugins into new format
+        for short_name, url in _installed.items():
+            name = ('/'.join(url.split('/')[-2:])).replace('.git', '')
+
+            t_installed = {name: {
+                'path': url,
+                'documentation': 'Unavilable',
+                'python': None,
+                'avatar_url': None,
+                }
+            }
+            repos.update(t_installed)
+
         core_to_update = 'all' in args or 'core' in args
         if core_to_update:
             directories.add(path.dirname(__file__))

--- a/errbot/core_plugins/plugins.py
+++ b/errbot/core_plugins/plugins.py
@@ -45,21 +45,9 @@ class Plugins(BotPlugin):
         """
         if not args.strip():
             return "You should have a repo name as argument"
-        repos = {}
-        _installed = self._bot.get_installed_plugin_repos()
 
-        # Fix to migrate exiting plugins into new format
-        for short_name, url in _installed.items():
-            name = ('/'.join(url.split('/')[-2:])).replace('.git', '')
+        repos = self._bot.get_installed_plugin_repos()
 
-            t_installed = {name: {
-                'path': url,
-                'documentation': 'Unavilable',
-                'python': None,
-                'avatar_url': None,
-                }
-            }
-            repos.update(t_installed)
         if args not in repos:
             return "This repo is not installed check with " + self._bot.prefix + "repos the list of installed ones"
 
@@ -82,22 +70,7 @@ class Plugins(BotPlugin):
         """ list the current active plugin repositories
         """
 
-        installed_repos = {}
-        _installed = self._bot.get_installed_plugin_repos()
-
-        # Fix to migrate exiting plugins into new format
-        for short_name, url in _installed.items():
-            name = ('/'.join(url.split('/')[-2:])).replace('.git', '')
-
-            t_installed = {name: {
-                'path': url,
-                'documentation': 'Unavilable',
-                'python': None,
-                'avatar_url': None,
-                }
-            }
-            installed_repos.update(t_installed)
-
+        installed_repos = self._bot.get_installed_plugin_repos()
 
         all_names = sorted(set([name for name in KNOWN_PUBLIC_REPOS] + [name for name in installed_repos]))
 

--- a/errbot/core_plugins/plugins.py
+++ b/errbot/core_plugins/plugins.py
@@ -59,7 +59,7 @@ class Plugins(BotPlugin):
 
         shutil.rmtree(plugin_path)
         repos.pop(args)
-        self[self._bot.REPOS] = repos
+        self._bot.set_plugin_repos(repos)
 
         return 'Plugins unloaded and repo %s removed' % args
 

--- a/errbot/core_plugins/plugins.py
+++ b/errbot/core_plugins/plugins.py
@@ -73,8 +73,6 @@ class Plugins(BotPlugin):
 
         # Fix to migrate exiting plugins into new format
         for short_name, url in _installed.items():
-            #import ipdb; ipdb.set_trace()
-
             name = ('/'.join(url.split('/')[-2:])).replace('.git', '')
 
             t_installed = {name: {

--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -506,7 +506,8 @@ class BotPluginManager(PluginManager, StoreMixin):
         if repo.endswith('tar.gz'):
             tar = TarFile(fileobj=urlopen(repo))
             tar.extractall(path=self.plugin_dir)
-            human_name = repo.split('/')[-1][:-7]
+            s = repo.split(':')[-1].split('/')[-2:]
+            human_name = '/'.join(s).rstrip('.tar.gz')
         else:
             human_name = human_name_for_git_url(repo)
             p = subprocess.Popen([git_path, 'clone', repo, human_name], cwd=self.plugin_dir, stdout=subprocess.PIPE,

--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -462,13 +462,14 @@ class BotPluginManager(PluginManager, StoreMixin):
 
     def install_repo(self, repo):
         if repo in KNOWN_PUBLIC_REPOS:
-            repo = KNOWN_PUBLIC_REPOS[repo][0]  # replace it by the url
+            repo = KNOWN_PUBLIC_REPOS[repo]['path']  # replace it by the url
         git_path = which('git')
 
         if not git_path:
             return ('git command not found: You need to have git installed on '
                     'your system to be able to install git based plugins.', )
 
+        # TODO: Update download path of plugin.
         if repo.endswith('tar.gz'):
             tar = TarFile(fileobj=urlopen(repo))
             tar.extractall(path=self.plugin_dir)

--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -376,7 +376,8 @@ class BotPluginManager(PluginManager, StoreMixin):
 
         # Fix to migrate exiting plugins into new format
         for url in self.get(self.REPOS, repos).values():
-            if type(url) == dict: continue
+            if type(url) == dict:
+                continue
             t_name = '/'.join(url.split('/')[-2:])
             name = t_name.replace('.git', '')
 

--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -368,7 +368,27 @@ class BotPluginManager(PluginManager, StoreMixin):
 
     # Repo management
     def get_installed_plugin_repos(self):
-        return self.get(self.REPOS, {})
+
+        repos = self.get(self.REPOS, {})
+
+        if not repos:
+            return repos
+
+        # Fix to migrate exiting plugins into new format
+        for url in self.get(self.REPOS, repos).values():
+            if type(url) == dict: continue
+            t_name = '/'.join(url.split('/')[-2:])
+            name = t_name.replace('.git', '')
+
+            t_installed = {name: {
+                'path': url,
+                'documentation': 'Unavilable',
+                'python': None,
+                'avatar_url': None,
+                }
+            }
+            repos.update(t_installed)
+        return repos
 
     def add_plugin_repo(self, name, url):
         if PY2:

--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -380,23 +380,35 @@ class BotPluginManager(PluginManager, StoreMixin):
             t_name = '/'.join(url.split('/')[-2:])
             name = t_name.replace('.git', '')
 
-            t_installed = {name: {
+            t_repo = {name: {
                 'path': url,
                 'documentation': 'Unavilable',
                 'python': None,
                 'avatar_url': None,
                 }
             }
-            repos.update(t_installed)
+            repos.update(t_repo)
         return repos
+
+    def set_plugin_repos(self, repos):
+        self[self.REPOS] = repos
 
     def add_plugin_repo(self, name, url):
         if PY2:
             name = name.encode('utf-8')
             url = url.encode('utf-8')
         repos = self.get_installed_plugin_repos()
-        repos[name] = url
-        self[self.REPOS] = repos
+
+        t_installed = {name: {
+            'path': url,
+            'documentation': 'Unavilable',
+            'python': None,
+            'avatar_url': None,
+            }
+        }
+
+        repos.update(t_installed)
+        self.set_plugin_repos(repos)
 
     # plugin blacklisting management
     def get_blacklisted_plugin(self):

--- a/errbot/repos.py
+++ b/errbot/repos.py
@@ -16,7 +16,7 @@ def get_known_repos():
         'python': None
     }, ...
     '''
-    registry_url = 'http://bit.ly/22pkjaq'
+    registry_url = 'http://bit.ly/1kjdlRX'
     registry = urllib.request.urlopen(registry_url).read()
     return ast.literal_eval(registry.decode('utf-8'))
 

--- a/errbot/repos.py
+++ b/errbot/repos.py
@@ -16,7 +16,7 @@ def get_known_repos():
         'python': None
     }, ...
     '''
-    registry = urllib.request.urlopen('http://localhost/repos.json').read()
+    registry = urllib.request.urlopen('https://gist.githubusercontent.com/sijis/95ac411600f085818f22/raw/84ef97b1fbc5c00ebf46c1558d6fd83c07091e6a/repos.json').read()
     return ast.literal_eval(registry.decode('utf-8'))
 
 KNOWN_PUBLIC_REPOS = get_known_repos()

--- a/errbot/repos.py
+++ b/errbot/repos.py
@@ -16,7 +16,8 @@ def get_known_repos():
         'python': None
     }, ...
     '''
-    registry = urllib.request.urlopen('https://gist.githubusercontent.com/sijis/95ac411600f085818f22/raw/84ef97b1fbc5c00ebf46c1558d6fd83c07091e6a/repos.json').read()
+    registry_url = 'http://bit.ly/22pkjaq'
+    registry = urllib.request.urlopen(registry_url).read()
     return ast.literal_eval(registry.decode('utf-8'))
 
 KNOWN_PUBLIC_REPOS = get_known_repos()

--- a/errbot/repos.py
+++ b/errbot/repos.py
@@ -1,145 +1,22 @@
 # This is a list of known public repos for err
 # Feel free to make a pull request to add yours !
+import urllib.request
+import ast
 
-KNOWN_PUBLIC_REPOS = {
-    'err-timemachine': (
-        'https://github.com/errbotio/err-timemachine.git',
-        'Log, index and search in message history'
-    ),
-    'err-gitbot': (
-        'https://github.com/errbotio/err-gitbot.git',
-        'a plugin that watchs your git repositories and shout in chatroom the last commits'
-    ),
-    'err-dictbot': (
-        'https://github.com/errbotio/err-dictbot.git',
-        'a plugin that gives you the definition of a word'
-    ),
-    'err-pollbot': (
-        'https://github.com/errbotio/err-pollbot.git',
-        'a voting plugin'
-    ),
-    'err-imagebot': (
-        'https://github.com/errbotio/err-imagebot.git',
-        'query google image, stockphotos, xkcd, dilbert, posters ... '
-    ),
-    'err-stalkerbot': (
-        'https://github.com/errbotio/err-stalkerbot.git',
-        'a bot that tell you the last time he saw somebody'
-    ),
-    'err-codebot': (
-        'https://github.com/errbotio/err-codebot.git',
-        'can make the bot execute code snippet in C, CPP and Python'
-    ),
-    'err-tv': (
-        'https://github.com/errbotio/err-tv.git',
-        'a plugin that gives you all you need to know about your favorite tv show, next airdate, status etc ...'
-    ),
-    'err-weatherbot': (
-        'https://github.com/atalyad/err-weatherbot.git',
-        'query the local weather'
-    ),
-    'err-coderwall': (
-        'https://github.com/errbotio/err-coderwall.git',
-        'query users on coderwall'
-    ),
-    'err-nettools': (
-        'https://github.com/errbotio/err-nettools.git',
-        'various network query utilities'
-    ),
-    'err-time': (
-        'https://github.com/errbotio/err-time.git',
-        'gives the current time at a given place'
-    ),
-    'err-elizabot': (
-        'https://github.com/errbotio/err-elizabot.git',
-        'a classic electronic shrink'
-    ),
-    'err-calcbot': (
-        'https://github.com/errbotio/err-calcbot.git',
-        'a smart calculator, unit converter and math solver'
-    ),
-    'err-pypi': (
-        'https://github.com/errbotio/err-pypi.git',
-        'some commands to query pypi'
-    ),
-    'err-reviewboard': (
-        'https://github.com/glenbot/err-reviewboard.git',
-        'Err bot that displays the latest reviews from review board'
-    ),
-    'err-topgunbot': (
-        'https://github.com/krismolendyke/err-topgunbot.git',
-        'An Err chatbot serving up supersonic TOP GUN lines.'
-    ),
-    'err-diehardbot': (
-        'https://github.com/krismolendyke/err-diehardbot.git',
-        'An Err chatbot serving up Die Hard lines during the time of miracles..'
-    ),
-    'err-devops_borat': (
-        'https://github.com/errbotio/err-devops_borat.git',
-        'random funny quotes about software development'
-    ),
-    'err-social': (
-        'https://github.com/errbotio/err-social.git',
-        'For the moment a Google plus bridge'
-    ),
-    'err-rssfeed': (
-        'https://github.com/atalyad/err-rssfeed.git',
-        'register to rss feeds and get updates in the chat.'
-    ),
-    'err-translate': (
-        'https://github.com/benvd/err-translate.git',
-        'Google Translate plugin for the err bot'
-    ),
-    'err-tourney': (
-        'https://github.com/errbotio/err-tourney.git',
-        'a ranking and tournament system for err'
-    ),
-    'err-music': (
-        'https://github.com/benvd/err-music.git',
-        'Query lyrics, compositors etc etc ...'
-    ),
-    'err-mailwatch': (
-        'https://github.com/zoni/err-mailwatch.git',
-        'Watch IMAP servers for new mails'
-    ),
-    'err-dnsutils': (
-        'https://github.com/zoni/err-dnsutils.git',
-        'Run common DNS utils: host, dig, nslookup'
-    ),
-    'err-insult': (
-        'https://github.com/xnaveira/err-insult.git',
-        'Hubot insult plugin clone for Err bot'
-    ),
-    'err-markovbot': (
-        'https://github.com/MaxWagner/err-markovbot.git',
-        'Markov chain bot that supports db generation from url, file or string'
-    ),
-    'err-faustbot': (
-        'https://github.com/Scaatis/err-faustbot.git',
-        'Output a random line of Goethe\'s "Faust" in sentence context (in German).'
-    ),
-    'err-sedbot': (
-        'https://github.com/errbotio/err-sedbot.git',
-        'errbot plugin for executing simple sed substitute commands'
-    ),
-    'err-dnsnative': (
-        'https://github.com/daenney/err-dnsnative.git',
-        'Provides common DNS utilities functionality using Python libraries'
-    ),
-    'err-githubhook': (
-        'https://github.com/daenney/err-githubhook.git',
-        'Webhooks endpoint supporting the majority of Github Webhook Events'
-    ),
-    'err-stash': (
-        'https://github.com/charlesrg/err-stash.git',
-        'Plugin to notify commits to Atlassian Stash Git repo to user or chatrooms.'
-    ),
-    'err-coffeetime': (
-        'https://github.com/Ecno92/err-coffeetime.git',
-        'Tells which member of the group chat should bring the coffee.'
-    ),
-    'err-shellexec': (
-        'https://github.com/sarlalian/err-shellexec.git',
-        'Allow users to run specifc shell scripts from chat.'
-    ),
-}
+
+def get_known_repos():
+    '''
+    Get known repos from registry
+
+    An example entry of the json file is the following
+    'errbotio/err-pypi': {
+        'avatar_url': None,
+        'documentation': 'some commands to query pypi',
+        'path': 'https://github.com/errbotio/err-pypi.git',
+        'python': None
+    }, ...
+    '''
+    registry = urllib.request.urlopen('http://localhost/repos.json').read()
+    return ast.literal_eval(registry.decode('utf-8'))
+
+KNOWN_PUBLIC_REPOS = get_known_repos()

--- a/errbot/utils.py
+++ b/errbot/utils.py
@@ -90,12 +90,8 @@ def get_class_for_method(meth):
 
 def human_name_for_git_url(url):
     # try to humanize the last part of the git url as much as we can
-    if url.find('/') > 0:
-        s = url.split('/')
-    else:
-        s = url.split(':')
-    last_part = str(s[-1]) if s[-1] else str(s[-2])
-    return last_part[:-4] if last_part.endswith('.git') else last_part
+    s = url.split(':')[-1].split('/')[-2:]
+    return str('/'.join(s).rstrip('.git'))
 
 
 def tail(f, window=20):

--- a/tests/commands_tests.py
+++ b/tests/commands_tests.py
@@ -90,42 +90,49 @@ class TestCommands(FullStackTest):
         self.assertCommand('!history', 'uptime')
 
     def test_plugin_cycle(self):
-        self.assertCommand('!repos install git://github.com/errbotio/err-helloworld.git',
-                           'err-helloworld',
-                           60)
-        self.assertIn('reload', self.bot.pop_message())
 
-        self.assertCommand('!help hello', 'this command says hello')
-        self.assertCommand('!hello', 'Hello World !')
+        plugins = [
+            # 'git://github.com/errbotio/err-helloworld.git',
+            'errbotio/err-helloworld',
+        ]
 
-        self.bot.push_message('!plugin reload HelloWorld')
-        self.assertEqual('Plugin HelloWorld reloaded.', self.bot.pop_message())
+        for plugin in plugins:
+            self.assertCommand('!repos install {0}'.format(plugin),
+                               'errbotio/err-helloworld',
+                               60)
+            self.assertIn('reload', self.bot.pop_message())
 
-        self.bot.push_message('!hello')  # should still respond
-        self.assertEqual('Hello World !', self.bot.pop_message())
+            self.assertCommand('!help hello', 'this command says hello')
+            self.assertCommand('!hello', 'Hello World !')
 
-        self.bot.push_message('!plugin blacklist HelloWorld')
-        self.assertEqual('Plugin HelloWorld is now blacklisted', self.bot.pop_message())
-        self.bot.push_message('!plugin deactivate HelloWorld')
-        self.assertEqual('HelloWorld is already deactivated.', self.bot.pop_message())
+            self.bot.push_message('!plugin reload HelloWorld')
+            self.assertEqual('Plugin HelloWorld reloaded.', self.bot.pop_message())
 
-        self.bot.push_message('!hello')  # should not respond
-        self.assertIn('Command "hello" not found', self.bot.pop_message())
+            self.bot.push_message('!hello')  # should still respond
+            self.assertEqual('Hello World !', self.bot.pop_message())
 
-        self.bot.push_message('!plugin unblacklist HelloWorld')
-        self.assertEqual('Plugin HelloWorld removed from blacklist', self.bot.pop_message())
-        self.bot.push_message('!plugin activate HelloWorld')
-        self.assertEqual('HelloWorld is already activated.', self.bot.pop_message())
+            self.bot.push_message('!plugin blacklist HelloWorld')
+            self.assertEqual('Plugin HelloWorld is now blacklisted', self.bot.pop_message())
+            self.bot.push_message('!plugin deactivate HelloWorld')
+            self.assertEqual('HelloWorld is already deactivated.', self.bot.pop_message())
 
-        self.bot.push_message('!hello')  # should respond back
-        self.assertEqual('Hello World !', self.bot.pop_message())
+            self.bot.push_message('!hello')  # should not respond
+            self.assertIn('Command "hello" not found', self.bot.pop_message())
 
-        self.bot.push_message('!repos uninstall err-helloworld')
-        self.assertEqual('Removing HelloWorld...', self.bot.pop_message())
-        self.assertEqual('Repo err-helloworld removed.', self.bot.pop_message())
+            self.bot.push_message('!plugin unblacklist HelloWorld')
+            self.assertEqual('Plugin HelloWorld removed from blacklist', self.bot.pop_message())
+            self.bot.push_message('!plugin activate HelloWorld')
+            self.assertEqual('HelloWorld is already activated.', self.bot.pop_message())
 
-        self.bot.push_message('!hello')  # should not respond
-        self.assertIn('Command "hello" not found', self.bot.pop_message())
+            self.bot.push_message('!hello')  # should respond back
+            self.assertEqual('Hello World !', self.bot.pop_message())
+
+            self.bot.push_message('!repos uninstall errbotio/err-helloworld')
+            self.assertEqual('Removing HelloWorld...', self.bot.pop_message())
+            self.assertEqual('Repo errbotio/err-helloworld removed.', self.bot.pop_message())
+
+            self.bot.push_message('!hello')  # should not respond
+            self.assertIn('Command "hello" not found', self.bot.pop_message())
 
     def test_backup(self):
         self.bot.push_message('!repos install git://github.com/errbotio/err-helloworld.git')

--- a/tests/commands_tests.py
+++ b/tests/commands_tests.py
@@ -137,7 +137,7 @@ class TestCommands(FullStackTest):
         filename = re.search(r"'([A-Za-z0-9_\./\\-]*)'", msg).group(1)
 
         # At least the backup should mention the installed plugin
-        self.assertIn('err-helloworld', open(filename).read())
+        self.assertIn('errbotio/err-helloworld', open(filename).read())
 
         # Now try to clean the bot and restore
         plugins_dir = path.join(self.bot.bot_config.BOT_DATA_DIR, 'plugins')
@@ -152,7 +152,7 @@ class TestCommands(FullStackTest):
         with open(filename) as f:
             exec(f.read())
         self.assertCommand('!hello', 'Hello World !')
-        self.bot.push_message('!repos uninstall err-helloworld')
+        self.bot.push_message('!repos uninstall errbotio/err-helloworld')
 
     def test_encoding_preservation(self):
         self.bot.push_message('!echo へようこそ')

--- a/tools/gen_home.py
+++ b/tools/gen_home.py
@@ -2,30 +2,28 @@
 from jinja2 import Template
 import requests
 import time
+import ast
 
 template = Template(open('plugins.md').read())
 
 blacklisted = [repo.strip() for repo in open('blacklisted.txt', 'r').readlines()]
 
-DEFAULT_AVATAR = 'https://upload.wikimedia.org/wikipedia/commons/5/5f/Err-logo.png'
+with open('repos.json', 'r') as p:
+    plugins = ast.literal_eval(p.read())
 
-with open('plugins.txt', 'r') as p:
-    plugins = [eval(line) for line in p]
-    # Removes the weird forks of errbot itself.
-    plugins = [plugin for plugin in plugins if not plugin['path'].startswith('errbot')]
+    # Removes the weird forks of errbot itself and
+    # blacklisted repos
+    for plugin, values in plugins.items():
+        if values['path'].startswith('errbot') or \
+           plugin in blacklisted:
+            plugins.pop(plugin)
 
-    # Be sure to remove the blacklisted ones.
-    plugins = [plugin for plugin in plugins if plugin['repo'] not in blacklisted]
-
-    # Removes dupes from the same repos.
-    plugins = {(plugin['repo'], plugin['name']): plugin for plugin in plugins}.values()
-
-    plugins = sorted(plugins, key=lambda plug: plug['name'])
+    sorted_plugins = sorted(plugins.items())
 
     with open('sorted-dedupped-plugins.txt', 'w') as out:
-        for plugin in plugins:
+        for plugin in sorted_plugins:
             out.write(repr(plugin))
             out.write('\n')
 
     with open('Home.md', 'w') as out:
-        out.write(template.render(plugins=plugins))
+        out.write(template.render(plugins=sorted_plugins))

--- a/tools/plugin-gen.py
+++ b/tools/plugin-gen.py
@@ -32,9 +32,8 @@ def add_blacklisted(repo):
 
 
 def add_plugin(plugin):
-    with open('plugins.txt', 'a') as f:
+    with open('repos.json', 'a') as f:
         f.write(repr(plugin))
-        f.write('\n')
 
 with open('blacklisted.txt', 'r') as f:
     BLACKLISTED = [line.strip() for line in f.readlines()]
@@ -72,6 +71,7 @@ def check_repo(repo):
         return
     avatar_url = get_avatar_url(repo)
 
+    plugins = {}
     for plug in plug_items:
         time.sleep(PAUSE)
         f = requests.get('https://raw.githubusercontent.com/%s/master/%s' % (repo, plug["path"]))
@@ -82,25 +82,32 @@ def check_repo(repo):
         parser.read_string(f.text)
         name = parser['Core']['Name']
         log.debug('Name: %s' % name)
+
         if 'Documentation' in parser:
             doc = parser['Documentation']['Description']
             log.debug('Documentation: %s' % doc)
         else:
             doc = ''
+
         if 'Python' in parser:
             python = parser['Python']['Version']
             log.debug('Python Version: %s' % python)
         else:
             python = '2'
 
-        plugin = {'repo': repo,
-                  'path': plug['path'],
-                  'documentation': doc,
-                  'name': name,
-                  'python': python,
-                  'avatar_url': avatar_url}
-        add_plugin(plugin)
+        plugin = {repo: {
+                          'path': plug['path'],
+                          'repo': 'https://github.com/{0}'.format(repo),
+                          'documentation': doc,
+                          'name': name,
+                          'python': python,
+                          'avatar_url': avatar_url,
+                      }
+                 }
+        plugins.update(plugin)
         print('Catalog added plugin %s.' % plugin['name'])
+
+    add_plugin(plugins)
 
 
 def find_plugins():

--- a/tools/plugin-gen.py
+++ b/tools/plugin-gen.py
@@ -96,14 +96,14 @@ def check_repo(repo):
             python = '2'
 
         plugin = {repo: {
-                          'path': plug['path'],
-                          'repo': 'https://github.com/{0}'.format(repo),
-                          'documentation': doc,
-                          'name': name,
-                          'python': python,
-                          'avatar_url': avatar_url,
-                      }
-                 }
+            'path': plug['path'],
+            'repo': 'https://github.com/{0}'.format(repo),
+            'documentation': doc,
+            'name': name,
+            'python': python,
+            'avatar_url': avatar_url,
+        }}
+
         plugins.update(plugin)
         print('Catalog added plugin %s.' % plugin['name'])
 

--- a/tools/plugins.md
+++ b/tools/plugins.md
@@ -3,12 +3,14 @@ If you are looking for errbot documentation, it is there: [errbot.io](http://err
 ### All errbot plugins found from github
 
 {% for plugin in plugins %}
-## {{loop.index}}\. <img src="{{plugin.avatar_url}}" width="32">  [{{plugin.name}}](https://github.com/{{plugin.repo}})
+{% set name = plugin[0] %}
+{% set values = plugin[1] %}
+## {{loop.index}}\. <img src="{{values.avatar_url}}" width="32">  [{{name}}]({{values.repo}})
 
-{{plugin.documentation}}
+{{values.documentation}}
 
-- Python {{plugin.python}}
-- Install: `!repos install https://github.com/{{plugin.repo}}.git`
+- Python {{values.python}}
+- Install: `!repos install {{values.repo}}`
 
 ---
 {% endfor %}


### PR DESCRIPTION
I'm just hacking away an idea to use a simple json file to get a 'realtime' pull of available plugins. The json is based on the script in `tools/` directory.

I changed the format of the plugin to be `<owner>/<plugin-name>`. The only reason I did that was in the even there were two plugins with the same name. In our case, we have multiple forks of the same plugin. Its possible the bot owner may want to try all of them and figure out the best one of the batch.

I did realize there is an `err-catalog` plugin. I honestly haven't checked it.