### PR TITLE
Allow simple strings in ACL rules

### DIFF
--- a/errbot/core_plugins/acls.py
+++ b/errbot/core_plugins/acls.py
@@ -1,4 +1,5 @@
 import fnmatch
+from types import StringType
 from errbot import BotPlugin, cmdfilter
 from errbot.backends.base import RoomOccupant
 from errbot.utils import compat_str
@@ -18,6 +19,8 @@ def glob(text, patterns):
     Match text against the list of patterns according to unix glob rules.
     Return True if a match is found, False otherwise.
     """
+    if type(patterns) is StringType:
+        patterns = (patterns,)
     return any(fnmatch.fnmatchcase(compat_str(text), compat_str(pattern)) for pattern in patterns)
 
 
@@ -28,6 +31,8 @@ def ciglob(text, patterns):
     Match text against the list of patterns according to unix glob rules.
     Return True if a match is found, False otherwise.
     """
+    if type(patterns) is StringType:
+        patterns = (patterns,)
     return glob(text.lower(), [p.lower() for p in patterns])
 
 


### PR DESCRIPTION
Previously only tuples or lists were allowed in ACL configurations like
"allowusers" and "allowrooms", while the code iterated over characters
in case of strings.
This led to confusion (like https://github.com/errbotio/errbot/issues/711).

The patch casts incoming strings to tuples, so that you can do

  ACCESS_CONTROLS_DEFAULT = {'allowusers': 'gbin@localhost'}

in addition to

  ACCESS_CONTROLS_DEFAULT = {'allowusers': ('gbin@localhost',)}

now.