### PR TITLE
Format URLs on Slack

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -10,7 +10,7 @@ from errbot.backends.base import Message, Presence, ONLINE, AWAY, Room, RoomErro
     UserDoesNotExistError, RoomOccupant, Person
 from errbot.errBot import ErrBot
 from errbot.utils import PY3, split_string_after
-from errbot.rendering import imtext
+from errbot.rendering.slack import slack_markdown_converter
 
 
 # Can't use __name__ because of Yapsy
@@ -193,7 +193,7 @@ class SlackBackend(ErrBot):
             )
             sys.exit(1)
         self.sc = None  # Will be initialized in serve_once
-        self.md = imtext()
+        self.md = slack_markdown_converter()
 
     def api_call(self, method, data=None, raise_errors=True):
         """
@@ -463,7 +463,12 @@ class SlackBackend(ErrBot):
             parts = self.prepare_message_body(body, limit)
 
             for part in parts:
-                self.sc.rtm_send_message(to_channel_id, part)
+                self.api_call('chat.postMessage', data={
+                    'channel': to_channel_id,
+                    'text': part,
+                    'unfurl_media': "true",
+                    'as_user': "true",
+                })
         except Exception:
             log.exception(
                 "An exception occurred while trying to send the following message "

--- a/errbot/rendering/slack.py
+++ b/errbot/rendering/slack.py
@@ -1,0 +1,31 @@
+import re
+
+from markdown import Markdown
+from markdown.extensions.extra import ExtraExtension
+from markdown.preprocessors import Preprocessor
+
+from .ansi import AnsiExtension
+
+
+MARKDOWN_LINK_REGEX = re.compile(r'([^!])\[(?P<text>.+?)\]\((?P<uri>[a-zA-Z0-9]+?:\S+?)\)')
+
+
+def slack_markdown_converter():
+    """
+    This is a Markdown converter for use with Slack.
+    """
+    md = Markdown(output_format='imtext', extensions=[ExtraExtension(), AnsiExtension()])
+    md.preprocessors['LinkPreProcessor'] = LinkPreProcessor(md)
+    md.stripTopLevelTags = False
+    return md
+
+
+class LinkPreProcessor(Preprocessor):
+    """
+    This preprocessor converts markdown URL notation into Slack URL notation
+    as described at https://api.slack.com/docs/formatting, section "Linking to URLs".
+    """
+    def run(self, lines):
+        for i, line in enumerate(lines):
+            lines[i] = MARKDOWN_LINK_REGEX.sub(r'\1&lt;\3|\2&gt;', line)
+        return lines

--- a/tests/backend_tests/slack_tests.py
+++ b/tests/backend_tests/slack_tests.py
@@ -203,3 +203,22 @@ class SlackTests(unittest.TestCase):
             "Multiple uris test@example.org, other@example.org and "
             "http://www.example.org, https://example.com and subdomain.example.org."
         )
+
+    def test_slack_markdown_link_preprocessor(self):
+        convert = self.slack.md.convert
+        self.assertEqual(
+            "This is <http://example.com/|a link>.",
+            convert("This is [a link](http://example.com/).")
+        )
+        self.assertEqual(
+            "This is <https://example.com/|a link> and <mailto:me@comp.org|an email address>.",
+            convert("This is [a link](https://example.com/) and [an email address](mailto:me@comp.org).")
+        )
+        self.assertEqual(
+            "This is <http://example.com/|a link> and a manual URL: https://example.com/.",
+            convert("This is [a link](http://example.com/) and a manual URL: https://example.com/.")
+        )
+        self.assertEqual(
+            "This is http://example.com/image.png.",
+            convert("This is ![an image](http://example.com/image.png).")
+        )


### PR DESCRIPTION
This converts URLs on Slack so that instead of printing the URL after
the link text it actually hyperlinks just the link text itself.

As a side effect, this changes how messages are sent from using the
RealTime Messaging API to the generic web API because the RTM API
does not support markup like this, only the web API does.

This is described at https://api.slack.com/rtm which states:

> The RTM API only supports posting simple messages formatted using
> our default message formatting mode. It does not support attachments
> or other message formatting modes. To post a more complex message as
> a user clients can call the chat.postMessage Web API method