### PR TITLE
Fixed text backends build_identifier() typo

### DIFF
--- a/errbot/backends/text.py
+++ b/errbot/backends/text.py
@@ -132,7 +132,7 @@ class TextBackend(ErrBot):
 
     def build_identifier(self, text_representation):
         if text_representation.startswith('#'):
-            return self.query_room(test_representation[1:])
+            return self.query_room(text_representation[1:])
         return TestPerson(text_representation)
 
     def build_reply(self, mess, text=None, private=False):


### PR DESCRIPTION
I believe I found a typo in `TextBackend`s `build_identifier()`.