### PR TITLE
Add the packaging metadata to build the errbot snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -18,5 +18,5 @@ parts:
   errbot:
     source: .
     plugin: python
-    build-packages: [libffi-dev, libssl-dev]
+    build-packages: [gcc, libffi-dev, libssl-dev]
     stage-packages: [git]

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -12,7 +12,7 @@ confinement: strict
 apps:
   errbot:
     command: env LC_ALL=C.UTF-8 errbot
-    plugs: [home, network]
+    plugs: [home, network, network-bind]
 
 parts:
   errbot:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,22 @@
+name: errbot
+version: master
+summary: chatbot that brings your tools into the conversation.
+description: |
+  Errbot is a chatbot. It allows you to start scripts interactively from your
+  chatrooms for any reason: random humour, chatops, starting a build, monitoring
+  commits, triggering alerts...
+
+grade: devel
+confinement: strict
+
+apps:
+  errbot:
+    command: env LC_ALL=C.UTF-8 errbot
+    plugs: [home, network]
+
+parts:
+  errbot:
+    source: .
+    plugin: python
+    build-packages: [libffi-dev, libssl-dev]
+    stage-packages: [git]


### PR DESCRIPTION
This is a package for the secure installation of apps that works in most Linux distributions.
Landing it upstream will enable builds for adventurous users.
