### PR TITLE
botmatch implementation.

### DIFF
--- a/errbot/__init__.py
+++ b/errbot/__init__.py
@@ -200,6 +200,51 @@ def re_botcmd(*args,
     return decorator(args[0]) if args else decorator
 
 
+def botmatch(*args, **kwargs):
+    """
+    Decorator for regex-based message match.
+
+    :param *args: The regular expression a message should match against in order to
+                   trigger the command.
+    :param flags: The `flags` parameter which should be passed to :func:`re.compile()`. This
+        allows the expression's behaviour to be modified, such as making it case-insensitive
+        for example.
+    :param matchall: By default, only the first match of the regular expression is returned
+        (as a `re.MatchObject`). When *matchall* is `True`, all non-overlapping matches are
+        returned (as a list of `re.MatchObject` items).
+    :param hidden: Prevents the command from being shown by the built-in help command when `True`.
+    :param name: The name to give to the command. Defaults to name of the function itself.
+    :param admin_only: Only allow the command to be executed by admins when `True`.
+    :param historize: Store the command in the history list (`!history`). This is enabled
+        by default.
+    :param template: The template to use when using Markdown output.
+
+    For example::
+
+        @botmatch(r'^(?:Yes|No)$')
+        def yes_or_no(self, msg, match):
+            pass
+    """
+    def decorator(func, pattern):
+        return _tag_botcmd(func,
+                           _re=True,
+                           _arg=False,
+                           prefixed=False,
+                           hidden=kwargs.get('hidden', False),
+                           name=kwargs.get('name', func.__name__),
+                           admin_only=kwargs.get('admin_only', False),
+                           historize=kwargs.get('historize', True),
+                           template=kwargs.get('template', None),
+                           pattern=pattern,
+                           flags=kwargs.get('flags', 0),
+                           matchall=kwargs.get('matchall', False))
+    if len(args) == 2:
+        return decorator(*args)
+    if len(args) == 1:
+        return lambda f: decorator(f, args[0])
+    raise ValueError("botmatch: You need to pass the pattern as parameter to the decorator.")
+
+
 def arg_botcmd(*args,
                hidden: bool=False,
                name: str=None,

--- a/tests/commands_tests.py
+++ b/tests/commands_tests.py
@@ -303,3 +303,6 @@ class TestCommands(FullStackTest):
 
         # Now reset our state so we don't bork the other tests
         self.bot.bot_config.BOT_PREFIX_OPTIONAL_ON_CHAT = prefix_optional
+
+    def test_simple_match(self):
+        self.assertCommand('match this', 'bar')

--- a/tests/dummy_plugin/dummy.py
+++ b/tests/dummy_plugin/dummy.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from errbot import BotPlugin, botcmd, re_botcmd
+from errbot import BotPlugin, botcmd, re_botcmd, botmatch
 
 
 class DummyTest(BotPlugin):
@@ -12,5 +12,10 @@ class DummyTest(BotPlugin):
 
     @re_botcmd(pattern=r"plz dont match this")
     def re_foo(self, msg, match):
+        """This runs re_foo."""
+        return 'bar'
+
+    @botmatch(r"match this")
+    def re_bar(self, msg, match):
         """This runs re_foo."""
         return 'bar'


### PR DESCRIPTION
This is a proposal to simplify the re_botcmd for a "conversational" response for the flows.
instead of having to use:

``` python
    @re_botcmd(pattern=r'^\d{1,2}$', prefixed=False)
    def guessing(self, msg, match):
```

You can simply do that, with full backward compatibility with regular re_botcmd params and behavior:

``` python
    @botmatch(r'^\d{1,2}$')
    def guessing(self, msg, match):
```