### PR TITLE
Do not install submodules of tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ if __name__ == "__main__":
     setup(
         name="errbot",
         version=VERSION,
-        packages=find_packages(src_root, exclude=['tests', 'tools']),
+        packages=find_packages(src_root, exclude=['tests', 'tests.*', 'tools']),
         entry_points={
             'console_scripts': [
                 'errbot = errbot.err:main',


### PR DESCRIPTION
Currently, installing errbot via `setup.py` would install a `tests.backend_tests` module.