### PR TITLE
Uses plugin name instead of class name everywhere

### DIFF
--- a/errbot/botplugin.py
+++ b/errbot/botplugin.py
@@ -157,10 +157,18 @@ class BotPluginBase(StoreMixin):
         """
         return self._bot.bot_identifier
 
+    @property
+    def name(self) -> str:
+        """
+        Get the plugin name as defined in its .plug file.
+        
+        :return: this plugin name. 
+        """
+        return self.__class__.__errname__
+
     def init_storage(self) -> None:
-        classname = self.__class__.__name__
-        log.debug('Init storage for %s' % classname)
-        self.open_storage(self._bot.storage_plugin, classname)
+        log.debug('Init storage for %s' % self.name)
+        self.open_storage(self._bot.storage_plugin, self.name)
 
     def activate(self) -> None:
         """

--- a/errbot/botplugin.py
+++ b/errbot/botplugin.py
@@ -161,8 +161,8 @@ class BotPluginBase(StoreMixin):
     def name(self) -> str:
         """
         Get the plugin name as defined in its .plug file.
-        
-        :return: this plugin name. 
+
+        :return: this plugin name.
         """
         return self.__class__.__errname__
 

--- a/errbot/botplugin.py
+++ b/errbot/botplugin.py
@@ -4,6 +4,7 @@ from threading import Timer, current_thread
 from types import ModuleType
 from typing import Tuple, Callable, Mapping, Sequence
 from io import IOBase
+import re
 
 from .storage import StoreMixin, StoreNotOpenError
 from errbot.backends.base import Message, Presence, Stream, Room, Identifier, ONLINE, Card
@@ -271,7 +272,10 @@ class BotPluginBase(StoreMixin):
         """
         if name in self._dynamic_plugins:
             raise ValueError('Dynamic plugin %s already created.')
-        plugin_class = type(name, (BotPlugin,), {command.name: command.definition for command in commands})
+        # cleans the name to be a valid python type.
+        plugin_class = type(re.sub('\W|^(?=\d)', '_', name), (BotPlugin,),
+                            {command.name: command.definition for command in commands})
+        plugin_class.__errname__ = name
         plugin_class.__errdoc__ = doc
         plugin = plugin_class(self._bot)
         self._dynamic_plugins[name] = plugin

--- a/errbot/core.py
+++ b/errbot/core.py
@@ -107,7 +107,7 @@ class ErrBot(Backend, StoreMixin):
         :param **kwargs: Passed to the callback function.
         """
         for plugin in self.plugin_manager.get_all_active_plugin_objects_ordered():
-            plugin_name = plugin.__class__.__name__
+            plugin_name = plugin.name
             log.debug("Triggering {} on {}".format(method, plugin_name))
             # noinspection PyBroadException
             try:
@@ -491,7 +491,7 @@ class ErrBot(Backend, StoreMixin):
 
     def inject_commands_from(self, instance_to_inject):
         with self._gbl:
-            classname = instance_to_inject.__class__.__name__
+            plugin_name = instance_to_inject.name
             for name, value in inspect.getmembers(instance_to_inject, inspect.ismethod):
                 if getattr(value, '_err_command', False):
                     commands = self.re_commands if getattr(value, '_err_re_command') else self.commands
@@ -499,9 +499,9 @@ class ErrBot(Backend, StoreMixin):
 
                     if name in commands:
                         f = commands[name]
-                        new_name = (classname + '-' + name).lower()
+                        new_name = (plugin_name + '-' + name).lower()
                         self.warn_admins('%s.%s clashes with %s.%s so it has been renamed %s' % (
-                            classname, name, type(f.__self__).__name__, f.__name__, new_name))
+                            plugin_name, name, type(f.__self__).__name__, f.__name__, new_name))
                         name = new_name
                         value.__func__._err_command_name = new_name  # To keep track of the renaming.
                     commands[name] = value

--- a/errbot/core_plugins/acls.py
+++ b/errbot/core_plugins/acls.py
@@ -60,7 +60,7 @@ class ACLS(BotPlugin):
         self.log.debug("Check %s for ACLs." % cmd)
         f = self._bot.all_commands[cmd]
         cmd_str = "{plugin}:{command}".format(
-            plugin=type(f.__self__).__name__,
+            plugin=f.__self__.name,
             command=cmd,
         )
 

--- a/errbot/core_plugins/help.py
+++ b/errbot/core_plugins/help.py
@@ -87,9 +87,9 @@ class Help(BotPlugin):
             for cls in sorted(cls_commands.keys(), key=lambda c: c.__errname__):
                 # shows class and description
                 usage += '\n**{name}**\n\n*{doc}*\n\n'.format(
-                                           name=cls.__errname__,
-                                           doc=cls.__errdoc__.strip() or '',
-                                       )
+                    name=cls.__errname__,
+                    doc=cls.__errdoc__.strip() or '',
+                )
 
                 for (name, command) in cls_commands[cls]:
                     if command._err_command_hidden:
@@ -109,9 +109,9 @@ class Help(BotPlugin):
                 get_name(self._bot.get_plugin_class_from_method(command)) == args]
 
             description = '\n**{name}**\n\n*{doc}*\n\n'.format(
-                                       name=cls.__errname__,
-                                       doc=cls.__errdoc__.strip() or '',
-                                   )
+                name=cls.__errname__,
+                doc=cls.__errdoc__.strip() or '',
+            )
             pairs = sorted([
                 (name, command)
                 for (name, command) in commands

--- a/errbot/core_plugins/help.py
+++ b/errbot/core_plugins/help.py
@@ -84,12 +84,12 @@ class Help(BotPlugin):
                     commands.append((name, command))
                     cls_commands[cls] = commands
 
-            for cls in sorted(set(cls_commands), key=lambda c: c.__name__):
+            for cls in sorted(cls_commands.keys(), key=lambda c: c.__errname__):
                 # shows class and description
                 usage += '\n**{name}**\n\n*{doc}*\n\n'.format(
-                    name=cls.__name__,
-                    doc=cls.__errdoc__.strip() or '',
-                )
+                                           name=cls.__errname__,
+                                           doc=cls.__errdoc__.strip() or '',
+                                       )
 
                 for (name, command) in cls_commands[cls]:
                     if command._err_command_hidden:
@@ -109,9 +109,9 @@ class Help(BotPlugin):
                 get_name(self._bot.get_plugin_class_from_method(command)) == args]
 
             description = '\n**{name}**\n\n*{doc}*\n\n'.format(
-                name=cls.__name__,
-                doc=cls.__errdoc__.strip() or '',
-            )
+                                       name=cls.__errname__,
+                                       doc=cls.__errdoc__.strip() or '',
+                                   )
             pairs = sorted([
                 (name, command)
                 for (name, command) in commands

--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -59,9 +59,10 @@ def _ensure_sys_path_contains(paths):
             sys.path.append(entry)
 
 
-def populate_doc(plugin):
-    plugin_type = type(plugin.plugin_object)
-    plugin_type.__errdoc__ = plugin_type.__doc__ if plugin_type.__doc__ else plugin.description
+def populate_doc(plugin_info: PluginInfo) -> None:
+    plugin_class = type(plugin_info.plugin_object)
+    plugin_class.__errdoc__ = plugin_class.__doc__ if plugin_class.__doc__ else plugin_info.description
+    plugin_class.__errname__ = plugin_info.name
 
 
 def install_packages(req_path):

--- a/errbot/streaming.py
+++ b/errbot/streaming.py
@@ -49,7 +49,7 @@ class Tee(object):
                 self.clients[index].callback_stream(streams[index])
                 if streams[index].status == STREAM_WAITING_TO_START:
                     streams[index].reject()
-                    plugin = self.clients[index].__class__.__name__
+                    plugin = self.clients[index].name
                     logging.warning("%s did not accept nor reject the incoming file transfer" % plugin)
                     logging.warning("I reject it as a fallback.")
             except Exception as _:

--- a/tests/base_backend_test.py
+++ b/tests/base_backend_test.py
@@ -42,6 +42,8 @@ SIMPLE_JSON_PLUGINS_INDEX = """
 
 
 class DummyBackend(ErrBot):
+
+
     def change_presence(self, status: str = ONLINE, message: str = '') -> None:
         pass
 
@@ -63,6 +65,10 @@ class DummyBackend(ErrBot):
         config = ShallowConfig()
         config.__dict__.update(sys.modules['errbot.config-template'].__dict__)
         bot_config_defaults(config)
+        
+        # It injects itself as a plugin. Changed the name to be sure we distinguish it.
+        self.name = 'DummyBackendRealName'
+
         config.BOT_DATA_DIR = tempdir
         config.BOT_LOG_FILE = tempdir + sep + 'log.txt'
         config.BOT_PLUGIN_INDEXES = tempdir + sep + 'repos.json'
@@ -712,7 +718,7 @@ def test_access_controls(dummy_backend):
         # ACCESS_CONTROLS scenarios WITH wildcards (>=4.0 format)
         dict(
             message=makemessage(dummy_backend, "!command"),
-            acl={'DummyBackend:command': {'denyusers': ('noterr',)}},
+            acl={'DummyBackendRealName:command': {'denyusers': ('noterr',)}},
             expected_response="You're not allowed to access this command from this user"
         ),
         dict(
@@ -722,15 +728,15 @@ def test_access_controls(dummy_backend):
         ),
         dict(
             message=makemessage(dummy_backend, "!command"),
-            acl={'DummyBackend:*': {'denyusers': ('noterr',)}},
+            acl={'DummyBackendRealName:*': {'denyusers': ('noterr',)}},
             expected_response="You're not allowed to access this command from this user"
         ),
         # Overlapping globs should use first match
         dict(
             message=makemessage(dummy_backend, "!command"),
             acl=OrderedDict([
-                ('DummyBackend:*', {'denyusers': ('noterr',)}),
-                ('DummyBackend:command', {'denyusers': ()})
+                ('DummyBackendRealName:*', {'denyusers': ('noterr',)}),
+                ('DummyBackendRealName:command', {'denyusers': ()})
             ]),
             expected_response="You're not allowed to access this command from this user"
         ),

--- a/tests/base_backend_test.py
+++ b/tests/base_backend_test.py
@@ -43,7 +43,6 @@ SIMPLE_JSON_PLUGINS_INDEX = """
 
 class DummyBackend(ErrBot):
 
-
     def change_presence(self, status: str = ONLINE, message: str = '') -> None:
         pass
 
@@ -65,7 +64,7 @@ class DummyBackend(ErrBot):
         config = ShallowConfig()
         config.__dict__.update(sys.modules['errbot.config-template'].__dict__)
         bot_config_defaults(config)
-        
+
         # It injects itself as a plugin. Changed the name to be sure we distinguish it.
         self.name = 'DummyBackendRealName'
 

--- a/tests/dyna_plugin/dyna.py
+++ b/tests/dyna_plugin/dyna.py
@@ -14,13 +14,13 @@ class Dyna(BotPlugin):
         simple1 = Command(lambda plugin, msg, args: 'yep %s' % type(plugin), name='say_yep')
         simple2 = Command(say_foo)
 
-        self.create_dynamic_plugin('simple', (simple1, simple2), doc='documented')
+        self.create_dynamic_plugin('simple with special#', (simple1, simple2), doc='documented')
 
         return 'added'
 
     @botcmd
     def remove_simple(self, msg, args):
-        self.destroy_dynamic_plugin('simple')
+        self.destroy_dynamic_plugin('simple with special#')
         return 'removed'
 
     @botcmd


### PR DESCRIPTION
It is recorded beside the doc at `cls.__errname__` so it can be reused.
