### PR TITLE
documentation update: sphinx should correctly split parameters

### DIFF
--- a/errbot/botplugin.py
+++ b/errbot/botplugin.py
@@ -47,7 +47,7 @@ class BotPluginBase(StoreMixin):
     def bot_config(self) -> ModuleType:
         """
         Get the bot configuration from config.py.
-        For exemple you can access:
+        For example you can access:
         self.bot_config.BOT_DATA_DIR
         """
         # if BOT_ADMINS is just an unique string make it a tuple for backwards
@@ -219,6 +219,7 @@ class BotPlugin(BotPluginBase):
            same type of first element of the template (no mix typed is supported)
 
         In case of validation error it should raise a errbot.utils.ValidationException
+
         :param configuration: the configuration to be checked.
         """
         recurse_check_structure(self.get_configuration_template(), configuration)  # default behavior
@@ -231,6 +232,7 @@ class BotPlugin(BotPluginBase):
 
         This method will be called before activation so don't expect to be activated
         at that point.
+
         :param configuration: injected configuration for the plugin.
         """
         self.config = configuration
@@ -303,6 +305,7 @@ class BotPlugin(BotPluginBase):
             You can block this call until you are done with the stream.
             To signal that you accept / reject the file, simply call stream.accept()
             or stream.reject() and return.
+
             :param stream:
                 the incoming stream request.
         """
@@ -370,6 +373,7 @@ class BotPlugin(BotPluginBase):
         """
             Sends asynchronously a message to a room or a user.
              if it is a room message_type needs to by 'groupchat' and user the room.
+
              :param groupchat_nick_reply: if True it will mention the user in the chatroom.
              :param message_type: 'chat' or 'groupchat'
              :param in_reply_to: optionally, the original message this message is the answer to.
@@ -399,6 +403,7 @@ class BotPlugin(BotPluginBase):
             Sends asynchronously a message to a room or a user.
             Same as send but passing a template name and parameters instead of directly the markdown text.
              if it is a room message_type needs to by 'groupchat' and user the room.
+
              :param template_parameters: arguments for the template.
              :param template_name: name of the template to use.
              :param groupchat_nick_reply: if True it will mention the user in the chatroom.
@@ -414,6 +419,7 @@ class BotPlugin(BotPluginBase):
         """
            Transform a textual representation of a user or room identifier to the correct
            Identifier object you can set in Message.to and Message.frm.
+
            :param txtrep: the textual representation of the identifier (it is backend dependent).
         """
         return self._bot.build_identifier(txtrep)
@@ -426,6 +432,7 @@ class BotPlugin(BotPluginBase):
                             stream_type: str=None):
         """
             Sends asynchronously a stream/file to a user.
+
             :param user: is the identifier of the person you want to send it to.
             :param fsource: is a file object you want to send.
             :param name: is an optional filename for it.
@@ -480,6 +487,7 @@ class BotPlugin(BotPluginBase):
             Also, you can program
             for example : self.program_poller(self, 30, fetch_stuff)
             where you have def fetch_stuff(self) in your plugin
+
             :param kwargs: kwargs for the method to callback.
             :param args: args for the method to callback.
             :param method: method to callback.
@@ -497,6 +505,7 @@ class BotPlugin(BotPluginBase):
 
             If the method equals None -> it stops all the pollers
             you need to regive the same parameters as the original start_poller to match a specific poller to stop
+
             :param kwargs: The initial kwargs you gave to start_poller.
             :param args: The initial args you gave to start_poller.
             :param method: The initial method you passed to start_poller.
@@ -519,6 +528,7 @@ class ArgParserBase(object):
 
         If splitting fails for any reason it should return an exception
         of some kind.
+
         :param args: string to parse
         """
         raise NotImplementedError()

--- a/errbot/errBot.py
+++ b/errbot/errBot.py
@@ -137,6 +137,7 @@ class ErrBot(Backend, StoreMixin):
 
     def send(self, user, text, in_reply_to=None, message_type='chat', groupchat_nick_reply=False):
         """ Sends a simple message to the specified user.
+
             :param user:
                 an identifier from build_identifier or from an incoming message
             :param in_reply_to:
@@ -172,6 +173,7 @@ class ErrBot(Backend, StoreMixin):
     def send_templated(self, user, template_name, template_parameters, in_reply_to=None, message_type='chat',
                        groupchat_nick_reply=False):
         """ Sends a simple message to the specified user using a template.
+
             :param template_parameters: the parameters for the template.
             :param template_name: the template name you want to use.
             :param user:
@@ -195,6 +197,7 @@ class ErrBot(Backend, StoreMixin):
     def send_message(self, mess):
         """
         This needs to be overridden by the backends with a super() call.
+
         :param mess: the message to send.
         :return: None
         """
@@ -207,6 +210,7 @@ class ErrBot(Backend, StoreMixin):
 
     def send_simple_reply(self, mess, text, private=False):
         """Send a simple response to a given incoming message
+
         :param private: if True will force a response in private.
         :param text: the markdown text of the message.
         :param mess: the message you are replying to.
@@ -216,6 +220,7 @@ class ErrBot(Backend, StoreMixin):
     def process_message(self, mess):
         """Check if the given message is a command for the bot and act on it.
         It return True for triggering the callback_messages on the .callback_messages on the plugins.
+
         :param mess: the incoming message.
         """
         # Prepare to handle either private chats or group chats

--- a/errbot/utils.py
+++ b/errbot/utils.py
@@ -256,6 +256,7 @@ def rate_limited(min_interval):
 
 def split_string_after(str_, n):
     """Yield chunks of length `n` from the given string
+
     :param n: length of the chunks.
     :param str_: the given string.
     """
@@ -267,6 +268,7 @@ def repeatfunc(func, times=None, *args):  # from the itertools receipes
     """Repeat calls to func with specified arguments.
 
     Example:  repeatfunc(random.random)
+
     :param args: params to the function to call.
     :param times: number of times to repeat.
     :param func:  the function to repeatedly call.
@@ -278,6 +280,7 @@ def repeatfunc(func, times=None, *args):  # from the itertools receipes
 
 def find_roots(path, file_sig='*.plug'):
     """Collects all the paths from path recursively that contains files of type `file_sig`.
+
        :param path:
             a base path to walk from
        :param file_sig:
@@ -301,6 +304,7 @@ def find_roots(path, file_sig='*.plug'):
 
 def find_roots_with_extra(base, extra, file_sig='*.plug'):
     """Collects all the paths from path recursively that contains files of type `file_sig`.
+
        :param base:
             a base path to walk from
        :param extra:
@@ -330,6 +334,7 @@ def get_class_that_defined_method(meth):
 def compat_str(s):
     """ Detect if s is a string and convert it to unicode if it is a byte or
         py2 string
+
         :param s: the string to ensure compatibility from."""
     if isinstance(s, str):
         return s


### PR DESCRIPTION
See for example http://errbot.io/errbot.html?highlight=send#errbot.BotPlugin.send_stream_request
The parameter description is mixed in with the description of the method itself.