### PR TITLE
Use pip from subprocess instead of package

### DIFF
--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -1,11 +1,11 @@
 """ Logic related to plugin loading and lifecycle """
-import traceback
 from configparser import NoSectionError, NoOptionError, ConfigParser
 from importlib import machinery, import_module
 import logging
-import sys
 import os
-import pip
+import subprocess
+import sys
+import traceback
 from yapsy import PluginInfo
 
 from errbot.flow import BotFlow

--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -1,7 +1,7 @@
 """ Logic related to plugin loading and lifecycle """
 import traceback
 from configparser import NoSectionError, NoOptionError, ConfigParser
-from importlib.machinery import SourceFileLoader
+from importlib import machinery, import_module
 import logging
 import sys
 import os
@@ -60,7 +60,7 @@ def install_package(package):
         # otherwise only install it as a user package
         pip.main(['install', '--user', package])
     try:
-        globals()[package] = importlib.import_module(package)
+        globals()[package] = import_module(package)
     except:
         log.exception("Failed to load the dependent package")
         return sys.exc_info()
@@ -346,7 +346,7 @@ class BotPluginManager(PluginManager, StoreMixin):
         module_alias = plugin.plugin_object.__module__
         module_old = __import__(module_alias)
         f = module_old.__file__
-        module_new = SourceFileLoader(module_alias, f).load_module(module_alias)
+        module_new = machinery.SourceFileLoader(module_alias, f).load_module(module_alias)
         class_name = type(plugin.plugin_object).__name__
         new_class = getattr(module_new, class_name)
         plugin.plugin_object.__class__ = new_class

--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -55,10 +55,11 @@ def install_package(package):
     log.info("Installing package '%s'." % package)
     if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and (sys.base_prefix != sys.prefix)):
         # this is a virtualenv, so we can use it directly
-        pip.main(['install', package])
+        p = subprocess.Popen(['pip', 'install', package])
     else:
         # otherwise only install it as a user package
-        pip.main(['install', '--user', package])
+        p = subprocess.Popen(['pip', 'install', '--user', package])
+    p.wait()
     try:
         globals()[package] = import_module(package)
     except:


### PR DESCRIPTION
This PR fixes #835. It has been tested in python3 venv with `AUTOINSTALL_DEPS = True` while installing a plugin containing a `requierements.txt`:
- with empty venv and fresh plugin installation and `BOT_ASYNC = True`
- with empty venv and fresh plugin installation and `BOT_ASYNC = False`
- with empty venv and already installed plugin and `BOT_ASYNC = True` (this was broken)
- with empty venv and already installed plugin and `BOT_ASYNC = False` 
- with venv containing all the requierements

The last two cases are typical Docker installation usage, the data directory might be persistant but the virtual env might not, causing the bot to fail the plugin at re-install with BOT_ASYNC is True.


It also has an additional commit (66c70b9) fixing a bug of a badly imported module at L63 throwing more cosmetic errors (the newly packages were loaded by the plugin anyway?).