### PR TITLE
Support globbing on BOT_ADMINS and ACCESS_CONTROLS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-v3.2.0 (unreleased)
+v9.9.9 (unreleased)
 -------------------
 
 features:
@@ -9,6 +9,7 @@ features:
 - Various improvements to the ``@arg_botcmd`` decorator.
 - Now the bot can set its own status/presence with change_presence
 - Non-standard hipchat server (thx Barak Schiller)
+- Support unix-style globbing in `BOT_ADMINS` and `ACCESS_CONTROLS`
 
 bugs:
 

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -162,6 +162,8 @@ BOT_IDENTITY = {
 # Set the admins of your bot. Only these users will have access
 # to the admin-only commands.
 #
+# Unix-style glob patterns are supported, so 'gbin@localhost'
+# would be considered an admin if setting '*@localhost'.
 BOT_ADMINS = ('gbin@localhost',)
 
 # Chatrooms your bot should join on startup. For the IRC backend you
@@ -231,10 +233,14 @@ BOT_PREFIX = '!'
 # Rules listed in ACCESS_CONTROLS_DEFAULT are applied when a command cannot
 # be found inside ACCESS_CONTROLS
 #
+# The options allowusers, denyusers, allowrooms and denyrooms support
+# unix-style globbing similar to BOT_ADMINS.
+#
 # Example:
+#
 #ACCESS_CONTROLS_DEFAULT = {} # Allow everyone access by default
 #ACCESS_CONTROLS = {'status': {'allowrooms': ('someroom@conference.localhost',)},
-#                   'about': {'denyusers': ('baduser@localhost',), 'allowrooms': ('room1@conference.localhost', 'room2@conference.localhost')},
+#                   'about': {'denyusers': ('*@evilhost',), 'allowrooms': ('room1@conference.localhost', 'room2@conference.localhost')},
 #                   'uptime': {'allowusers': BOT_ADMINS},
 #                   'help': {'allowmuc': False},
 #                  }


### PR DESCRIPTION
Title says it all. See modified tests for examples.

Regarding the changelog: I put this in to ensure its not forgotten when a new release is made, and set the version to 9.9.9 because 3.2.0 has already been released. Some of those items are incorrect though (already in 3.2.0) so we'll have to doublecheck the changelog when making a release.

Maybe merge this file with the one from the 3.2 branch?