### PR TITLE
Fix extracting Slack identifier w/piped username

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -648,6 +648,7 @@ class SlackBackend(ErrBot):
 
             <#C12345>
             <@U12345>
+            <@U12345|user>
             @user
             #channel/user
             #channel
@@ -657,7 +658,7 @@ class SlackBackend(ErrBot):
         """
         exception_message = (
             "Unparseable slack identifier, should be of the format `<#C12345>`, `<@U12345>`, "
-            "`@user`, `#channel/user` or `#channel`. (Got `%s`)"
+            "`<@U12345|user>`, `@user`, `#channel/user` or `#channel`. (Got `%s`)"
         )
         text = text.strip()
 
@@ -678,7 +679,10 @@ class SlackBackend(ErrBot):
             if text == "":
                 raise ValueError(exception_message % "")
             if text[0] in ('U', 'B'):
-                userid = text
+                if '|' in text:
+                    userid, username = text.split('|')
+                else:
+                    userid = text
             elif text[0] in ('C', 'G', 'D'):
                 channelid = text
             else:

--- a/tests/backend_tests/slack_tests.py
+++ b/tests/backend_tests/slack_tests.py
@@ -128,6 +128,11 @@ class SlackTests(unittest.TestCase):
         )
 
         self.assertEqual(
+            extract_from("<@U12345|UName>"),
+            ("UName", "U12345", None, None)
+        )
+
+        self.assertEqual(
             extract_from("<@B12345>"),
             (None, "B12345", None, None)
         )


### PR DESCRIPTION
The channel leave event (and possibly others), return the user
id piped with the username, i.e.:

```
{
    "type": "message",
    "subtype": "channel_leave",
    "ts": "1358877455.000010",
    "user": "U2147483828",
    "text": "<@U2147483828|cal> has left the channel"
}
```

This commit updates extract_identifiers_from_string to allow this