### PR TITLE
Increase the efficiency of the Slack backend for busy instances

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -319,9 +319,12 @@ class SlackBackend(ErrBot):
 
             try:
                 while True:
-                    for message in self.sc.rtm_read():
-                        self._dispatch_slack_message(message)
-                    time.sleep(1)
+                    messages = self.sc.rtm_read()
+                    if messages:
+                        for message in messages:
+                            self._dispatch_slack_message(message)
+                    else:
+                        time.sleep(1)
             except KeyboardInterrupt:
                 log.info("Interrupt received, shutting down..")
                 return True


### PR DESCRIPTION
SlackClient.rtm_read ultimately calls a function that can only return one websocket frame at a a time. Used in this way, errbot will only process one message at a time. With a 1 sec pause between messages, errbot can end up taking a long time before it processes commands on a busy Slack instance.