### PR TITLE
Fixes join when password is set for room.

### DIFF
--- a/errbot/core_plugins/chatRoom.py
+++ b/errbot/core_plugins/chatRoom.py
@@ -33,7 +33,7 @@ class ChatRoom(BotPlugin):
                     self.log.exception("Joining room %s failed", repr(room))
 
     def _join_room(self, room):
-        if isinstance(room, tuple):
+        if isinstance(room, tuple) or isinstance(room, list):
             room_name = compat_str(room[0])
             room_password = compat_str(room[1])
             room, username, password = (room_name, self.bot_config.CHATROOM_FN, room_password)

--- a/errbot/core_plugins/chatRoom.py
+++ b/errbot/core_plugins/chatRoom.py
@@ -33,12 +33,15 @@ class ChatRoom(BotPlugin):
                     self.log.exception("Joining room %s failed", repr(room))
 
     def _join_room(self, room):
-        room_name = compat_str(room)
-        if room_name is not None:
-            room, username, password = (room_name, self.bot_config.CHATROOM_FN, None)
+        if isinstance(room, tuple):
+            room_name = compat_str(room[0])
+            room_password = compat_str(room[1])
+            room, username, password = (room_name, self.bot_config.CHATROOM_FN, room_password)
+            self.log.info("Joining room {} with username {} and password".format(room, username))
         else:
-            room, username, password = (room[0], self.bot_config.CHATROOM_FN, room[1])
-        self.log.info("Joining room {} with username {}".format(room, username))
+            room_name = compat_str(room)
+            room, username, password = (room_name, self.bot_config.CHATROOM_FN, None)
+            self.log.info("Joining room {} with username {}".format(room, username))
         try:
             self.query_room(room).join(username=self.bot_config.CHATROOM_FN, password=password)
         except NotImplementedError:


### PR DESCRIPTION
_join_room() was expecting compat_str() to bail out with None.
That is not the case anymore (commit 4ed92ff24bf3c7917c9f46b88d800a144aaaaf24).
Therefore room JID was junk and password enabled XMPP MUC rooms could not be joined.