### PR TITLE
Allow bot configuration from groupchat

### DIFF
--- a/errbot/backends/test.py
+++ b/errbot/backends/test.py
@@ -96,7 +96,7 @@ class TestOccupant(TestPerson, RoomOccupant):
         return self._room
 
     def __unicode__(self):
-        return self._person + '@' + self._room
+        return self._person + '@' + str(self._room)
 
     __str__ = __unicode__
 

--- a/errbot/core_plugins/acls.py
+++ b/errbot/core_plugins/acls.py
@@ -93,23 +93,13 @@ class ACLS(BotPlugin):
                     dry_run
             )
 
-        return msg, cmd, args
-
-    @cmdfilter
-    def admin(self, msg, cmd, args, dry_run):
-        """
-        Check command against the is_admin criteria.
-
-        :param msg: The original message the commands is coming from.
-        :param cmd: The command name
-        :param args: Its arguments.
-        :param dry_run: pass True to not act on the check (messages / deferred auth etc.)
-
-        """
         self.log.info("Check if %s is admin only command." % cmd)
-        f = self._bot.all_commands[cmd]
-
-        if f._err_command_admin_only and not glob(get_acl_usr(msg), self.bot_config.BOT_ADMINS):
-            return self.access_denied(msg, "This command requires bot-admin privileges", dry_run)
+        if f._err_command_admin_only:
+            if not glob(get_acl_usr(msg), self.bot_config.BOT_ADMINS):
+                return self.access_denied(msg, "This command requires bot-admin privileges", dry_run)
+            # For security reasons, admin-only commands are direct-message only UNLESS
+            # specifically overridden by setting allowmuc to True for such commands.
+            if msg.is_group and not acl.get("allowmuc", False):
+                return self.access_denied(msg, "This command may only be issued through a direct message", dry_run)
 
         return msg, cmd, args

--- a/errbot/core_plugins/acls.py
+++ b/errbot/core_plugins/acls.py
@@ -109,13 +109,7 @@ class ACLS(BotPlugin):
         self.log.info("Check if %s is admin only command." % cmd)
         f = self._bot.all_commands[cmd]
 
-        if f._err_command_admin_only:
-            if msg.is_group:
-                return self.access_denied(
-                        msg,
-                        "You cannot administer the bot from a chatroom, message the bot directly", dry_run)
-
-            if not glob(get_acl_usr(msg), self.bot_config.BOT_ADMINS):
-                return self.access_denied(msg, "This command requires bot-admin privileges", dry_run)
+        if f._err_command_admin_only and not glob(get_acl_usr(msg), self.bot_config.BOT_ADMINS):
+            return self.access_denied(msg, "This command requires bot-admin privileges", dry_run)
 
         return msg, cmd, args

--- a/tests/base_backend_tests.py
+++ b/tests/base_backend_tests.py
@@ -514,6 +514,7 @@ class BotCmds(unittest.TestCase):
         self.assertEquals("%s %s" % (first_name, last_name), self.dummy.pop_message().body)
 
     def test_access_controls(self):
+        testroom = TestRoom("room", bot=self.dummy)
         tests = [
             # BOT_ADMINS scenarios
             dict(
@@ -529,6 +530,24 @@ class BotCmds(unittest.TestCase):
             dict(
                 message=self.makemessage("!admin_command"),
                 bot_admins=('*err'),
+                expected_response="Admin command",
+            ),
+
+            # admin_only commands SHOULD be private-message only by default
+            dict(
+                message=self.makemessage("!admin_command",
+                                         from_=TestOccupant('noterr', room=testroom),
+                                         to=testroom),
+                bot_admins=('noterr'),
+                expected_response="This command may only be issued through a direct message",
+            ),
+            # But MAY be sent via groupchat IF 'allowmuc' is specifically set to True.
+            dict(
+                message=self.makemessage("!admin_command",
+                                         from_=TestOccupant('noterr', room=testroom),
+                                         to=testroom),
+                bot_admins=('noterr'),
+                acl={'admin_command': {'allowmuc': True}},
                 expected_response="Admin command",
             ),
 


### PR DESCRIPTION
I've always been annoyed how the bot forces me to send `admin_only` commands via a direct message, because I'm often in restricted, private channels with just the bot alone.

I think it should be up to end-users to decide whether they want to be able to issue admin_only commands in rooms as well, or whether they should be forced through a private message. Our ACLs make this really easy to configure now if this is desired so there's no reason for us to force this on users with no way to turn it off.