### PR TITLE
Don't remove original commands remove_commands_from

### DIFF
--- a/errbot/errBot.py
+++ b/errbot/errBot.py
@@ -525,6 +525,7 @@ class ErrBot(Backend, StoreMixin):
                         self.warn_admins('%s.%s clashes with %s.%s so it has been renamed %s' % (
                             classname, name, type(f.__self__).__name__, f.__name__, new_name))
                         name = new_name
+                        value.__func__._err_command_name = new_name  # To keep track of the renaming.
                     commands[name] = value
 
                     if getattr(value, '_err_re_command'):
@@ -566,9 +567,9 @@ class ErrBot(Backend, StoreMixin):
                 if getattr(value, '_err_command', False):
                     name = getattr(value, '_err_command_name')
                     if getattr(value, '_err_re_command') and name in self.re_commands:
-                        del (self.re_commands[name])
+                        del self.re_commands[name]
                     elif not getattr(value, '_err_re_command') and name in self.commands:
-                        del (self.commands[name])
+                        del self.commands[name]
 
     def remove_command_filters_from(self, instance_to_inject):
         with self._gbl:

--- a/tests/dyna_plugin/dyna.py
+++ b/tests/dyna_plugin/dyna.py
@@ -50,3 +50,18 @@ class Dyna(BotPlugin):
     def remove_saw(self, msg, args):
         self.destroy_dynamic_plugin('saw')
         return 'removed'
+
+    @botcmd
+    def clash(self, msg, args):
+        return 'original'
+
+    @botcmd
+    def add_clashing(self, _, _1):
+        simple1 = Command(lambda plugin, msg, args: 'dynamic', name='clash')
+        self.create_dynamic_plugin('clashing', (simple1, ))
+        return 'added'
+
+    @botcmd
+    def remove_clashing(self, _, _1):
+        self.destroy_dynamic_plugin('clashing')
+        return 'removed'

--- a/tests/dynaplug_tests.py
+++ b/tests/dynaplug_tests.py
@@ -30,3 +30,14 @@ class TestDynaPlugins(FullStackTest):
         self.assertCommand('!add_saw', 'added')
         self.assertCommand('!splitme foo,bar,baz', 'foo+bar+baz')
         self.assertCommand('!remove_saw', 'removed')
+
+    def test_clashing(self):
+        self.assertCommand('!clash', 'original')
+        self.assertCommand('!add_clashing',
+                           'clashing.clash clashes with Dyna.clash so it has been renamed clashing-clash')
+        self.assertIn('added', self.bot.pop_message())
+        self.assertCommand('!clash', 'original')
+        self.assertCommand('!clashing-clash', 'dynamic')
+        self.assertCommand('!remove_clashing', 'removed')
+        self.assertCommand('!clash', 'original')
+        self.assertCommand('!clashing-clash', 'not found')


### PR DESCRIPTION
Track the real name of the command by changing _err_command_name.
Thx @dufton for debugging this.

fixes #724