### PR TITLE
Instead of chunking large slack messages, simply upload as a plain-text file

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -461,12 +461,12 @@ class SlackBackend(ErrBot):
             log.debug('Message size: %d' % len(body))
 
             limit = min(self.bot_config.MESSAGE_SIZE_LIMIT, SLACK_MESSAGE_LIMIT)
-	    if len(body) > limit:
+            if len(body) > limit:
                 self.api_call('files.upload', data={
                     'channels': [to_channel_id],
                     'content': body,
                     'filename': hashlib.sha224(body).hexdigest(),
-		    'filetype': 'text',
+                    'filetype': 'text',
                 })
             else:
                 self.api_call('chat.postMessage', data={

--- a/tests/backend_tests/slack_tests.py
+++ b/tests/backend_tests/slack_tests.py
@@ -83,33 +83,6 @@ class SlackTests(unittest.TestCase):
 
         self.assertEqual(msg.extras['attachments'], [attachment])
 
-    def testPrepareMessageBody(self):
-        test_body = """
-        hey, this is some code:
-            ```
-            foobar
-            ```
-        """
-        parts = self.slack.prepare_message_body(test_body, 10000)
-        assert parts == [test_body]
-
-        test_body = """this block is unclosed: ``` foobar """
-        parts = self.slack.prepare_message_body(test_body, 10000)
-        assert parts == [test_body + "\n```\n"]
-
-        test_body = """``` foobar """
-        parts = self.slack.prepare_message_body(test_body, 10000)
-        assert parts == [test_body + "\n```\n"]
-
-        test_body = """closed ``` foobar ``` not closed ```"""
-        # ---------------------------------^ 21st char
-        parts = self.slack.prepare_message_body(test_body, 21)
-        assert len(parts) == 2
-        assert parts[0].count('```') == 2
-        assert parts[0].endswith('```')
-        assert parts[1].count('```') == 2
-        assert parts[1].endswith('```\n')
-
     def test_extract_identifiers(self):
         extract_from = self.slack.extract_identifiers_from_string
 


### PR DESCRIPTION
This is a big UX improvement, and also simplifies the code. 