### PR TITLE
Clarify warning about system encoding.

### DIFF
--- a/errbot/cli.py
+++ b/errbot/cli.py
@@ -31,7 +31,7 @@ log = logging.getLogger(__name__)
 if locale.getpreferredencoding().lower() != 'utf-8':
     log.warning('Starting errbot with a default system encoding other than \'utf-8\''
                 ' might cause you a heap of troubles.'
-                ' Your current encoding is set at \'%s\'' % sys.getdefaultencoding())
+                ' Your current encoding is set at \'%s\'' % locale.getpreferredencoding().lower())
 
 
 # noinspection PyUnusedLocal


### PR DESCRIPTION
Sys and locale can have different ideas about what encoding will be
used, and checking one but echoing the other can be weird.

Locale module seems like the source of truth in practice.

Fixes issue #821