### PR TITLE
Support compact output on Slack and Telegram

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -193,7 +193,8 @@ class SlackBackend(ErrBot):
             )
             sys.exit(1)
         self.sc = None  # Will be initialized in serve_once
-        self.md = slack_markdown_converter()
+        compact = config.COMPACT_OUTPUT if hasattr(config, 'COMPACT_OUTPUT') else False
+        self.md = slack_markdown_converter(compact)
 
     def api_call(self, method, data=None, raise_errors=True):
         """

--- a/errbot/backends/telegram_messenger.py
+++ b/errbot/backends/telegram_messenger.py
@@ -5,6 +5,7 @@ from errbot import PY2
 from errbot.backends.base import RoomError, Identifier, Person, RoomOccupant, ONLINE, Room
 from errbot.errBot import ErrBot
 from errbot.rendering import text
+from errbot.rendering.ansi import enable_format, TEXT_CHRS
 
 
 # Can't use __name__ because of Yapsy
@@ -190,6 +191,9 @@ class TelegramBackend(ErrBot):
             sys.exit(1)
         self.telegram = None  # Will be initialized in serve_once
         self.bot_instance = None  # Will be set in serve_once
+
+        compact = config.COMPACT_OUTPUT if hasattr(config, 'COMPACT_OUTPUT') else False
+        enable_format('text', TEXT_CHRS, borders=not compact)
         self.md_converter = text()
 
     def serve_once(self):

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -363,7 +363,7 @@ REVERSE_CHATROOM_RELAY = {}
 # Allow messages sent in a chatroom to be directed at requester.
 #GROUPCHAT_NICK_PREFIXED = False
 
-# Disables table borders (IRC only for now). You can reenable them switching that to  False
+# Disable table borders, making output more compact (supported only on IRC and Telegram currently).
 # COMPACT_OUTPUT = True
 
 # Disables the logging output in Text mode and only outputs Ansi.

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -363,7 +363,7 @@ REVERSE_CHATROOM_RELAY = {}
 # Allow messages sent in a chatroom to be directed at requester.
 #GROUPCHAT_NICK_PREFIXED = False
 
-# Disable table borders, making output more compact (supported only on IRC and Telegram currently).
+# Disable table borders, making output more compact (supported only on IRC, Slack and Telegram currently).
 # COMPACT_OUTPUT = True
 
 # Disables the logging output in Text mode and only outputs Ansi.

--- a/errbot/rendering/slack.py
+++ b/errbot/rendering/slack.py
@@ -4,16 +4,16 @@ from markdown import Markdown
 from markdown.extensions.extra import ExtraExtension
 from markdown.preprocessors import Preprocessor
 
-from .ansi import AnsiExtension
-
+from .ansi import AnsiExtension, enable_format, IMTEXT_CHRS
 
 MARKDOWN_LINK_REGEX = re.compile(r'([^!])\[(?P<text>.+?)\]\((?P<uri>[a-zA-Z0-9]+?:\S+?)\)')
 
 
-def slack_markdown_converter():
+def slack_markdown_converter(compact_output=False):
     """
     This is a Markdown converter for use with Slack.
     """
+    enable_format('imtext', IMTEXT_CHRS, borders=not compact_output)
     md = Markdown(output_format='imtext', extensions=[ExtraExtension(), AnsiExtension()])
     md.preprocessors['LinkPreProcessor'] = LinkPreProcessor(md)
     md.stripTopLevelTags = False


### PR DESCRIPTION
These were easy to port from IRC. XMPP/HipChat use a very different renderer so I'm not going to work on those for now.