### PR TITLE
Fixed parsing of Slack identifiers with channel and username

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -656,10 +656,12 @@ class SlackBackend(ErrBot):
             return SlackPerson(self.sc, None, channelid)
         if username is not None:
             userid = self.username_to_userid(username)
-            return SlackPerson(self.sc, userid, self.get_im_channel(userid))
         if channelname is not None:
             channelid = self.channelname_to_channelid(channelname)
+        if userid is not None and channelid is not None:
             return SlackRoomOccupant(self.sc, userid, channelid, bot=self)
+        if userid is not None:
+            return SlackPerson(self.sc, userid, self.get_im_channel(userid))
 
         raise Exception(
             "You found a bug. I expected at least one of userid, channelid, username or channelname "

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -147,7 +147,11 @@ class SlackPerson(Person):
     @property
     def fullname(self):
         """Convert a Slack user ID to their user name"""
-        return "@%s" % self.username
+        user = self._sc.server.users.find(self._userid)
+        if user is None:
+            log.error("Cannot find user with ID %s" % self._userid)
+            return "<%s>" % self._userid
+        return user.real_name
 
     def __unicode__(self):
         return "@%s" % self.username

--- a/tests/backend_tests/slack_tests.py
+++ b/tests/backend_tests/slack_tests.py
@@ -31,8 +31,14 @@ if slack:
             """Have to mock because we don't have a slack server."""
             return 'Utest'
 
+        def channelname_to_channelid(self, channelname):
+            return 'Ctest'
+
         def channelid_to_channelname(self, channelid):
             return 'meh'
+
+        def get_im_channel(self, id_):
+            return 'Cfoo'
 
 
 @unittest.skipIf(not slack, "package slackclient not installed")
@@ -167,6 +173,34 @@ class SlackTests(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             extract_from("<@I12345>")
+
+    def test_build_identifier(self):
+        build_from = self.slack.build_identifier
+
+        self.assertEqual(
+            build_from("<#C12345>"),
+            slack.SlackPerson(None, userid=None, channelid="C12345")
+        )
+
+        self.assertEqual(
+            build_from("<@U12345>"),
+            slack.SlackPerson(None, userid="U12345", channelid="Cfoo")
+        )
+
+        self.assertEqual(
+            build_from("@user"),
+            slack.SlackPerson(None, userid="Utest", channelid="Cfoo")
+        )
+
+        self.assertEqual(
+            build_from("#channel"),
+            slack.SlackPerson(None, userid=None, channelid="Ctest")
+        )
+
+        self.assertEqual(
+            build_from("#channel/user"),
+            slack.SlackRoomOccupant(None, "Utest", "Cfoo", self.slack)
+        )
 
     def test_uri_sanitization(self):
         sanitize = self.slack.sanitize_uris


### PR DESCRIPTION
The current implementation returns a `SlackPerson` even with identifiers that have a channel and a username. This fixes that bug.