### PR TITLE
Flexible ACL patterns for IRC

### DIFF
--- a/docs/user_guide/configuration/irc.rst
+++ b/docs/user_guide/configuration/irc.rst
@@ -37,7 +37,12 @@ Bot admins
 ----------
 
 You can set `BOT_ADMINS` to configure which IRC users are bot administrators.
-For example: `BOT_ADMINS = ('gbin', 'zoni')`
+For example: `BOT_ADMINS = ('gbin!gbin@*', '*!*@trusted.host.com')`
+
+.. note::
+
+    The default syntax for users on IRC is `{nick}!{user}@{host}` but this can
+    be changed by adjusting the `IRC_ACL_PATTERN` setting.
 
 
 Channels

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -327,6 +327,15 @@ REVERSE_CHATROOM_RELAY = {}
                             # reconnect
 #IRC_RECONNECT_ON_DISCONNECT = 5  # Reconnect back to a channel after a disconenction (in seconds)
 
+# The pattern to build a user representation from for ACL matches.
+# The default is "{nick}!{user}@{host}" which results in "zoni!zoni@ams1.groenen.me"
+# for the user zoni connecting from ams1.groenen.me.
+# Available substitution variables:
+#   {nick}  ->  The nickname of the user
+#   {user}  ->  The username of the user
+#   {host}  ->  The hostname the user is connecting from
+#IRC_ACL_PATTERN = "{nick}!{user}@{host}"
+
 # Allow messages sent in a chatroom to be directed at requester.
 #GROUPCHAT_NICK_PREFIXED = False
 


### PR DESCRIPTION
This change makes it possible to configure how ACLs should be matched on
IRC. It allows for full, traditional IRC `nick!user@host` style matches
(now the default*), the 3.2 behavior of `user@host` and the old behavior
of `nick` only, all configurable by the user.

* Reasoning for making the default `nick!user@host`:

  With 3.2 the default changed to user@host, but this is in my opinion a
  very bad default. Most IRC networks support nickname registration
  and enforcement through NickServ, but registering usernames is much
  less common so it is very easy for people to connect with any username
  they like.

  Additionally, the `nick!user@host` format is what you will find in
  most IRC software so most experienced IRC users would more likely
  expect this format over `user@host` alone.