### PR TITLE
New feature: with self.mutable(key) as value:

### DIFF
--- a/docs/user_guide/plugin_development/persistence.rst
+++ b/docs/user_guide/plugin_development/persistence.rst
@@ -37,6 +37,7 @@ The storing occurs when you *assign the key*. So for example:
     d['subkey'] = 'NONONONONONO'
 
 You need to do that instead:
+(manual method)
 
 .. code-block:: python
 
@@ -47,3 +48,17 @@ You need to do that instead:
     # later ...
     d['subkey'] = 'NONONONONONO'
     self['FOO'] = d  # restore the full key if something changed in memory.
+
+Or use the mutable contex manager:
+
+.. code-block:: python
+
+    # THIS WORKS AND IS CLEANER
+    d = {}
+    self['FOO'] = d
+
+    # later ...
+
+    with self.mutable('FOO') as d:
+        d['subkey'] = 'NONONONONONO'
+    # it will save automatically the key

--- a/errbot/storage/__init__.py
+++ b/errbot/storage/__init__.py
@@ -1,4 +1,6 @@
+import types
 from collections import MutableMapping
+from contextlib import contextmanager
 import logging
 log = logging.getLogger(__name__)
 
@@ -41,6 +43,16 @@ class StoreMixin(MutableMapping):
     # those are the minimal things to behave like a dictionary with the UserDict.DictMixin
     def __getitem__(self, key):
         return self._store.get(key)
+
+    @contextmanager
+    def mutable(self, key):
+        obj = self._store.get(key)
+        yield obj
+        # implements autosave for a plugin persistent entry
+        # with self['foo'] as f:
+        #     f[4] = 2
+        # saves the entry !
+        self._store.set(key, obj)
 
     def __setitem__(self, key, item):
         return self._store.set(key, item)

--- a/tests/persistence_tests.py
+++ b/tests/persistence_tests.py
@@ -1,0 +1,20 @@
+from errbot.storage import StoreMixin
+from errbot.storage.memory import MemoryStoragePlugin
+
+
+def test_simple_store_retreive():
+    sm = StoreMixin()
+    sm.open_storage(MemoryStoragePlugin(None), 'ns')
+    sm['toto'] = 'titui'
+    assert sm['toto'] == 'titui'
+
+
+def test_mutable():
+    sm = StoreMixin()
+    sm.open_storage(MemoryStoragePlugin(None), 'ns')
+    sm['toto'] = [1, 3]
+
+    with sm.mutable('toto') as titi:
+        titi[1] = 5
+
+    assert sm['toto'] == [1, 5]


### PR DESCRIPTION
This is a common ugly pattern we make our user do:

```python
d = self['key']
# do somthing with d
self['key'] = d
```

Now they can just do that:

```python
with self.mutable('key') as d:
   # do something on d
```
And d will be saved automatically in the key entry at the end of the
scope.