### PR TITLE
Enable symbolic links in paths of plugins.

### DIFF
--- a/errbot/utils.py
+++ b/errbot/utils.py
@@ -275,13 +275,16 @@ def find_roots(path, file_sig='*.plug'):
        :return: a set of paths
     """
     roots = set()  # you can have several .plug per directory.
-    for root, dirnames, filenames in os.walk(path):
+    for root, dirnames, filenames in os.walk(path, followlinks=True):
         for filename in fnmatch.filter(filenames, file_sig):
             dir_to_add = os.path.dirname(os.path.join(root, filename))
             relative = os.path.relpath(os.path.realpath(dir_to_add), os.path.realpath(path))
             for subelement in relative.split(os.path.sep):
-                if subelement != '.' and (subelement.startswith('.') or subelement == '__pycache__'):
-                    # this is not a directoty to consider
+                # if one of the element is just a relative construct, it is ok to continue inspecting it.
+                if subelement in ('.', '..'):
+                    continue
+                # if it is an hidden directory or a python temp directory, just ignore it.
+                if subelement.startswith('.') or subelement == '__pycache__':
                     log.debug("Ignore %s" % dir_to_add)
                     break
             else:

--- a/tests/link_test.py
+++ b/tests/link_test.py
@@ -1,11 +1,11 @@
 # coding=utf-8
-from os import path, mkdir
+from os import path
 
 import pytest
 
 extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), 'test_link')
 
+
 def test_linked_plugin_here(testbot):
     testbot.push_message('!status plugins')
     assert 'Dummy' in testbot.pop_message()
-

--- a/tests/link_test.py
+++ b/tests/link_test.py
@@ -1,0 +1,11 @@
+# coding=utf-8
+from os import path, mkdir
+
+import pytest
+
+extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), 'test_link')
+
+def test_linked_plugin_here(testbot):
+    testbot.push_message('!status plugins')
+    assert 'Dummy' in testbot.pop_message()
+

--- a/tests/test_link/dummy_plugin
+++ b/tests/test_link/dummy_plugin
@@ -1,0 +1,1 @@
+../dummy_plugin


### PR DESCRIPTION
It also correct a bug in the plugin path validation where '..' was
considered as a temporary directory because it started with '.'.
Fixes #896.
