### PR TITLE
Use username instead of userid as Slack .person property

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -125,7 +125,6 @@ class SlackPerson(Person):
         return self._sc.server.domain
 
     # Compatibility with the generic API.
-    person = userid
     client = channelid
     nick = username
 
@@ -153,6 +152,12 @@ class SlackPerson(Person):
 
     def __eq__(self, other):
         return other.userid == self.userid
+
+    @property
+    def person(self):
+        # Don't use str(self) here because we want SlackRoomOccupant
+        # to return just our @username too.
+        return "@%s" % self.username
 
 
 class SlackRoomOccupant(RoomOccupant, SlackPerson):


### PR DESCRIPTION
This provides more readable/user-friendly names when displaying users on Slack (`!room occupants` uses this for example).

I think this is a lot nicer to work with (seeing `@zoni` instead of `U12356`) but it might affect some users as it's technically an API change. That said though, the string representation of an identifier and the use of an identifier object itself (received through `Message.frm` or created via `build_identifier()`) hasn't changed and this is what people should be using, so the impact should be minimal.