### PR TITLE
Enforce storage key is a str

### DIFF
--- a/errbot/storage.py
+++ b/errbot/storage.py
@@ -69,4 +69,4 @@ class StoreMixin(MutableMapping):
             yield i
 
     def __contains__(self, x):
-        return x in self.shelf
+        return str(x) in self.shelf


### PR DESCRIPTION
In cases where a unicode key is provided, this was breaking