### PR TITLE
Customizable self identity check per backend

### DIFF
--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -752,6 +752,18 @@ class Backend(ABC):
     def build_identifier(self, text_representation: str) -> Identifier:
         pass
 
+    def is_from_self(self, msg: Message) -> bool:
+        """
+        Needs to be overridden to check if the incoming message is from the bot itself.
+
+        :param msg: The incoming message.
+        :return: True if the message is coming from the bot.
+        """
+        # Default implementation (XMPP-like check using an extra config).
+        # Most of the backends should have a better way to determine this.
+        return (msg.is_direct and msg.frm == self.bot_identifier) or \
+               (msg.is_group and msg.frm.nick == self.bot_config.CHATROOM_FN)
+
     def serve_once(self) -> None:
         """
         Connect the back-end to the server and serve a connection once

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -726,6 +726,9 @@ class SlackBackend(ErrBot):
             "to be resolved but none of them were. This shouldn't happen so, please file a bug."
         )
 
+    def is_from_self(self, msg: Message) -> bool:
+        return self.bot_identifier.userid == msg.frm.userid
+
     def build_reply(self, mess, text=None, private=False):
         response = self.build_message(text)
         response.frm = self.bot_identifier

--- a/errbot/core.py
+++ b/errbot/core.py
@@ -218,8 +218,7 @@ class ErrBot(Backend, StoreMixin):
             log.debug("Message from history, ignore it")
             return False
 
-        if (mess.is_direct and frm == self.bot_identifier) or \
-                (mess.is_group and frm.nick == self.bot_config.CHATROOM_FN):
+        if self.is_from_self(mess):
             log.debug("Ignoring message from self")
             return False
 


### PR DESCRIPTION
This fixes #819.

And potentially individual backends will have a better and simpler
self-check out of that.