### PR TITLE
Implements a filter for core plugins.

### DIFF
--- a/errbot/backends/test.py
+++ b/errbot/backends/test.py
@@ -340,7 +340,11 @@ class TestBot(object):
     bot_thread = None
 
     def __init__(self, extra_plugin_dir=None, loglevel=logging.DEBUG, extra_config=None):
+        self.setup(extra_plugin_dir=extra_plugin_dir, loglevel=loglevel, extra_config=extra_config)
+
+    def setup(self, extra_plugin_dir=None, loglevel=logging.DEBUG, extra_config=None):
         """
+        :param extra_config: Piece of extra configuration you want to inject to the config.
         :param extra_plugin_dir: Path to a directory from which additional
             plugins should be loaded.
         :param loglevel: Logging verbosity. Expects one of the constants
@@ -461,7 +465,7 @@ class FullStackTest(unittest.TestCase, TestBot):
         if extra_plugin_dir is None and extra_test_file is not None:
             extra_plugin_dir = sep.join(abspath(extra_test_file).split(sep)[:-2])
 
-        TestBot.__init__(self, extra_plugin_dir=extra_plugin_dir, loglevel=loglevel, extra_config=extra_config)
+        self.setup(extra_plugin_dir=extra_plugin_dir, loglevel=loglevel, extra_config=extra_config)
         self.start()
 
     def tearDown(self):

--- a/errbot/backends/test.py
+++ b/errbot/backends/test.py
@@ -1,3 +1,4 @@
+import importlib
 import logging
 import sys
 import unittest
@@ -13,7 +14,6 @@ from errbot.backends.base import Message, MUCRoom, Identifier, MUCIdentifier, ON
 from errbot.core_plugins.wsview import reset_app
 from errbot.errBot import ErrBot
 from errbot.main import setup_bot
-
 
 # Can't use __name__ because of Yapsy
 log = logging.getLogger('errbot.backends.test')
@@ -38,6 +38,7 @@ class TestIdentifier(Identifier):
     from object instead and make sure it includes all properties and
     methods exposed by this class.
     """
+
     def __init__(self, person, client=None, nick=None, fullname=None):
         self._person = person
         self._client = client
@@ -73,6 +74,7 @@ class TestIdentifier(Identifier):
         if self.client:
             return self._person + "/" + self._client
         return self._person
+
     __str__ = __unicode__
 
     def __eq__(self, other):
@@ -84,6 +86,7 @@ class TestMUCOccupant(TestIdentifier, MUCIdentifier):
     """ This is a MUC occupant represented as a string.
         DO NOT USE THIS DIRECTLY AS IT IS NOT COMPATIBLE WITH MOST BACKENDS,
     """
+
     def __init__(self, person, room):
         super().__init__(person)
         self._room = room
@@ -318,6 +321,10 @@ class TestBackend(ErrBot):
         self._rooms = []
 
 
+class ShallowConfig(object):
+    pass
+
+
 class TestBot(object):
     """
     A minimal bot utilizing the TestBackend, for use with unit testing.
@@ -339,9 +346,11 @@ class TestBot(object):
         :param loglevel: Logging verbosity. Expects one of the constants
             defined by the logging module.
         """
-        __import__('errbot.config-template')
-        config = sys.modules['errbot.config-template']
         tempdir = mkdtemp()
+
+        # This is for test isolation.
+        config = ShallowConfig()
+        config.__dict__.update(importlib.import_module('errbot.config-template').__dict__)
         config.BOT_DATA_DIR = tempdir
         config.BOT_LOG_FILE = tempdir + sep + 'log.txt'
 
@@ -524,10 +533,10 @@ def testbot(request):
     kwargs = {}
 
     for attr, default in (('extra_plugin_dir', None), ('loglevel', logging.DEBUG),):
-            if hasattr(request, 'instance'):
-                kwargs[attr] = getattr(request.instance, attr, None)
-            if kwargs[attr] is None:
-                kwargs[attr] = getattr(request.module, attr, default)
+        if hasattr(request, 'instance'):
+            kwargs[attr] = getattr(request.instance, attr, None)
+        if kwargs[attr] is None:
+            kwargs[attr] = getattr(request.module, attr, default)
 
     bot = TestBot(**kwargs)
     bot.start()

--- a/errbot/backends/test.py
+++ b/errbot/backends/test.py
@@ -332,7 +332,7 @@ class TestBot(object):
     """
     bot_thread = None
 
-    def __init__(self, extra_plugin_dir=None, loglevel=logging.DEBUG):
+    def __init__(self, extra_plugin_dir=None, loglevel=logging.DEBUG, extra_config=None):
         """
         :param extra_plugin_dir: Path to a directory from which additional
             plugins should be loaded.
@@ -344,6 +344,11 @@ class TestBot(object):
         tempdir = mkdtemp()
         config.BOT_DATA_DIR = tempdir
         config.BOT_LOG_FILE = tempdir + sep + 'log.txt'
+
+        if extra_config is not None:
+            log.debug('Merging %s to the bot config.' % repr(extra_config))
+            for k, v in extra_config.items():
+                setattr(config, k, v)
 
         # reset logging to console
         logging.basicConfig(format='%(levelname)s:%(message)s')
@@ -433,7 +438,7 @@ class FullStackTest(unittest.TestCase, TestBot):
                 self.assertIn('Err version', self.pop_message())
     """
 
-    def setUp(self, extra_plugin_dir=None, extra_test_file=None, loglevel=logging.DEBUG):
+    def setUp(self, extra_plugin_dir=None, extra_test_file=None, loglevel=logging.DEBUG, extra_config=None):
         """
         :param extra_plugin_dir: Path to a directory from which additional
             plugins should be loaded.
@@ -442,11 +447,12 @@ class FullStackTest(unittest.TestCase, TestBot):
             Path to an additional plugin which should be loaded.
         :param loglevel: Logging verbosity. Expects one of the constants
             defined by the logging module.
+        :param extra_config: Piece of extra bot config in a dict.
         """
         if extra_plugin_dir is None and extra_test_file is not None:
             extra_plugin_dir = sep.join(abspath(extra_test_file).split(sep)[:-2])
 
-        TestBot.__init__(self, extra_plugin_dir=extra_plugin_dir, loglevel=loglevel)
+        TestBot.__init__(self, extra_plugin_dir=extra_plugin_dir, loglevel=loglevel, extra_config=extra_config)
         self.start()
 
     def tearDown(self):

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -61,6 +61,11 @@ BOT_EXTRA_PLUGIN_DIR = None
 # this is where you tell err where to find it.
 # BOT_EXTRA_BACKEND_DIR = '/opt/errbackends'
 
+# If you want only a subset of the core plugins that are bundled with errbot, you can specify them here.
+# CORE_PLUGINS = None # This is default, all core plugins.
+# For example CORE_PLUGINS = ('ACLs', 'Backup', 'Help') you get those names from the .plug files Name entry.
+# For absolutely no plug: CORE_PLUGINS = ()
+
 # Should plugin dependencies be installed automatically? If this is true
 # then Err will use pip to install any missing dependencies automatically.
 #

--- a/errbot/core_plugins/acls.plug
+++ b/errbot/core_plugins/acls.plug
@@ -1,6 +1,7 @@
 [Core]
 Name = ACLs
 Module = acls
+Core = True
 
 [Documentation]
 Description = This is checking commands for ACLs.

--- a/errbot/core_plugins/backup.plug
+++ b/errbot/core_plugins/backup.plug
@@ -1,6 +1,7 @@
 [Core]
 Name = Backup
 Module = backup
+Core = True
 
 [Documentation]
 Description = This core plugin manage import and export of data from Err.

--- a/errbot/core_plugins/chatRoom.plug
+++ b/errbot/core_plugins/chatRoom.plug
@@ -1,6 +1,7 @@
 [Core]
 Name = ChatRoom
 Module = chatRoom
+Core = True
 
 [Documentation]
 Description = This is a basic implementation of a chatroom

--- a/errbot/core_plugins/health.plug
+++ b/errbot/core_plugins/health.plug
@@ -1,6 +1,7 @@
 [Core]
 Name = Health
 Module = health
+Core = True
 
 [Documentation]
 Description = Core plugin for bot lifecycle and health related commands.

--- a/errbot/core_plugins/help.plug
+++ b/errbot/core_plugins/help.plug
@@ -1,6 +1,7 @@
 [Core]
 Name = Help
 Module = help
+Core = True
 
 [Documentation]
 Description = Core plugin of help related functions.

--- a/errbot/core_plugins/plugins.plug
+++ b/errbot/core_plugins/plugins.plug
@@ -1,6 +1,7 @@
 [Core]
 Name = Plugins
 Module = plugins
+Core = True
 
 [Documentation]
 Description = Commands to manage the plugins of the bot by chatting.

--- a/errbot/core_plugins/utils.plug
+++ b/errbot/core_plugins/utils.plug
@@ -1,6 +1,7 @@
 [Core]
 Name = Utils
 Module = utils
+Core = True
 
 [Documentation]
 Description = Core Errbot utils commands.

--- a/errbot/core_plugins/vcheck.plug
+++ b/errbot/core_plugins/vcheck.plug
@@ -1,6 +1,7 @@
 [Core]
 Name = VersionChecker
 Module = vcheck
+Core = True
 
 [Documentation]
 Description = This is calling home to check if err has a new version available

--- a/errbot/core_plugins/webserver.plug
+++ b/errbot/core_plugins/webserver.plug
@@ -1,6 +1,7 @@
 [Core]
 Name = Webserver
 Module = webserver
+Core = True
 
 [Documentation]
 Description = This is a plugin for enabling webhooks and web interface to err

--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -92,6 +92,23 @@ def check_dependencies(path):
         return 'You need to have setuptools installed for the dependency check of the plugins', []
 
 
+def check_enabled_core_plugin(name: str, config: ConfigParser, core_plugin_list) -> bool:
+    """ Checks if the given plugin is core and if it is, if it is part of the enabled core_plugins_list.
+
+    :param name: The plugin name
+    :param config: Its config
+    :param core_plugin_list: the list from CORE_PLUGINS in the config.
+    :return: True if it is OK to load this plugin.
+    """
+    try:
+        core = config.get("Core", "Core")
+        if core.lower() == 'true' and name not in core_plugin_list:
+            return False
+    except NoOptionError:
+        pass
+    return True
+
+
 def check_python_plug_section(name: str, config: ConfigParser) -> bool:
     """ Checks if we have the correct version to run this plugin.
     Returns true if the plugin is loadable """
@@ -200,6 +217,11 @@ class BotPluginManager(PluginManager, StoreMixin):
     def _init_plugin_manager(self, bot_config):
         self.plugin_dir = os.path.join(bot_config.BOT_DATA_DIR, PLUGINS_SUBDIR)
         self.open_storage(os.path.join(bot_config.BOT_DATA_DIR, 'core.db'))
+        if hasattr(bot_config, 'CORE_PLUGINS'):
+            self.core_plugins = bot_config.CORE_PLUGINS
+        else:
+            self.core_plugins = None
+
         # be sure we have a configs entry for the plugin configurations
         if self.CONFIGS not in self:
             self[self.CONFIGS] = {}
@@ -237,6 +259,11 @@ class BotPluginManager(PluginManager, StoreMixin):
         if pta_item is None:
             log.warning('Could not activate %s', name)
             return None
+
+        if self.core_plugins is not None:
+            if not check_enabled_core_plugin(name, pta_item.details, self.core_plugins):
+                log.warn('Core plugin "%s" has been skipped because it is not in CORE_PLUGINS in config.py.' % name)
+                return None
 
         if not check_python_plug_section(name, pta_item.details):
             log.error('%s failed python version check.', name)

--- a/tests/core_plugins_tests.py
+++ b/tests/core_plugins_tests.py
@@ -1,0 +1,29 @@
+import logging
+import os
+
+from errbot.backends.test import FullStackTest
+
+
+class TestCorePlugins(FullStackTest):
+    """
+    Tests the CORE_PLUGINS filter fromt the config file.
+    It only allows Help and Backup, this checks if the state is consistent with that.
+    """
+
+    def setUp(self, extra_plugin_dir=None, extra_test_file=None, loglevel=logging.DEBUG, extra_config=None):
+        super().setUp(extra_plugin_dir=os.path.join(os.path.dirname(os.path.realpath(__file__)), 'room_tests'),
+                      extra_test_file=extra_test_file,
+                      extra_config={'CORE_PLUGINS': ('Help', 'Utils')})
+        # we NEED utils otherwise the test locks at startup
+
+    def test_help_is_still_here(self):
+        self.assertCommand('!help', 'Available help')
+
+    def test_backup_help_not_here(self):
+        self.assertCommand('!help backup', 'That command is not defined.')
+
+    def test_backup_should_not_be_there(self):
+        self.assertCommand('!backup', 'Command "backup" not found.')
+
+    def test_echo_still_here(self):
+        self.assertCommand('!echo toto', 'toto')

--- a/tests/muc_tests.py
+++ b/tests/muc_tests.py
@@ -2,15 +2,14 @@ import os
 import errbot.backends.base
 from errbot.backends.test import FullStackTest, TestMUCOccupant
 import logging
-import unittest
 log = logging.getLogger(__name__)
 
 
 class TestMUC(FullStackTest):
 
     def setUp(self, extra_plugin_dir=None, extra_test_file=None, loglevel=logging.DEBUG):
-        super().setUp(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'room_tests'),
-                      extra_test_file)
+        super().setUp(extra_plugin_dir=os.path.join(os.path.dirname(os.path.realpath(__file__)), 'room_tests'),
+                      extra_test_file=extra_test_file)
 
     def test_plugin_methods(self):  # noqa
         p = self.bot.get_plugin_obj_by_name('ChatRoom')


### PR DESCRIPTION
Some bundled plugins are not useful for everybody and creates noise in
the Help system and potential security issues if they are not configured
correctly.

This adds a CORE_PLUGINS entry to the config.py so users can select the
set of core plugins they need at config time.

If it is None or unspecified, all the coreplugins are started.