### PR TITLE
Accept multiple admins in BOT_ADMINS string

### DIFF
--- a/errbot/botplugin.py
+++ b/errbot/botplugin.py
@@ -108,7 +108,7 @@ class BotPluginBase(StoreMixin):
         # if BOT_ADMINS is just an unique string make it a tuple for backwards
         # compatibility
         if isinstance(self._bot.bot_config.BOT_ADMINS, str):
-            self._bot.bot_config.BOT_ADMINS = (self._bot.bot_config.BOT_ADMINS,)
+            self._bot.bot_config.BOT_ADMINS = tuple(self._bot.bot_config.BOT_ADMINS.split(','))
         return self._bot.bot_config
 
     @property

--- a/tests/base_backend_tests.py
+++ b/tests/base_backend_tests.py
@@ -250,6 +250,11 @@ def test_bot_admins_unique_string():
     assert dummy.bot_config.BOT_ADMINS == ('err@localhost',)
 
 
+def test_bot_admins_unique_string_multiple():
+    dummy = DummyBackend(extra_config={'BOT_ADMINS': 'err@localhost,err2@localhost'})
+    assert dummy.bot_config.BOT_ADMINS == ('err@localhost', 'err2@localhost',)
+
+
 @pytest.fixture
 def dummy_execute_and_send():
     dummy = DummyBackend()


### PR DESCRIPTION
Following on from #461, allow multiple admins to be specified
when converted to a tuple, rather than just one