### PR TITLE
Configuration-based plugins callback ordering

### DIFF
--- a/errbot/bootstrap.py
+++ b/errbot/bootstrap.py
@@ -109,7 +109,8 @@ def setup_bot(backend_name, logger, config, restore=None):
                              repo_manager,
                              config.BOT_EXTRA_PLUGIN_DIR,
                              config.AUTOINSTALL_DEPS,
-                             getattr(config, 'CORE_PLUGINS', None))
+                             getattr(config, 'CORE_PLUGINS', None),
+                             getattr(config, 'PLUGINS_CALLBACK_ORDER', (None, )))
 
     # init the backend manager & the bot
     backendpm = bpm_from_config(config)

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -93,6 +93,12 @@ BOT_EXTRA_PLUGIN_DIR = None
 # For example CORE_PLUGINS = ('ACLs', 'Backup', 'Help') you get those names from the .plug files Name entry.
 # For absolutely no plug: CORE_PLUGINS = ()
 
+# Defines an order in which the plugins are getting their callbacks. Useful if you want to have plugins do
+# pre- or post-processing on messages.
+# The 'None' tuple entry represents all the plugins that aren't to be expicitely ordered. For example, if
+# you want 'A' to run first, then everything else but 'B', then 'B', you would use ('A', None, 'B').
+PLUGINS_CALLBACK_ORDER = (None, )
+
 # Should plugin dependencies be installed automatically? If this is true
 # then Err will use pip to install any missing dependencies automatically.
 #

--- a/errbot/core.py
+++ b/errbot/core.py
@@ -105,7 +105,7 @@ class ErrBot(Backend, StoreMixin):
         :param *args: Passed to the callback function.
         :param **kwargs: Passed to the callback function.
         """
-        for plugin in self.plugin_manager.get_all_active_plugin_objects():
+        for plugin in self.plugin_manager.get_all_active_plugin_objects_ordered():
             plugin_name = plugin.__class__.__name__
             log.debug("Triggering {} on {}".format(method, plugin_name))
             # noinspection PyBroadException

--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -390,7 +390,10 @@ class BotPluginManager(PluginManager, StoreMixin):
         for name in self.plugins_callback_order:
             # None is a placeholder for any plugin not having a defined order
             if name is None:
-                all_plugins += [p for p in self.getPluginsOfCategory(BOTPLUGIN_TAG) if p.name not in self.plugins_callback_order]
+                all_plugins += [
+                    p for p in self.getPluginsOfCategory(BOTPLUGIN_TAG)
+                    if p.name not in self.plugins_callback_order
+                ]
             else:
                 p = self.get_plugin_by_name(name)
                 if p is not None:

--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -386,6 +386,11 @@ class BotPluginManager(PluginManager, StoreMixin):
         return errors
 
     def get_all_active_plugin_objects_ordered(self):
+        # Make sure there is a 'None' entry in the callback order, to include
+        # any plugin not explicitly ordered.
+        if None not in self.plugins_callback_order:
+            self.plugins_callback_order = self.plugins_callback_order + (None, )
+
         all_plugins = []
         for name in self.plugins_callback_order:
             # None is a placeholder for any plugin not having a defined order

--- a/tests/base_backend_tests.py
+++ b/tests/base_backend_tests.py
@@ -103,7 +103,8 @@ class DummyBackend(ErrBot):
                                                     repo_manager,
                                                     config.BOT_EXTRA_PLUGIN_DIR,
                                                     config.AUTOINSTALL_DEPS,
-                                                    getattr(config, 'CORE_PLUGINS', None)))
+                                                    getattr(config, 'CORE_PLUGINS', None),
+                                                    getattr(config, 'PLUGINS_CALLBACK_ORDER', (None, ))))
         self.inject_commands_from(self)
         self.inject_command_filters_from(ACLS(self))
 


### PR DESCRIPTION
This PR is a follow-up to #760.

This implements the suggested configuration-based plugins callback ordering, rather than having priorities in the plugin themselves. By default (i.e. with a legacy configuration, or with the default configuration generated by the template), the ordering isn't changed.

However, it is now possible for end-users to set a `PLUGINS_CALLBACK_ORDER` option in their `config.py` file, which allows for flexible sorting of plugins callbacks.