### PR TITLE
docs: Add example init daemon configs (#726)

### DIFF
--- a/docs/code_examples/supervisord.conf
+++ b/docs/code_examples/supervisord.conf
@@ -1,0 +1,5 @@
+[program:errbot]
+directory=/etc/errbot
+command=/path/to/my/virtualenv/bin/errbot
+autostart=true
+autorestart=true

--- a/docs/code_examples/supervisord.conf
+++ b/docs/code_examples/supervisord.conf
@@ -1,5 +1,10 @@
 [program:errbot]
-directory=/etc/errbot
-command=/path/to/my/virtualenv/bin/errbot
-autostart=true
-autorestart=true
+command = /path/to/errbot/virtualenv/bin/errbot --config /path/to/errbot/config.py
+user = errbot
+stdout_logfile = /var/log/supervisor/errbot.log
+stderr_logfile = NONE
+redirect_stderr = true
+directory = /path/to/errbot/
+startsecs = 3
+stopsignal = INT
+environment = LC_ALL="en_US.UTF-8"

--- a/docs/code_examples/systemd.service
+++ b/docs/code_examples/systemd.service
@@ -3,4 +3,8 @@ Description=Start Errbot chatbot
 After=network.service
 
 [Service]
-ExecStart=/path/to/my/virtualenv/bin/errbot --daemon --config /etc/errbot/config.py
+Type=forking
+Environment="LC_ALL=en_US.UTF-8"
+ExecStart=/path/to/errbot/virtualenv/bin/errbot --daemon --config /path/to/errbot/config.py
+WorkingDirectory=/path/to/errbot/
+User=errbot

--- a/docs/code_examples/systemd.service
+++ b/docs/code_examples/systemd.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Start Errbot chatbot
+After=network.service
+
+[Service]
+ExecStart=/path/to/my/virtualenv/bin/errbot --daemon --config /etc/errbot/config.py

--- a/docs/code_examples/systemd.service
+++ b/docs/code_examples/systemd.service
@@ -3,8 +3,7 @@ Description=Start Errbot chatbot
 After=network.service
 
 [Service]
-Type=forking
 Environment="LC_ALL=en_US.UTF-8"
-ExecStart=/path/to/errbot/virtualenv/bin/errbot --daemon --config /path/to/errbot/config.py
+ExecStart=/path/to/errbot/virtualenv/bin/errbot --config /path/to/errbot/config.py
 WorkingDirectory=/path/to/errbot/
 User=errbot

--- a/docs/code_examples/systemd.service
+++ b/docs/code_examples/systemd.service
@@ -7,3 +7,5 @@ Environment="LC_ALL=en_US.UTF-8"
 ExecStart=/path/to/errbot/virtualenv/bin/errbot --config /path/to/errbot/config.py
 WorkingDirectory=/path/to/errbot/
 User=errbot
+Restart=always
+KillSignal=SIGINT

--- a/docs/user_guide/setup.rst
+++ b/docs/user_guide/setup.rst
@@ -148,6 +148,20 @@ is outside the scope of this document however.
 
     If you're running errbot in the foreground then pressing Ctrl+C is equivalent to sending `SIGINT`.
 
+Daemon Configurations
+^^^^^^^^^^^^^^^^^^^^^
+
+These are a few example configurations using common init daemons:
+
+**supervisord** (`/etc/supervisor/conf.d/errbot.conf`)
+
+.. literalinclude:: ../code_examples/supervisord.conf
+    :language: sh
+
+**systemd** (`/etc/systemd/system/errbot.service`)
+
+.. literalinclude:: ../code_examples/systemd.service
+    :language: sh
 
 Upgrading
 ---------


### PR DESCRIPTION
An idea to add the example daemon init script to the docs.

Examples are trimmed down from issue #726.

Alternatively, I could add this to a `contrib/` directory in the codebase. I thought, having it in the docs was more visible for new users.
