### PR TITLE
Give better error message about malformed .plug files

### DIFF
--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -372,7 +372,19 @@ class BotPluginManager(PluginManager, StoreMixin):
         else:
             errors.update({path: result[0] for path, result in dependencies_result.items() if result is not None})
         self.setPluginPlaces(paths)
-        self.locatePlugins()
+        try:
+            self.locatePlugins()
+        except ValueError:
+            # See https://github.com/errbotio/errbot/issues/769.
+            # Unfortunately we cannot obtain information on which file specifically caused the issue,
+            # but we can point users in the right direction at least.
+            log.error(
+                "ValueError was raised while scanning directories for plugins. "
+                "This typically happens when your bot and/or plugin directories contain "
+                "badly formatted .plug files. To help troubleshoot, we suggest temporarily "
+                "removing all data and plugins from your bot and then trying again."
+            )
+            raise
 
         self.all_candidates = [candidate[2] for candidate in self.getPluginCandidates()]
 


### PR DESCRIPTION
When errbot starts up it scans through various directories to load
plugins. It does this by using Yapsy which looks for specially
formatted .plug files.

Yapsy raises a ValueError when it encounters a plugin file which misses
some required attributes however. Doing something as simple as `echo >
broken.plug` into one of the directories scanned by errbot will prevent
the bot from starting up.

Since the exception is thrown deep inside yapsy itself there isn't much
we can do about this, but by capturing this error we can log a more
helpful error message to the user so that they know where to look.

Closes #769.