### PR TITLE
Fix !help formatting of plugin docstring

### DIFF
--- a/errbot/core_plugins/help.py
+++ b/errbot/core_plugins/help.py
@@ -86,9 +86,9 @@ class Help(BotPlugin):
 
             for cls in sorted(set(cls_commands), key=lambda c: c.__name__):
                 # shows class and description
-                usage += '#### {name}\n*{doc}*\n'.format(
+                usage += '\n**{name}**\n\n*{doc}*\n\n'.format(
                                            name=cls.__name__,
-                                           doc=cls.__errdoc__ or '',
+                                           doc=cls.__errdoc__.strip() or '',
                                        )
 
                 for (name, command) in cls_commands[cls]:
@@ -108,9 +108,9 @@ class Help(BotPlugin):
                 in self._bot.all_commands.items() if
                 get_name(get_class_that_defined_method(command)) == args]
 
-            description = '#### {name}\n*{doc}*\n'.format(
+            description = '\n**{name}**\n\n*{doc}*\n\n'.format(
                                        name=cls.__name__,
-                                       doc=cls.__errdoc__ or '',
+                                       doc=cls.__errdoc__.strip() or '',
                                    )
             pairs = sorted([
                 (name, command)


### PR DESCRIPTION
In some cases, the docstring has leading and/or ending spaces
and that could lead to broken formatting.

Fixes #592