### PR TITLE
Mark commands_tests as flaky

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ if not PY35_OR_GREATER:
 deps += ['mock',
          'nose',
          'pep8',
+         'flaky',
          # Order matters here, pytest must come last. See also:
          #   https://github.com/errbotio/errbot/pull/496
          #   https://bitbucket.org/pypa/setuptools/issues/196/tests_require-pytest-pytest-cov-breaks

--- a/tests/commands_tests.py
+++ b/tests/commands_tests.py
@@ -1,16 +1,14 @@
 # coding=utf-8
-from queue import Empty
 import re
 import logging
-
+from errbot.backends.test import FullStackTest
+from flaky import flaky
 from os import path, mkdir
+from queue import Empty
 from shutil import rmtree
 
-import pytest
 
-from errbot.backends.test import FullStackTest
-
-
+@flaky
 class TestCommands(FullStackTest):
 
     def setUp(self, *args, **kwargs):


### PR DESCRIPTION
This will retry any failed test in tests/commands_tests.py once before
giving up and marking it as having failed. This should drastically cut
down on the number of falsely failed tests.

See #603