### PR TITLE
Slack: Process messages from webhook users

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -227,6 +227,12 @@ class SlackBot(SlackPerson):
     nick = username
 
     @property
+    def aclattr(self):
+        # Make ACLs match against integration ID rather than human-readable
+        # nicknames to avoid webhooks impersonating other people.
+        return "<%s>" % self._bot_id
+
+    @property
     def fullname(self):
         return None
 


### PR DESCRIPTION
These changes introduce new identifiers for bot users (which are special
kind of users on slack). This avoids crashing on messages sent via
webhook integration(s) and allows these messages to be processed similar
to regular user messages.

Example from a groupchat session:

```
webhookbot BOT [16:26]
.whoami

rafiki-development BOT [16:26]
┏━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ @webhookbot: ┃ key      ┃ value         ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│              │ person   │ `@webhookbot` │
├──────────────┼──────────┼───────────────┤
│              │ nick     │ `webhookbot`  │
├──────────────┼──────────┼───────────────┤
│              │ fullname │ `None`        │
├──────────────┼──────────┼───────────────┤
│              │ client   │ `None`        │
└──────────────┴──────────┴───────────────┘

`room` is #rafiki-dev
• string representation is '#rafiki-dev/webhookbot'
• class is 'SlackRoomBot'
```

(Webhook sent via: `curl -X POST --data-urlencode 'payload={"channel": "@rafiki-development", "username": "webhookbot", "text": ".whoami", "icon_emoji": ":ghost:"}' https://hooks.slack.com/services/secret/`)

Webhook messages sent as a private message are successfully processed as
well, with the caveat that attempting to respond will result in an
exception:

```
16:32:23 DEBUG    errbot.backends.slack     Saw an event: {'bot_id': 'B2Z3Q0GTH',
 'channel': 'D2Z350S4F',
 'icons': {'emoji': ':ghost:',
           'image_64': 'https://a.slack-edge.com/d4bf/img/emoji_2015_2/apple/1f47b.png'},
 'subtype': 'bot_message',
 'team': 'T0B1QFTC3',
 'text': '.whoami',
 'ts': '1478273542.000007',
 'type': 'message',
 'user_team': 'T0B1QFTC3',
 'username': 'webhookbot'}
16:32:23 DEBUG    errbot.backends.slack     Escaped IDs event text: .whoami
16:32:23 DEBUG    errbot.core               *** frm = @webhookbot
16:32:23 DEBUG    errbot.core               *** username = @webhookbot
16:32:23 DEBUG    errbot.core               *** text = .whoami
16:32:23 DEBUG    errbot.plugins.ACLS       Check whoami for ACLs.
16:32:23 INFO     errbot.plugins.ACLS       Matching ACL {} against username @webhookbot for command Utils:whoami
16:32:23 INFO     errbot.plugins.ACLS       Check if whoami is admin only command.
16:32:23 INFO     errbot.core               Processing command 'whoami' with parameters '' from @webhookbot
16:32:23 DEBUG    errbot.core               Triggering callback_message on Backup
16:32:23 DEBUG    errbot.core               Triggering callback_message on Utils
16:32:23 DEBUG    errbot.core               Triggering callback_message on Help
16:32:23 DEBUG    errbot.core               Triggering callback_message on Health
16:32:23 DEBUG    errbot.flow               Test if the command whoami is a trigger for an inflight flow ...
16:32:23 DEBUG    errbot.core               Triggering callback_message on VersionChecker
16:32:23 DEBUG    errbot.flow               None matched.
16:32:23 DEBUG    errbot.core               Triggering callback_message on Flows
16:32:23 DEBUG    errbot.backends.slack     Sending direct message to webhookbot (None)
16:32:23 DEBUG    errbot.core               Triggering callback_message on Plugins
16:32:23 DEBUG    errbot.backends.slack     Message size: 389
16:32:23 DEBUG    errbot.core               Triggering callback_message on ACLS
16:32:23 INFO     requests.packages.urllib3 Starting new HTTPS connection (1): slack.com
16:32:23 DEBUG    errbot.core               Triggering callback_message on ChatRoom
16:32:23 DEBUG    requests.packages.urllib3 "POST /api/chat.postMessage HTTP/1.1" 200 60
16:32:23 ERROR    errbot.backends.slack     An exception occurred while trying to send the following message to webhookbot: | key      | value
| -------- | --------
| person   | `@webhookbot`
| nick     | `webhookbot`
| fullname | `None`
| client   | `None`

- string representation is '@webhookbot'
- class is 'SlackBot'

Traceback (most recent call last):
  File "/x/errbot/backends/slack.py", line 630, in send_message
    'as_user': 'true',
  File "/x/errbot/backends/slack.py", line 326, in api_call
    error=response['error']
yapsy_loaded_plugin_Slack_0.SlackAPIResponseError: Slack API call to chat.postMessage failed: channel_not_found
```

Fixes #874