### PR TITLE
Implement command shortcuts, by fuzzy matching.

### DIFF
--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -371,3 +371,11 @@ REVERSE_CHATROOM_RELAY = {}
 
 # Prevent ErrBot from saying anything if the command is unrecognized.
 # SUPPRESS_CMD_NOT_FOUND = False
+
+# Enable command shortcuts, by fuzzy matching the typed command to the full command names,
+# if no command matches literally.
+# Only an unambiguous match is executed.
+# BOT_COMMAND_SHORTCUTS = True
+
+# Wether or not ErrBot should reply with the expanded command name
+# BOT_COMMAND_SHORTCUTS_EXPANSION_MSG = True

--- a/errbot/core.py
+++ b/errbot/core.py
@@ -270,6 +270,7 @@ class ErrBot(Backend, StoreMixin):
         cmd = None
         command = None
         args = ''
+        candidates = set()
         ambiguous_shortcut = False
         if not only_check_re_command:
             if len(text_split) > 1:

--- a/errbot/core.py
+++ b/errbot/core.py
@@ -450,11 +450,11 @@ class ErrBot(Backend, StoreMixin):
 
         #['ab', 'c'] -> 'a<pattern>*?b<pattern>*?<seperator>c<pattern>*?'
         full_pattern = '^{}$'.format(separator.join(map(_mkpat, shortcuts)))
-        regex = re.compile(full_pattern)
+        regex = re.compile(full_pattern, re.I)
 
         matches = set()
         for name in fullnames:
-            if regex.search(name):
+            if regex.match(name):
                 matches.add(name)
 
         return matches


### PR DESCRIPTION
Allows arbitrary shortcuts of commands, by fuzzy matching them, if no
literal match was found.
The current fuzzy match is a rather naive approach, simply allowing to
omit any character from the command, as long as it stays unambiguous. No
swapping of characters allowed.
