### PR TITLE
fix: Sending group messages to IRC channels

### DIFF
--- a/errbot/backends/irc.py
+++ b/errbot/backends/irc.py
@@ -713,8 +713,10 @@ class IRCBackend(ErrBot):
 
     def build_identifier(self, txtrep):
         log.debug("Build identifier from [%s]" % txtrep)
+        # A textual representation starting with # means that we are talking
+        # about an IRC channel -- IRCRoom in internal err-speak.
         if txtrep.startswith('#'):
-            return IRCRoomOccupant(None, txtrep)
+            return IRCRoom(txtrep, self)
 
         # Occupants are represented as 2 lines, one is the IRC mask and the second is the Room.
         if '\n' in txtrep:


### PR DESCRIPTION
* IRC backend's `build_identifier` [returns an instance of
  `IRCRoomOccupant`](https://github.com/errbotio/errbot/blob/25284b9df2cd5615a4859af60a1d3f138b58f658/errbot/backends/irc.py#L716) when asked to create an identifier for an IRC
  channel (i.e. `#errbot`). However, since the `IRCRoomOccupant` class
  [inherits class `IRCPerson`](https://github.com/errbotio/errbot/blob/25284b9df2cd5615a4859af60a1d3f138b58f658/errbot/backends/irc.py#L123) which in turn [inherits class `Person`](https://github.com/errbotio/errbot/blob/25284b9df2cd5615a4859af60a1d3f138b58f658/errbot/backends/irc.py#L75), the
  Base backend will evaluate a message sent to an identifier created in
  such a way as a ['direct'](https://github.com/errbotio/errbot/blob/25284b9df2cd5615a4859af60a1d3f138b58f658/errbot/backends/base.py#L344) one. This is clearly not desirable, as [direct
  messages are sent to the `person` attribute of the Identifier](https://github.com/errbotio/errbot/blob/25284b9df2cd5615a4859af60a1d3f138b58f658/errbot/backends/irc.py#L661), which
  would be `None` in this case.

  All in all, this means that it is impossible to send group messages to
  IRC channels, while following proper procedures.

* This commit changes the behavior of `build_identifier` so that it
  returns an instance of `IRCRoom` when asked to create an identifier
  for an IRC channel. This makes group messages to IRC channels work
  again.

Signed-off-by: mr.Shu <mr@shu.io>