### PR TITLE
Allow ACLs on entire plugins and wildcard commands

### DIFF
--- a/errbot/__init__.py
+++ b/errbot/__init__.py
@@ -376,8 +376,9 @@ def cmdfilter(*args, **kwargs):
 
     This decorator should be applied to methods of :class:`~errbot.botplugin.BotPlugin`
     classes to turn them into command filters.
-    Those filters are executed just before the execution.
-    It gives a mean to add transversal features like security, logging, audit etc.
+
+    These filters are executed just before the execution of a command and provide
+    the means to add features such as custom security, logging, auditing, etc.
 
     These methods are expected to have a signature and a return a tuple like the following::
 

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -248,6 +248,16 @@ BOT_PREFIX = '!'
 # The options allowusers, denyusers, allowrooms and denyrooms support
 # unix-style globbing similar to BOT_ADMINS.
 #
+# Command names also support unix-style globs and can optionally be restricted
+# to a specific plugin by prefixing the command with the name of a plugin,
+# separated by a colon. For example, `Health:status` will match the `!status`
+# command of the `Health` plugin and `Health:*` will match all commands defined
+# by the `Health` plugin.
+#
+# Please note that the first command match found will be used so if you have
+# overlapping patterns you must used an OrderedDict instead of a regular dict:
+# https://docs.python.org/3.4/library/collections.html#collections.OrderedDict
+#
 # Example:
 #
 #ACCESS_CONTROLS_DEFAULT = {} # Allow everyone access by default
@@ -255,6 +265,8 @@ BOT_PREFIX = '!'
 #                   'about': {'denyusers': ('*@evilhost',), 'allowrooms': ('room1@conference.localhost', 'room2@conference.localhost')},
 #                   'uptime': {'allowusers': BOT_ADMINS},
 #                   'help': {'allowmuc': False},
+#                   'help': {'allowmuc': False},
+#                   'ChatRoom:*': {'allowusers': BOT_ADMINS},
 #                  }
 
 # Uncomment and set this to True to hide the restricted commands from

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -242,8 +242,8 @@ BOT_PREFIX = '!'
 #   denyrooms: Deny command in these rooms
 #   allowprivate: Allow command from direct messages to the bot
 #   allowmuc: Allow command inside rooms
-# Rules listed in ACCESS_CONTROLS_DEFAULT are applied when a command cannot
-# be found inside ACCESS_CONTROLS
+# Rules listed in ACCESS_CONTROLS_DEFAULT are applied by default and merged
+# with any commands found in ACCESS_CONTROLS.
 #
 # The options allowusers, denyusers, allowrooms and denyrooms support
 # unix-style globbing similar to BOT_ADMINS.

--- a/tests/base_backend_tests.py
+++ b/tests/base_backend_tests.py
@@ -562,6 +562,18 @@ class BotCmds(unittest.TestCase):
             ),
             dict(
                     message=self.makemessage("!command"),
+                    acl={'command': {'allowprivate': False}},
+                    acl_default={'allowmuc': False, 'allowprivate': True},
+                    expected_response="You're not allowed to access this command via private message to me"
+            ),
+            dict(
+                    message=self.makemessage("!command"),
+                    acl={'command': {'allowmuc': True}},
+                    acl_default={'allowmuc': True, 'allowprivate': False},
+                    expected_response="You're not allowed to access this command via private message to me"
+            ),
+            dict(
+                    message=self.makemessage("!command"),
                     acl={'command': {'allowprivate': True}},
                     acl_default={'allowmuc': False, 'allowprivate': False},
                     expected_response="Regular command"


### PR DESCRIPTION
This modifies ACLs in three ways.

1. Wildcards are now supported, so `status*` will match `!status` as
well as `!status_plugins`, etc.

2. ACLs can include the plugin name by placing it in front of the
command, separated by a colon (`:`). For example, `Health:status` will
match the `!status` command of the `Health` plugin and `Health:*` will
match all commands defined by the `Health` plugin.

3. This ensures that all the settings defined in ACCESS_CONTROLS_DEFAULT
are applied to each command listed in ACCESS_CONTROLS. If a certain
command wants to override the default set in ACCESS_CONTROLS_DEFAULT,
it must be explicitly set up.

    This is more natural and more intuitive, removing the need to specify
the default for every single command where you define other rules.

Closes #442.