### PR TITLE
Fix dependency error in py27 where 'configparser' was not found

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if PY2:
     deps += ['dnspython',  # dnspython is needed for SRV records
              'config',
              'backports.functools_lru_cache',
-             'configparser', ]  # This is a backport from Python 3
+             'configparser==3.5.0b2', ]  # This is a backport from Python 3
 else:
     deps += ['dnspython3', ]  # dnspython3 for SRV records
 


### PR DESCRIPTION
Fixing error where in python 2.7, you get the following error:

```
[saviles:~/virtualenvs/tmp-d4cbd6dcd01fa8ac] [tmp-d4cbd6dcd01fa8ac] $ errbot
Traceback (most recent call last):
  File "/home/saviles/virtualenvs/tmp-d4cbd6dcd01fa8ac/bin/errbot", line 9, in <module>
    load_entry_point('errbot==4.0.1', 'console_scripts', 'errbot')()
  File "/home/saviles/virtualenvs/tmp-d4cbd6dcd01fa8ac/lib/python2.7/site-packages/pkg_resources/__init__.py", line 519, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/home/saviles/virtualenvs/tmp-d4cbd6dcd01fa8ac/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2630, in load_entry_point
    return ep.load()
  File "/home/saviles/virtualenvs/tmp-d4cbd6dcd01fa8ac/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2310, in load
    return self.resolve()
  File "/home/saviles/virtualenvs/tmp-d4cbd6dcd01fa8ac/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2316, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/home/saviles/virtualenvs/tmp-d4cbd6dcd01fa8ac/lib/python2.7/site-packages/errbot/err.py", line 25, in <module>
    from .plugin_wizard import new_plugin_wizard
  File "/home/saviles/virtualenvs/tmp-d4cbd6dcd01fa8ac/lib/python2.7/site-packages/errbot/plugin_wizard.py", line 16, in <module>
    from backports.configparser import ConfigParser
ImportError: No module named configparser
```