### PR TITLE
Allow configurable SSL verification for Hipchat Backend

### DIFF
--- a/docs/user_guide/configuration/hipchat.rst
+++ b/docs/user_guide/configuration/hipchat.rst
@@ -41,13 +41,15 @@ You can now configure the account by setting up `BOT_IDENTITY` as follows::
         # If you're using HipChat server (self-hosted HipChat) then you should set
         # the endpoint below. If you don't use HipChat server but use the hosted version
         # of HipChat then you may leave this commented out.
-        # 'endpoint' : 'https://api.hipchat.com'
-
+        # 'endpoint' : 'https://api.hipchat.com',
+        # If your self-hosted Hipchat server is using SSL, and your certificate
+        # is self-signed, set verify to False or hypchat will fail
+        # 'verify': False,
 
 Bot admins
 ----------
 
-You can set `BOT_ADMINS` to configure which Slack users are bot administrators.
+You can set `BOT_ADMINS` to configure which Hipchat users are bot administrators.
 Make sure to include the `@` sign.
 For example: `BOT_ADMINS = ('@gbin', '@zoni')`
 

--- a/errbot/backends/hipchat.py
+++ b/errbot/backends/hipchat.py
@@ -346,12 +346,15 @@ class HipchatClient(XMPPConnection):
     def __init__(self, *args, **kwargs):
         self.token = kwargs.pop('token')
         self.endpoint = kwargs.pop('endpoint')
+        verify = kwargs.pop('verify')
+        if verify is None:
+            verify = True
         if self.endpoint is None:
-            self.hypchat = hypchat.HypChat(self.token)
+            self.hypchat = hypchat.HypChat(self.token, verify=verify)
         else:
             # We could always pass in the endpoint, with a default value if it's
             # None, but this way we support hypchat<0.18
-            self.hypchat = hypchat.HypChat(self.token, endpoint=self.endpoint)
+            self.hypchat = hypchat.HypChat(self.token, endpoint=self.endpoint, verify=verify)
         super().__init__(*args, **kwargs)
 
     @property

--- a/errbot/backends/hipchat.py
+++ b/errbot/backends/hipchat.py
@@ -378,6 +378,7 @@ class HipchatBackend(XMPPBackend):
     def __init__(self, config):
         self.api_token = config.BOT_IDENTITY['token']
         self.api_endpoint = config.BOT_IDENTITY.get('endpoint', None)
+        self.api_verify = config.BOT_IDENTITY.get('verify', True)
         self.md = hipchat_html()
         super().__init__(config)
 
@@ -396,7 +397,8 @@ class HipchatBackend(XMPPBackend):
             ca_cert=self.ca_cert,
             token=self.api_token,
             endpoint=self.api_endpoint,
-            server=self.server
+            server=self.server,
+            verify=self.api_verify,
         )
 
     def callback_message(self, mess):


### PR DESCRIPTION
Support for self-signed Hipchat server connections:

When using an alternate/internal Hipchat server, there's a good chance that if it's using SSL the certificate will be self-signed. This change adds a `verify` config that passes through to the hypchat client so that it can connect to servers with self-signed (non-verifiable) SSL certificates.

`verify` defaults to `True` to preserve current behavior.

Tested with Hipchat Server (could not find the version but it's a version or so behind)