### PR TITLE
Escape asterisk when displaying name in help output

### DIFF
--- a/errbot/core_plugins/help.py
+++ b/errbot/core_plugins/help.py
@@ -155,6 +155,6 @@ class Help(BotPlugin):
             if len(cmd_doc) > 80:
                 cmd_doc = '{doc}...'.format(doc=cmd_doc[:77])
 
-        help_str = '- **{prefix}{name}** - {doc}\n'.format(prefix=prefix, name=name, doc=cmd_doc)
+        help_str = '- **{prefix}{name}** - {doc}\n'.format(prefix=prefix, name=name.replace('*', '\*'), doc=cmd_doc)
 
         return help_str


### PR DESCRIPTION
If the name of the command includes an asterisk (for example in an re_botcmd regex) ensure the asterisk is escaped to avoid incorrectly formatted markdown
