### PR TITLE
Fix hipchat room.occupants error

### DIFF
--- a/errbot/backends/hipchat.py
+++ b/errbot/backends/hipchat.py
@@ -298,6 +298,7 @@ class HipChatRoom(Room):
         participants = self.room.participants(expand="items")['items']
         occupants = []
         for p in participants:
+            p['xmpp_jid'] = "{}/{}".format(p['name'], p['xmpp_jid'])
             occupants.append(HipChatRoomOccupant(p))
         return occupants
 


### PR DESCRIPTION
when calling occupants on hipchat room, errbot gets an exception because xmpid that is used does not contain the resource:

  File "/usr/lib/python2.7/site-packages/err-3.1.1-py2.7.egg/errbot/backends/hipchat.py", line 85, in __init__
    node, domain = node_domain.split(u'@')

This fix prepends the resource to node and domain so the super class doesn't fail.