### PR TITLE
Adding exception catches for files not existing.

### DIFF
--- a/tools/plugin-gen.py
+++ b/tools/plugin-gen.py
@@ -16,7 +16,7 @@ log.setLevel(logging.DEBUG)
 DEFAULT_AVATAR = 'https://upload.wikimedia.org/wikipedia/commons/5/5f/Err-logo.png'
 
 try:
-    user,token = open('token', 'r').read().strip().split(':')
+    user, token = open('token', 'r').read().strip().split(':')
     # token is generated from the personal tokens in github.
     AUTH = HTTPBasicAuth(user, token)
 except FileNotFoundError:
@@ -32,8 +32,9 @@ try:
     with open('user_cache', 'r') as f:
         user_cache = eval(f.read())
 except FileNotFoundError:
-    #File doesn't exist, so we continue on
-    log.info("No user cache existing, will be generating it for the first time.")
+    # File doesn't exist, so we continue on
+    log.info("No user cache existing, will be generating it for the " +
+             "first time.")
 
 
 def add_blacklisted(repo):

--- a/tools/plugin-gen.py
+++ b/tools/plugin-gen.py
@@ -21,9 +21,9 @@ try:
     AUTH = HTTPBasicAuth(user, token)
 except FileNotFoundError:
     log.fatal("No token found, cannot access the GitHub API")
-    sys.exit(-1)
 except ValueError:
     log.fatal("Token file cannot be properly read, should be of the form username:token")
+finally:
     sys.exit(-1)
 
 user_cache = {}

--- a/tools/plugin-gen.py
+++ b/tools/plugin-gen.py
@@ -15,13 +15,21 @@ log.setLevel(logging.DEBUG)
 
 DEFAULT_AVATAR = 'https://upload.wikimedia.org/wikipedia/commons/5/5f/Err-logo.png'
 
-# token is generated from the personal tokens in github.
-AUTH = HTTPBasicAuth('gbin', open('token', 'r').read().strip())
+try:
+    # token is generated from the personal tokens in github.
+    AUTH = HTTPBasicAuth('gbin', open('token', 'r').read().strip())
+except FileNotFoundError:
+    log.fatal("No token found, cannot access the GitHub API")
+    sys.exit(-1)
 
 user_cache = {}
 
-with open('user_cache', 'r') as f:
-    user_cache = eval(f.read())
+try:
+    with open('user_cache', 'r') as f:
+        user_cache = eval(f.read())
+except FileNotFoundError:
+    #File doesn't exist, so we continue on
+    log.info("No user cache existing, will be generating it for the first time.")
 
 
 def add_blacklisted(repo):
@@ -36,8 +44,12 @@ def save_plugins():
     with open('repos.json', 'w') as f:
         f.write(json.dumps(plugins))
 
-with open('blacklisted.txt', 'r') as f:
-    BLACKLISTED = [line.strip() for line in f.readlines()]
+BLACKLISTED = []
+try:
+    with open('blacklisted.txt', 'r') as f:
+        BLACKLISTED = [line.strip() for line in f.readlines()]
+except FileNotFoundError:
+    log.info("No blacklisted.txt found, no plugins will be blacklisted.")
 
 
 def get_avatar_url(repo):

--- a/tools/plugin-gen.py
+++ b/tools/plugin-gen.py
@@ -16,10 +16,14 @@ log.setLevel(logging.DEBUG)
 DEFAULT_AVATAR = 'https://upload.wikimedia.org/wikipedia/commons/5/5f/Err-logo.png'
 
 try:
+    user,token = open('token', 'r').read().strip().split(':')
     # token is generated from the personal tokens in github.
-    AUTH = HTTPBasicAuth('gbin', open('token', 'r').read().strip())
+    AUTH = HTTPBasicAuth(user, token)
 except FileNotFoundError:
     log.fatal("No token found, cannot access the GitHub API")
+    sys.exit(-1)
+except ValueError:
+    log.fatal("Token file cannot be properly read, should be of the form username:token")
     sys.exit(-1)
 
 user_cache = {}


### PR DESCRIPTION
This safely bypasses if the user_cache or blacklist doesn't exist, but the GitHub API token must exist.