### PR TITLE
Adds a GPLv3 exception for Errbot plugins.

### DIFF
--- a/gplv3-exceptions.txt
+++ b/gplv3-exceptions.txt
@@ -1,4 +1,5 @@
-As a special exception, the copyright holders of Errbot hereby grant permission 
-for plug-ins and script add-ons to be used with Errbot, provided that you also 
-meet the terms and conditions of the licenses of those plug-ins and script
-add-ons.
+As a special exception, the copyright holders of Errbot hereby grant permission
+for plug-ins, scripts or add-ons not bundled or distributed as part
+of Errbot itself and potentially licensed under a different license, to be
+used with Errbot, provided that you also meet the terms and conditions of the
+licenses of those plug-ins, scripts or add-ons.

--- a/gplv3-exceptions.txt
+++ b/gplv3-exceptions.txt
@@ -1,0 +1,4 @@
+As a special exception, the copyright holders of Errbot hereby grant permission 
+for plug-ins and script add-ons to be used with Errbot, provided that you also 
+meet the terms and conditions of the licenses of those plug-ins and script
+add-ons.


### PR DESCRIPTION
This was the original intent, the goal here is to avoid forcing the entire ecosystem under GPLv3 or making them run with a "main" or a separate process. The GPLv3 is not totally clear about it, so I would prefer to totally clarify that.

