### PR TITLE
Fixing room references from the Slack mobile client.

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -796,7 +796,7 @@ class SlackBackend(ErrBot):
         """
         mentioned = []
 
-        m = re.findall('<@[^>]*>*', text)
+        m = re.findall('<[@#][^>]*>*', text)
 
         for word in m:
             try:
@@ -809,6 +809,9 @@ class SlackBackend(ErrBot):
             if isinstance(identifier, SlackPerson):
                 log.debug('Someone mentioned')
                 mentioned.append(identifier)
+                text = text.replace(word, str(identifier))
+            elif isinstance(identifier, SlackRoom):
+                log.debug('Room mentioned')
                 text = text.replace(word, str(identifier))
 
         return text, mentioned

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -647,6 +647,7 @@ class SlackBackend(ErrBot):
         Supports strings with the following formats::
 
             <#C12345>
+            <#C12345|channelname>
             <@U12345>
             <@U12345|user>
             @user
@@ -684,7 +685,10 @@ class SlackBackend(ErrBot):
                 else:
                     userid = text
             elif text[0] in ('C', 'G', 'D'):
-                channelid = text
+                if '|' in text:
+                    channelid, channelname = text.split('|')
+                else:
+                    channelid = text
             else:
                 raise ValueError(exception_message % text)
         elif text[0] == '@':


### PR DESCRIPTION
This fixes room references from the Slack mobile client, which sends room references in the form <#C12345|channelname>.