### PR TITLE
Feature: use conftest to register fixture instead of importing

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = ['errbot.backends.test']

--- a/docs/user_guide/plugin_development/testing.rst
+++ b/docs/user_guide/plugin_development/testing.rst
@@ -38,24 +38,23 @@ This does absolutely nothing shocking, but how do you test it?
 We need to interact with the bot somehow, send it `!mycommand` and validate the reply.
 Fortunatly Errbot provides some help.
 
+
+
 Our test, *test_myplugin.py*:
 
 .. code-block:: python
 
-    import os
-    from errbot.backends.test import testbot
+    pytest_plugins = ["errbot.backends.test"]
 
+    extra_plugin_dir = '.'
 
-    class TestMyPlugin(object):
-        extra_plugin_dir = '.'
+    def test_command(testbot):
+        testbot.push_message('!mycommand')
+        assert 'This is my awesome command' in testbot.pop_message()
 
-        def test_command(self, testbot):
-            testbot.push_message('!mycommand')
-            assert 'This is my awesome command' in testbot.pop_message()
+Lets walk through this line for line. First of all, we specify our pytest fixture location :class:`~errbot.backends.test` in the backends tests, to allow us to spin up a bot for testing purposes and interact with the message queue. To avoid specifying the module in every test module, you can simply place this line in your conftest.py_.
 
-Lets walk through this line for line. First of all, we import :class:`~errbot.backends.test.testbot` from the backends tests, to allow us to spin up a bot for testing purposes and interact with the message queue.
-
-Then we define our own test class and inside of it we set `extra_plugin_dir` to `.`, the current directory so that the test bot will pick up on your plugin.
+Then we set `extra_plugin_dir` to `.`, the current directory so that the test bot will pick up on your plugin.
 
 After that we define our first `test_` method which simply sends a command to the bot using :func:`~errbot.backends.test.TestBot.push_message` and then asserts that the response we expect, *"This is my awesome command"* is in the message we receive from the bot which we get by calling :func:`~errbot.backends.test.TestBot.pop_message`.
 
@@ -85,12 +84,10 @@ Such methods can be tested very easily, without needing a bot:
 
     import myplugin
 
-    class TestMyPlugin(object):
-
-        def test_mycommand_helper(self):
-            expected = "This is my awesome command"
-            result = myplugin.MyPlugin.mycommand_helper()
-            assert result == expected
+    def test_mycommand_helper():
+        expected = "This is my awesome command"
+        result = myplugin.MyPlugin.mycommand_helper()
+        assert result == expected
 
 Here we simply import `myplugin` and since it's a `@staticmethod` we can directly access it through `myplugin.MyPlugin.method()`.
 
@@ -112,17 +109,13 @@ What we need now is get access to the instance of our plugin itself. Fortunately
 
 .. code-block:: python
 
-    import os
-    from errbot.backends.test import testbot
+    extra_plugin_dir = '.'
 
-    class TestMyPlugin(object)
-        extra_plugin_dir = '.'
-
-        def test_mycommand_helper(self, testbot):
-            plugin = testbot.bot.plugin_manager.get_plugin_obj_by_name('MyPlugin')
-            expected = "This is my awesome command"
-            result = plugin.mycommand_helper()
-            assert result == expected
+    def test_mycommand_helper(testbot):
+        plugin = testbot._bot.plugin_manager.get_plugin_obj_by_name('MyPlugin')
+        expected = "This is my awesome command"
+        result = plugin.mycommand_helper()
+        assert result == expected
 
 There we go, we first grab out plugin thanks to a helper method on :mod:`~errbot.plugin_manager` and then simply execute the method and compare what we get with what we expect. You can also access `@classmethod` or `@staticmethod` methods this way, you just don't have to.
 
@@ -177,39 +170,28 @@ All together now
 
 .. code-block:: python
 
-    import os
-    import unittest
     import myplugin
-    from errbot.backends.test import testbot
 
-    class TestMyPluginBot(object):
-        extra_plugin_dir = '.'
+    extra_plugin_dir = '.'
 
-        def test_mycommand(self, testbot):
-            testbot.push_message('!mycommand')
-            assert 'This is my awesome command' in testbot.pop_message()
+    def test_mycommand(testbot):
+        testbot.push_message('!mycommand')
+        assert 'This is my awesome command' in testbot.pop_message()
 
-        def test_mycommand_another(self, testbot):
-            testbot.push_message('!mycommand another')
-            assert 'This is another awesome command' in testbot.pop_message()
+    def test_mycommand_another(testbot):
+        testbot.push_message('!mycommand another')
+        assert 'This is another awesome command' in testbot.pop_message()
 
+    def test_mycommand_helper():
+        expected = "This is my awesome command"
+        result = myplugin.MyPlugin.mycommand_helper()
+        assert result == expected
 
-    class TestMyPluginStaticMethods(object):
-
-        def test_mycommand_helper(self):
-            expected = "This is my awesome command"
-            result = myplugin.MyPlugin.mycommand_helper()
-            assert result == expected
-
-
-    class TestMyPluginInstanceMethods(object):
-        extra_plugin_dir = '.'
-
-        def test_mycommand_another_helper(self):
-            plugin = self._bot.plugin_manager.get_plugin_obj_by_name('MyPlugin')
-            expected = "This is another awesome command"
-            result = plugin.mycommand_another_helper()
-            assert result == expected
+    def test_mycommand_another_helper():
+        plugin = testbot._bot.plugin_manager.get_plugin_obj_by_name('MyPlugin')
+        expected = "This is another awesome command"
+        result = plugin.mycommand_another_helper()
+        assert result == expected
 
 You can now simply run :command:`py.test` to execute the tests.
 
@@ -265,6 +247,7 @@ The `-q` flag causes pip to be a lot more quiet and `--use-wheel` will cause pip
 Both Travis-CI and Coveralls easily integrate with Github hosted code.
 
 .. _py.test: http://pytest.org
+.. _conftest.py: http://doc.pytest.org/en/latest/writing_plugins.html#conftest-py-local-per-directory-plugins
 .. _Coveralls.io: https://coveralls.io
 .. _Travis-CI: https://travis-ci.org
 .. _Yapsy: http://yapsy.sourceforge.net

--- a/errbot/backends/test.py
+++ b/errbot/backends/test.py
@@ -504,8 +504,6 @@ def testbot(request) -> TestBot:
     For example, if you wanted to test the builtin `!about` command,
     you could write a test file with the following::
 
-        from errbot.backends.test import testbot
-
         def test_about(testbot):
             testbot.push_message('!about')
             assert "Err version" in testbot.pop_message()
@@ -514,8 +512,6 @@ def testbot(request) -> TestBot:
     by setting variables at module level or as class attributes (the
     latter taking precedence over the former). For example::
 
-        from errbot.backends.test import testbot
-
         extra_plugin_dir = '/foo/bar'
 
         def test_about(testbot):
@@ -523,8 +519,6 @@ def testbot(request) -> TestBot:
             assert "Err version" in testbot.pop_message()
 
     ..or::
-
-        from errbot.backends.test import testbot
 
         extra_plugin_dir = '/foo/bar'
 

--- a/errbot/flow.py
+++ b/errbot/flow.py
@@ -24,6 +24,7 @@ class FlowNode(object):
 
     The predicate is a function that takes one parameter, the context of the conversation.
     """
+
     def __init__(self, command: str=None):
         """
         Creates a FlowNone, takes the command to which the Node is linked to.

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -10,8 +10,6 @@ from tempfile import mkdtemp
 import pytest
 import tarfile
 
-from errbot.backends.test import testbot  # noqa
-
 extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), 'dummy_plugin')
 
 

--- a/tests/core_plugins_test.py
+++ b/tests/core_plugins_test.py
@@ -1,7 +1,5 @@
 import os
 
-from errbot.backends.test import testbot  # noqa
-
 extra_plugin_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'room_plugin')
 extra_config = {'CORE_PLUGINS': ('Help', 'Utils'), 'BOT_ALT_PREFIXES': ('!',), 'BOT_PREFIX': '$'}
 

--- a/tests/dependencies_test.py
+++ b/tests/dependencies_test.py
@@ -1,7 +1,5 @@
 import os
 
-from errbot.backends.test import testbot  # noqa
-
 extra_plugin_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'dependent_plugins')
 
 

--- a/tests/dynaplug_test.py
+++ b/tests/dynaplug_test.py
@@ -1,7 +1,5 @@
 from os import path
 
-from errbot.backends.test import testbot  # noqa
-
 extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), 'dyna_plugin')
 
 

--- a/tests/flow_e2e_test.py
+++ b/tests/flow_e2e_test.py
@@ -3,8 +3,6 @@ from queue import Empty
 
 import pytest
 
-from errbot.backends.test import testbot
-
 extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), 'flow_plugin')
 
 

--- a/tests/i18n_test.py
+++ b/tests/i18n_test.py
@@ -1,7 +1,5 @@
 # -*- coding=utf-8 -*-
 from os import path
-from errbot.backends.test import testbot
-
 # This is to test end2end i18n behavior.
 
 extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), 'i18n_plugin')

--- a/tests/mention_test.py
+++ b/tests/mention_test.py
@@ -1,4 +1,3 @@
-from errbot.backends.test import testbot
 from os import path
 
 extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), 'mention_plugin')

--- a/tests/muc_test.py
+++ b/tests/muc_test.py
@@ -1,6 +1,6 @@
 import os
 import errbot.backends.base
-from errbot.backends.test import testbot, TestOccupant
+from errbot.backends.test import TestOccupant
 import logging
 log = logging.getLogger(__name__)
 

--- a/tests/plugin_config_fail_test.py
+++ b/tests/plugin_config_fail_test.py
@@ -1,8 +1,5 @@
 from os import path
 
-import pytest
-from errbot.backends.test import testbot
-
 extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), 'fail_config_plugin')
 
 

--- a/tests/plugin_config_test.py
+++ b/tests/plugin_config_test.py
@@ -1,7 +1,5 @@
 from os import path
 
-import pytest
-from errbot.backends.test import testbot
 
 extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), 'config_plugin')
 

--- a/tests/syntax_test.py
+++ b/tests/syntax_test.py
@@ -1,4 +1,3 @@
-from errbot.backends.test import testbot
 from os import path
 
 extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), 'syntax_plugin')

--- a/tests/templates_test.py
+++ b/tests/templates_test.py
@@ -1,5 +1,4 @@
 from os import path
-from errbot.backends.test import testbot
 
 # This is to test end2end i18n behavior.
 


### PR DESCRIPTION
This is the de-facto method to register fixtures as far as I know, and should simplify writing tests, errbot's as well as for plugin developers.