### PR TITLE
Python 2.7 import for hipchat

### DIFF
--- a/errbot/backends/hipchat.py
+++ b/errbot/backends/hipchat.py
@@ -2,7 +2,10 @@
 # vim: ts=4:sw=4
 import logging
 import sys
-from functools import lru_cache
+try:
+    from functools import lru_cache
+except ImportError:
+    from backports.functools_lru_cache import lru_cache
 
 from markdown import Markdown
 from markdown.extensions.extra import ExtraExtension


### PR DESCRIPTION
`lru_cache` import was not 2.7-safe.