### PR TITLE
irc: Fix random `UnicodeDecodeError`s

### DIFF
--- a/errbot/backends/irc.py
+++ b/errbot/backends/irc.py
@@ -304,6 +304,11 @@ class IRCConnection(SingleServerIRCBot):
         super().__init__([(server, port, password)], nickname, username, reconnection_interval=reconnect_on_disconnect)
 
     def connect(self, *args, **kwargs):
+        # Decode all input to UTF-8, but use a replacement character for
+        # unrecognized byte sequences
+        # (as described at https://pypi.python.org/pypi/irc)
+        self.connection.buffer_class.errors = 'replace'
+
         connection_factory_kwargs = {}
         if self.use_ssl:
             import ssl


### PR DESCRIPTION
* In #569 it was reported that `UnicodeDecodeError`s are thrown randomly
  when the IRC backend is used. This commit tries to resolve this
  situation by using a replacement character for unrecognized byte
  sequences as described at https://pypi.python.org/pypi/irc

Signed-off-by: mr.Shu <mr@shu.io>

---------------------------------------------------

Note that this should fix #569.