### PR TITLE
Add a "new plugin wizard" to errbot

### DIFF
--- a/errbot/err.py
+++ b/errbot/err.py
@@ -21,6 +21,7 @@ import logging
 import argparse
 from os import path, sep, getcwd, access, W_OK
 from platform import system
+from .plugin_wizard import new_plugin_wizard
 from .version import VERSION
 
 PY3 = sys.version_info[0] == 3
@@ -161,6 +162,8 @@ def main():
     mode_selection.add_argument('-r', '--restore', nargs='?', default=None, const='default',
                                 help='restore a bot from backup.py (default: backup.py from the bot data directory)')
     mode_selection.add_argument('-l', '--list', action='store_true', help='list all available backends')
+    mode_selection.add_argument('--new-plugin', nargs='?', default=None, const='current_dir',
+                                help='create a new plugin in the specified directory')
     mode_selection.add_argument('-T', '--text', dest="backend", action='store_const', const="Text",
                                 help='force local text backend')
     mode_selection.add_argument('-G', '--graphic', dest="backend", action='store_const', const="Graphic",
@@ -173,6 +176,19 @@ def main():
                                   help='Specify the pid file for the daemon (default: current bot data directory)')
 
     args = vars(parser.parse_args())  # create a dictionary of args
+
+    # This must come BEFORE the config is loaded below, to avoid printing
+    # logs as a side effect of config loading.
+    if args['new_plugin']:
+        directory = os.getcwd() if args['new_plugin'] == "current_dir" else args['new_plugin']
+        logging.getLogger('').setLevel(level=1000)  # Avoid logging stuff
+        try:
+            new_plugin_wizard(directory)
+        except KeyboardInterrupt:
+            sys.exit(1)
+        finally:
+            sys.exit(0)
+
     config_path = args['config']
     # setup the environment to be able to import the config.py
     if config_path:

--- a/errbot/err.py
+++ b/errbot/err.py
@@ -181,7 +181,8 @@ def main():
     # logs as a side effect of config loading.
     if args['new_plugin']:
         directory = os.getcwd() if args['new_plugin'] == "current_dir" else args['new_plugin']
-        logging.getLogger('').setLevel(level=1000)  # Avoid logging stuff
+        for handler in logging.getLogger().handlers:
+            logger.removeHandler(handler)
         try:
             new_plugin_wizard(directory)
         except KeyboardInterrupt:

--- a/errbot/err.py
+++ b/errbot/err.py
@@ -187,6 +187,9 @@ def main():
             new_plugin_wizard(directory)
         except KeyboardInterrupt:
             sys.exit(1)
+        except Exception as e:
+            sys.stderr.write(str(e) + "\n")
+            sys.exit(1)
         finally:
             sys.exit(0)
 

--- a/errbot/plugin_wizard.py
+++ b/errbot/plugin_wizard.py
@@ -39,10 +39,17 @@ def new_plugin_wizard(directory=None):
     description = ask(
         "What may I use as a short (one-line) description of your plugin?"
     )
+    if PY2:
+        default_python_version = "2+"
+    else:
+        default_python_version = "3"
     python_version = ask(
-        "Which python version will your plugin work with? 2, 2+ or 3?",
-        valid_responses=['2', '2+', '3']
+        "Which python version will your plugin work with? 2, 2+ or 3? I will default to "
+        "{version} if you leave this blank.".format(version=default_python_version),
+        valid_responses=['2', '2+', '3', '']
     )
+    if python_version.strip() == "":
+        python_version = default_python_version
     errbot_min_version = ask(
         "Which minimum version of errbot will your plugin work with? "
         "Leave blank to support any version or input CURRENT to select the "

--- a/errbot/plugin_wizard.py
+++ b/errbot/plugin_wizard.py
@@ -24,8 +24,8 @@ def new_plugin_wizard(directory=None):
     else:
         print("This wizard will create a new plugin for you in '%s'." % directory)
 
-    if not os.path.isdir(directory):
-        print("Error: The path '%s' does not exist or is not a directory." % directory)
+    if os.path.exists(directory) and not os.path.isdir(directory):
+        print("Error: The path '%s' exists but it isn't a directory" % directory)
         sys.exit(1)
 
     name = ask(
@@ -82,12 +82,12 @@ def new_plugin_wizard(directory=None):
     if errbot_max_version != "":
         plug["Errbot"]["Max"] = errbot_max_version
 
-    plugin_path = os.path.join(directory, "errbot-%s" % directory_name)
+    plugin_path = directory
     plugfile_path = os.path.join(plugin_path, module_name+".plug")
     pyfile_path = os.path.join(plugin_path, module_name+".py")
 
     try:
-        os.mkdir(plugin_path, mode=0o700)
+        os.makedirs(plugin_path, mode=0o700)
     except IOError as e:
         if e.errno != errno.EEXIST:
             raise
@@ -110,7 +110,7 @@ def new_plugin_wizard(directory=None):
     with open(pyfile_path, 'w') as f:
         f.write(render_plugin(locals()))
 
-    print("Success! You'll find your new plugin inside '%s'" % plugin_path)
+    print("Success! You'll find your new plugin at '%s'" % plugfile_path)
     print("(Don't forget to include a LICENSE file if you are going to publish your plugin)")
 
 

--- a/errbot/plugin_wizard.py
+++ b/errbot/plugin_wizard.py
@@ -7,6 +7,7 @@ import re
 import sys
 
 from errbot import PY2
+from errbot.version import VERSION
 
 if PY2:
     input = raw_input
@@ -41,11 +42,19 @@ def new_plugin_wizard(directory=None):
         valid_responses=['2', '2+', '3']
     )
     errbot_min_version = ask(
-        "Which minimum version of errbot will your plugin work with? Leave blank to support any version"
+        "Which minimum version of errbot will your plugin work with? "
+        "Leave blank to support any version or input CURRENT to select the "
+        "current version (%s)" % VERSION
     ).strip()
+    if errbot_min_version.upper() == "CURRENT":
+        errbot_min_version = VERSION
     errbot_max_version = ask(
-        "Which maximum version of errbot will your plugin work with? Leave blank to support any version"
+        "Which maximum version of errbot will your plugin work with? "
+        "Leave blank to support any version or input CURRENT to select the "
+        "current version (%s)" % VERSION
     ).strip()
+    if errbot_max_version.upper() == "CURRENT":
+        errbot_max_version = VERSION
 
     plug = configparser.ConfigParser()
     plug["Core"] = {

--- a/errbot/plugin_wizard.py
+++ b/errbot/plugin_wizard.py
@@ -129,6 +129,7 @@ def render_plugin(values):
     env = jinja2.Environment(
         loader=jinja2.FileSystemLoader(os.path.join(os.path.dirname(__file__), 'templates')),
         auto_reload=False,
+        keep_trailing_newline=True,
     )
     template = env.get_template("new_plugin_template.py")
     return template.render(**values)

--- a/errbot/plugin_wizard.py
+++ b/errbot/plugin_wizard.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python
+
+import configparser
+import os
+import re
+import requests
+import sys
+
+from errbot import PY2
+
+if PY2:
+    input = raw_input
+
+
+def new_plugin_wizard(directory=None):
+    """
+    Start the wizard to create a new plugin in the current working directory.
+    """
+    if directory is None:
+        print("This wizard will create a new plugin for you in the current directory.")
+        directory = os.getcwd()
+    else:
+        print("This wizard will create a new plugin for you in '%s'." % directory)
+
+    if not os.path.isdir(directory):
+        print("Error: The path '%s' does not exist or is not a directory." % directory)
+        sys.exit(1)
+
+    try:
+        plugin_code = download_plugin_skeleton()
+    except requests.HTTPError as e:
+        print(
+            "Error: I couldn't download the plugin skeleton from GitHub "
+            "which is needed to write out a new plugin file for you."
+        )
+        print("Details: {!s}".format(e))
+        sys.exit(1)
+
+    name = ask(
+        "What should the name of your new plugin be?",
+        validation_regex=r'^[a-zA-Z][a-zA-Z0-9 _-]*$'
+    ).strip()
+    module_name = name.lower().replace(' ', '_')
+    class_name = "".join([s.capitalize() for s in name.lower().split(' ')])
+
+    description = ask(
+        "What may I use as a short (one-line) description of your plugin?"
+    )
+    python_version = ask(
+        "Which python version will your plugin work with? 2, 2+ or 3?",
+        valid_responses=['2', '2+', '3']
+    )
+    errbot_min_version = ask(
+        "Which minimum version of errbot will your plugin work with? Leave blank to support any version"
+    ).strip()
+    errbot_max_version = ask(
+        "Which maximum version of errbot will your plugin work with? Leave blank to support any version"
+    ).strip()
+
+    plug = configparser.ConfigParser()
+    plug["Core"] = {
+        "Name": name,
+        "Module": module_name,
+    }
+    plug["Documentation"] = {
+        "Description": description,
+    }
+    plug["Python"] = {
+        "Version": python_version,
+    }
+    plug["Errbot"] = {}
+    if errbot_min_version != "":
+        plug["Errbot"]["Min"] = errbot_min_version
+    if errbot_max_version != "":
+        plug["Errbot"]["Max"] = errbot_max_version
+
+    plug_path = os.path.join(directory, module_name+".plug")
+    py_path = os.path.join(directory, module_name+".py")
+    if os.path.exists(plug_path) or os.path.exists(py_path):
+        print(
+            "Warning: A plugin with this name was already found at {path}\n"
+            "If you continue, these will be overwritten.".format(
+                path=os.path.join(directory, module_name+".{py,plug}")
+            )
+        )
+        ask(
+            "Press Ctrl+C to abort now or type in 'overwrite' to confirm overwriting of these files.",
+            valid_responses=["overwrite"],
+        )
+
+    with open(plug_path, 'w') as f:
+        plug.write(f)
+
+    plugin_code = plugin_code.replace("class Skeleton(", "class %s(" % class_name)
+    plugin_code = plugin_code.replace("Fill in your plugin description here.", description)
+
+    with open(py_path, 'w') as f:
+        f.write(plugin_code)
+
+    print("Success! You'll find your new plugin at '%s'" % py_path)
+
+
+def ask(question, valid_responses=None, validation_regex=None):
+    """
+    Ask the user for some input. If valid_responses is supplied, the user
+    must respond with something present in this list.
+    """
+    response = None
+    print(question)
+    while True:
+        response = input("> ")
+        if valid_responses is not None:
+            assert isinstance(valid_responses, list)
+            if response in valid_responses:
+                break
+            else:
+                print("Bad input: Please answer one of: %s" % ", ".join(valid_responses))
+        elif validation_regex is not None:
+            m = re.search(validation_regex, response)
+            if m is None:
+                print("Bad input: Please respond with something matching this regex: %s" % validation_regex)
+            else:
+                break
+        else:
+            break
+    return response
+
+
+def download_plugin_skeleton():
+    """
+    Download the plugin skeleton from https://github.com/errbotio/plugin-skeleton.
+
+    Returns the contents of skeleton.py from the one on GitHub.
+    """
+    response = requests.get("https://github.com/errbotio/plugin-skeleton/raw/master/skeleton.py")
+    response.raise_for_status()
+    return response.text
+
+
+if __name__ == "__main__":
+    try:
+        new_plugin_wizard()
+    except KeyboardInterrupt:
+        sys.exit(1)

--- a/errbot/plugin_wizard.py
+++ b/errbot/plugin_wizard.py
@@ -111,6 +111,7 @@ def new_plugin_wizard(directory=None):
         f.write(render_plugin(locals()))
 
     print("Success! You'll find your new plugin inside '%s'" % plugin_path)
+    print("(Don't forget to include a LICENSE file if you are going to publish your plugin)")
 
 
 def ask(question, valid_responses=None, validation_regex=None):

--- a/errbot/templates/new_plugin_template.py
+++ b/errbot/templates/new_plugin_template.py
@@ -1,0 +1,94 @@
+from errbot import BotPlugin, botcmd, arg_botcmd, webhook
+
+
+class {{ class_name }}(BotPlugin):
+    """
+    {{ description }}
+    """
+
+    def activate(self):
+        """
+        Triggers on plugin activation
+
+        You should delete it if you're not using it to override any default behaviour
+        """
+        super({{ class_name }}, self).activate()
+
+    def deactivate(self):
+        """
+        Triggers on plugin deactivation
+
+        You should delete it if you're not using it to override any default behaviour
+        """
+        super({{ class_name }}, self).deactivate()
+
+    def get_configuration_template(self):
+        """
+        Defines the configuration structure this plugin supports
+
+        You should delete it if your plugin doesn't use any configuration like this
+        """
+        return {'EXAMPLE_KEY_1': "Example value",
+                'EXAMPLE_KEY_2': ["Example", "Value"]
+               }
+
+    def check_configuration(self, configuration):
+        """
+        Triggers when the configuration is checked, shortly before activation
+
+        You should delete it if you're not using it to override any default behaviour
+        """
+        super({{ class_name }}, self).check_configuration()
+
+    def callback_connect(self):
+        """
+        Triggers when bot is connected
+
+        You should delete it if you're not using it to override any default behaviour
+        """
+        pass
+
+    def callback_message(self, message):
+        """
+        Triggered for every received message that isn't coming from the bot itself
+
+        You should delete it if you're not using it to override any default behaviour
+        """
+        pass
+
+    def callback_botmessage(self, message):
+        """
+        Triggered for every message that comes from the bot itself
+
+        You should delete it if you're not using it to override any default behaviour
+        """
+        pass
+
+    @webhook
+    def example_webhook(self, incoming_request):
+        """A webhook which simply returns 'Example'"""
+        return "Example"
+
+    # Passing split_args_with=None will cause arguments to be split on any kind
+    # of whitespace, just like Python's split() does
+    @botcmd(split_args_with=None)
+    def example(self, message, args):
+        """A command which simply returns 'Example'"""
+        return "Example"
+
+    @arg_botcmd('name', type=str)
+    @arg_botcmd('--favorite-number', type=int, unpack_args=False)
+    def hello(self, message, args):
+        """
+        A command which says hello to someone.
+
+        If you include --favorite-number, it will also tell you their
+        favorite number.
+        """
+        if args.favorite_number is None:
+            return "Hello {name}".format(name=args.name)
+        else:
+            return "Hello {name}, I hear your favorite number is {number}".format(
+                name=args.name,
+                number=args.favorite_number,
+            )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [pep8]
 max-line-length = 120
-exclude = errbot/bundled/*,docs/*,config*.py,errbot/config-*.py,build/*,data/*
+exclude = errbot/bundled/*,docs/*,config*.py,errbot/config-*.py,build/*,data/*,errbot/templates/new_plugin_template.py
 
 [pytest]
 addopts = --ignore run_tests.py


### PR DESCRIPTION
This adds a new flag, `--new-plugin` to errbot which asks a series of
questions to create a skeleton for a new plugin.

Example:

```
$ errbot --new-plugin /tmp
This wizard will create a new plugin for you in '/tmp'.
What should the name of your new plugin be?
> Example Bot
What may I use as a short (one-line) description of your plugin?
> An example bot
Which python version will your plugin work with? 2, 2+ or 3?
> 2+
Which minimum version of errbot will your plugin work with? Leave blank to support any version
> 0.0.0
Which maximum version of errbot will your plugin work with? Leave blank to support any version
> 4.0.0
Success! You'll find your new plugin at '/tmp/example_bot.py'

$ cat /tmp/example_bot.plug
[Core]
name = Example Bot
module = example_bot

[Documentation]
description = An example bot

[Python]
version = 2+

[Errbot]
min = 0.0.0
max = 4.0.0

$ head /tmp/example_bot.py
from errbot import BotPlugin, botcmd, webhook

class ExampleBot(BotPlugin):
    """
    An example bot
    """

    def activate(self):
        """
```