### PR TITLE
Allow an optional priority to be set for plugins

### DIFF
--- a/errbot/botplugin.py
+++ b/errbot/botplugin.py
@@ -265,6 +265,10 @@ class BotPluginBase(StoreMixin):
 # noinspection PyAbstractClass
 class BotPlugin(BotPluginBase):
 
+    PRIORITY_RUN_FIRST = 10
+    PRIORITY_DEFAULT   = 0
+    PRIORITY_RUN_LAST  = -10
+
     def get_configuration_template(self) -> Mapping:
         """
         If your plugin needs a configuration, override this method and return
@@ -308,6 +312,18 @@ class BotPlugin(BotPluginBase):
         :param configuration: injected configuration for the plugin.
         """
         self.config = configuration
+
+    def get_priority(self) -> int:
+        """
+            Callback on plugins are executed in priority order.
+            
+            Override this method if you want your plugin to get its callbacks in a
+            specific order relative to the other plugins. You should return one of:
+            - `self.PRIORITY_RUN_FIRST`
+            - `self.PRIORITY_DEFAULT` (which is the default)
+            - `self.PRIORITY_RUN_LAST`
+        """
+        return self.PRIORITY_DEFAULT
 
     def activate(self) -> None:
         """

--- a/errbot/botplugin.py
+++ b/errbot/botplugin.py
@@ -266,8 +266,8 @@ class BotPluginBase(StoreMixin):
 class BotPlugin(BotPluginBase):
 
     PRIORITY_RUN_FIRST = 10
-    PRIORITY_DEFAULT   = 0
-    PRIORITY_RUN_LAST  = -10
+    PRIORITY_DEFAULT = 0
+    PRIORITY_RUN_LAST = -10
 
     def get_configuration_template(self) -> Mapping:
         """

--- a/errbot/botplugin.py
+++ b/errbot/botplugin.py
@@ -316,7 +316,7 @@ class BotPlugin(BotPluginBase):
     def get_priority(self) -> int:
         """
             Callback on plugins are executed in priority order.
-            
+
             Override this method if you want your plugin to get its callbacks in a
             specific order relative to the other plugins. You should return one of:
             - `self.PRIORITY_RUN_FIRST`

--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -210,11 +210,7 @@ def check_errbot_plug_section(name: str, config: ConfigParser) -> bool:
 
 
 def get_plugin_priority(plugin) -> int:
-    try:
-        priority = int(plugin.details.get("Core", "Priority"))
-    except (NoOptionError, ValueError):
-        priority = 0
-    return priority
+    return plugin.plugin_object.get_priority()
 
 
 def global_restart():

--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -209,6 +209,14 @@ def check_errbot_plug_section(name: str, config: ConfigParser) -> bool:
     return True
 
 
+def get_plugin_priority(plugin) -> int:
+    try:
+        priority = int(plugin.details.get("Core", "Priority"))
+    except (NoOptionError, ValueError):
+        priority = 0
+    return priority
+
+
 def global_restart():
     python = sys.executable
     os.execl(python, python, *sys.argv)
@@ -382,16 +390,22 @@ class BotPluginManager(PluginManager, StoreMixin):
                        for pluginfo in loaded_plugins if pluginfo.error is not None})
         return errors
 
+    def get_all_plugins_ordered(self):
+        return sorted(self.getAllPlugins(), key=lambda p: get_plugin_priority(p), reverse=True)
+
+    def get_plugins_of_category_ordered(self, category):
+        return sorted(self.getPluginsOfCategory(category), key=lambda p: get_plugin_priority(p), reverse=True)
+
     def get_all_active_plugin_objects(self):
         return [plug.plugin_object
-                for plug in self.getPluginsOfCategory(BOTPLUGIN_TAG)
+                for plug in self.get_plugins_of_category_ordered(BOTPLUGIN_TAG)
                 if hasattr(plug, 'is_activated') and plug.is_activated]
 
     def get_all_active_plugin_names(self):
-        return [p.name for p in self.getAllPlugins() if hasattr(p, 'is_activated') and p.is_activated]
+        return [p.name for p in self.get_all_plugins_ordered() if hasattr(p, 'is_activated') and p.is_activated]
 
     def get_all_plugin_names(self):
-        return [p.name for p in self.getPluginsOfCategory(BOTPLUGIN_TAG)]
+        return [p.name for p in self.get_plugins_of_category_ordered(BOTPLUGIN_TAG)]
 
     def deactivate_all_plugins(self):
         for name in self.get_all_active_plugin_names():
@@ -447,7 +461,7 @@ class BotPluginManager(PluginManager, StoreMixin):
         log.info('Activate bot plugins...')
         configs = self[self.CONFIGS]
         errors = ''
-        for pluginInfo in self.getPluginsOfCategory(BOTPLUGIN_TAG):
+        for pluginInfo in self.get_plugins_of_category_ordered(BOTPLUGIN_TAG):
             try:
                 if self.is_plugin_blacklisted(pluginInfo.name):
                     errors += 'Notice: %s is blacklisted, use %s plugin unblacklist %s to unblacklist it\n' % (
@@ -461,7 +475,7 @@ class BotPluginManager(PluginManager, StoreMixin):
                 errors += 'Error: %s failed to start: %s\n' % (pluginInfo.name, e)
 
         log.debug('Activate flow plugins ...')
-        for pluginInfo in self.getPluginsOfCategory(BOTFLOW_TAG):
+        for pluginInfo in self.get_plugins_of_category_ordered(BOTFLOW_TAG):
             try:
                 if hasattr(pluginInfo, 'is_activated') and not pluginInfo.is_activated:
                     name = pluginInfo.name
@@ -529,7 +543,7 @@ class BotPluginManager(PluginManager, StoreMixin):
         """
         Remove all the plugins that are in the filetree pointed by root.
         """
-        for plugin in self.getAllPlugins():
+        for plugin in self.get_all_plugins_ordered():
             if plugin.path.startswith(root):
                 self.remove_plugin(plugin)
 

--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -210,7 +210,10 @@ def check_errbot_plug_section(name: str, config: ConfigParser) -> bool:
 
 
 def get_plugin_priority(plugin) -> int:
-    return plugin.plugin_object.get_priority()
+    try:
+        return plugin.plugin_object.get_priority()
+    except AttributeError:
+        return 0
 
 
 def global_restart():


### PR DESCRIPTION
Plugins, when iterated over, will be sorted by order of decreasing priority. Plugins that aren't explicitly declaring a priority in their `plug` file will have a priority of `0`.

This is useful in a setting where multiple plugins have loose interaction. For example, one might want to create a plugin which does some form of pre-processing of messages. Using this change, it is possible by setting that plugin priority to a greater than zero value, and by updating the message in the `callback_message` implementation of that plugin.

I realize this might not be a very common use-case, but I needed it. :)