### PR TITLE
Adding support for stream requests to the Slack backend.

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -585,6 +585,8 @@ class SlackBackend(ErrBot):
     def send_stream_request(self, identifier, fsource, name='file', size=None, stream_type=None):
         """Starts a file transfer. For Slack, the size and stream_type are unsupported"""
         stream = Stream(identifier, fsource, name, size, stream_type)
+        log.debug("Requesting upload of {0} to {1} (size hint: {2}, stream type: {3})".format(name,
+                  identifier.channelname, size, stream_type))
         self.thread_pool.putRequest(WorkRequest(self._slack_upload, args=(stream,)))
         return stream
 

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -565,9 +565,8 @@ class SlackBackend(ErrBot):
                 "to %s: %s" % (to_humanreadable, mess.body)
             )
 
-    def send_stream_request(self, identifier, fsource, name=None, size=None, stream_type=None):
+    def send_stream_request(self, identifier, fsource, name='file', size=None, stream_type=None):
         """Starts a file transfer. For Slack, the size and stream_type are unsupported"""
-        name = name if name else 'file'
         stream = Stream(identifier, fsource, name, size, stream_type)
         log.debug('Initiating upload of {0}'.format(name))
         resp = self.api_call('files.upload', data={

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -568,16 +568,19 @@ class SlackBackend(ErrBot):
 
     def _slack_upload(self, stream):
         """Perform upload defined in a stream."""
-        stream.accept()
-        resp = self.api_call('files.upload', data={
-            'channels': stream.identifier.channelid,
-            'filename': stream.name,
-            'file': stream
-            })
-        if "ok" in resp and resp["ok"]:
-            stream.success()
-        else:
-            stream.error()
+        try:
+            stream.accept()
+            resp = self.api_call('files.upload', data={
+                'channels': stream.identifier.channelid,
+                'filename': stream.name,
+                'file': stream
+                })
+            if "ok" in resp and resp["ok"]:
+                stream.success()
+            else:
+                stream.error()
+        except:
+            log.exception("Upload of {0} to {1} failed.".format(stream.name, stream.identifier.channelname))
 
     def send_stream_request(self, identifier, fsource, name='file', size=None, stream_type=None):
         """Starts a file transfer. For Slack, the size and stream_type are unsupported"""


### PR DESCRIPTION
This allows files to be uploaded to Slack using the stream interface. Slack's API for file uploads appears to be a blocking interface, so the Stream returned from the `send_stream_request()` function is marked successful or errored upon return.