### PR TITLE
Fix bug in user guide

### DIFF
--- a/docs/user_guide/plugin_development/messaging.rst
+++ b/docs/user_guide/plugin_development/messaging.rst
@@ -124,7 +124,7 @@ The following code demonstrate the various available fields.
 
     class Travel(BotPlugin):
         @botcmd
-        def send_card(self, msg, args):
+        def hello_card(self, msg, args):
             """Say a card in the chatroom."""
             self.send_card(title='Title + Body',
                            body='text body to put in the card',


### PR DESCRIPTION
In the send_card example the choice of re-using send_card for the bot method name meant self.send_card was calling that instead of the actual parent implementation. Probably a better idea to use a different command method name?