### PR TITLE
Fix telegram shelf storage

### DIFF
--- a/errbot/backends/telegram.py
+++ b/errbot/backends/telegram.py
@@ -3,11 +3,7 @@ import sys
 
 from errbot.backends.base import RoomError, Identifier, MUCIdentifier, ONLINE
 from errbot.errBot import ErrBot
-from errbot.main import CORE_STORAGE
 from errbot.rendering import text
-from errbot.specific_plugin_manager import SpecificPluginManager
-from errbot.storage import StoreMixin
-from errbot.storage.base import StoragePluginBase
 
 
 # Can't use __name__ because of Yapsy
@@ -113,7 +109,7 @@ class TelegramMUCOccupant(MUCIdentifier, TelegramIdentifier):
     room = TelegramIdentifier.id
 
 
-class TelegramBackend(ErrBot, StoreMixin):
+class TelegramBackend(ErrBot):
     def __init__(self, config):
         super().__init__(config)
         config.MESSAGE_SIZE_LIMIT = TELEGRAM_MESSAGE_SIZE_LIMIT
@@ -130,18 +126,6 @@ class TelegramBackend(ErrBot, StoreMixin):
         self.telegram = None  # Will be initialized in serve_once
         self.bot_instance = None  # Will be set in serve_once
         self.md_converter = text()
-
-        # Initialize internal storage for the backend itself, which is
-        # needed for the bot to keep track of the getUpdates() offset.
-        # It is important for this storage to be local, not some shared DB
-        # otherwise two different instances will get conflicting offsets.
-        spm = SpecificPluginManager(config, 'storage', StoragePluginBase, CORE_STORAGE)
-        storage_plugin = spm.get_plugin_by_name('Shelf')
-        self.open_storage(storage_plugin, 'TelegramBackend')
-
-    def shutdown(self):
-        self.close_storage()
-        super().shutdown()
 
     def serve_once(self):
         log.info("Initializing connection")

--- a/errbot/main.py
+++ b/errbot/main.py
@@ -81,6 +81,7 @@ def setup_bot(backend_name, logger, config, restore=None):
         bot.attach_storage_plugin(storage_plugin)
         bot.attach_repo_manager(repo_manager)
         bot.attach_plugin_manager(botpm)
+        bot.initialize_backend_storage()
     except Exception:
         log.exception("Unable to load or configure the backend.")
         exit(-1)


### PR DESCRIPTION
With the storage backend changes, backend plugins no longer have a shelf by default. Telegram needs this to store the offset for getUpdates() calls, so we let it initialize some storage specifically.

Without this, Telegram on master is broken and refuses to start at all.