### PR TITLE
Don't sanitize slack file_share event texts.

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -423,7 +423,8 @@ class SlackBackend(ErrBot):
 
         text, mentioned = self.process_mentions(text)
 
-        text = self.sanitize_uris(text)
+        if subtype != 'file_share':
+            text = self.sanitize_uris(text)
 
         log.debug("Saw an event: %s" % pprint.pformat(event))
         log.debug("Escaped IDs event text: %s" % text)


### PR DESCRIPTION
Fixes #872 