### PR TITLE
Rework shutdown and restart logic

### DIFF
--- a/errbot/err.py
+++ b/errbot/err.py
@@ -15,6 +15,7 @@
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 import inspect
+import os
 import sys
 import logging
 import argparse
@@ -248,7 +249,7 @@ def main():
                 from errbot.main import main
                 main(backend, logger, config)
 
-            daemon = Daemonize(app="err", pid=pid, action=action)
+            daemon = Daemonize(app="err", pid=pid, action=action, chdir=os.getcwd())
             daemon.start()
         except Exception:
             log.exception('Failed to daemonize the process')


### PR DESCRIPTION
* This fixes #647, because with `--daemonize` the bot couldn't find its
  `config.py` on restart.
* This fixes shutdown, which was keeping the bot hanging but with storage
  and plugins shut down. It also greatly simplifies the shutdown logic.
* It provides a `--kill` flag to instantly kill the bot with a SIGKILL.
* It renames `killbot` to `shutdown` to more accurately reflect what it
  does and be consistent with the `!restart` naming.