### PR TITLE
Update docs for slack bot prefix feature

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ sphinx>=1.2
 # is fixed and included into a new release.
 https://github.com/zoni/sphinx-autodoc-annotation/archive/issue-2.zip
 
--e .
+-e ../.
 sleekxmpp
 irc
 pyfire

--- a/docs/user_guide/configuration/slack.rst
+++ b/docs/user_guide/configuration/slack.rst
@@ -36,8 +36,10 @@ Bot admins
 ----------
 
 You can set `BOT_ADMINS` to configure which Slack users are bot administrators.
-Make sure to include the `@` sign.
-For example: `BOT_ADMINS = ('@gbin', '@zoni')`
+Make sure to include the `@` sign::
+
+    BOT_ADMINS = ('@gbin', '@zoni')
+
 
 Bot mentions using @
 --------------------

--- a/docs/user_guide/configuration/slack.rst
+++ b/docs/user_guide/configuration/slack.rst
@@ -42,10 +42,10 @@ For example: `BOT_ADMINS = ('@gbin', '@zoni')`
 Bot mentions using @
 --------------------
 
-To enable using the bot's name in `BOT_ALT_PREFIXES` for @mentions in Slack, you must use the bot's SlackID.
+To enable using the bot's name in `BOT_ALT_PREFIXES` for @mentions in Slack, simply add the bot's name as follows::
 
-1. Find the bot's Slack ID. You can obtain this using Slack's [API tester](https://api.slack.com/methods/users.list) or by inspecting the errbot debug logs (by setting `BOT_LOG_LEVEL = logging.DEBUG`). It should look like `U023BECGF`.
-2. Enter this ID in `BOT_ALT_PREFIXES` in the form: `<@ID_NUMBER>`. For the example above it would be `<@U023BECGF>`.
+    BOT_ALT_PREFIXES = ('@botname',)
+
 
 Channels/groups
 ---------------


### PR DESCRIPTION
Update documentation to include references regarding using the botname as a bot prefix in slack backend.

See #768 