### PR TITLE
Slack -- link names

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -633,6 +633,7 @@ class SlackBackend(ErrBot):
                     'channel': to_channel_id,
                     'text': part,
                     'unfurl_media': 'true',
+                    'link_names': '1',
                     'as_user': 'true',
                 })
         except Exception:
@@ -688,7 +689,13 @@ class SlackBackend(ErrBot):
         if card.fields:
             attachment['fields'] = [{'title': key, 'value': value, 'short': True} for key, value in card.fields]
 
-        data = {'text': ' ', 'channel': to_channel_id, 'attachments': json.dumps([attachment]), 'as_user': 'true'}
+        data = {
+            'text': ' ',
+            'channel': to_channel_id,
+            'attachments': json.dumps([attachment]),
+            'link_names': '1',
+            'as_user': 'true'
+        }
         try:
             log.debug('Sending data:\n%s', data)
             self.api_call('chat.postMessage', data=data)


### PR DESCRIPTION
Fixes https://github.com/errbotio/errbot/issues/892

I have tested this and @ names and # channels link fine, as well as `@here, @everyone` etc. The `<U398232>` and `<!here>` formats still work too, although other formats are mangled by the markdown formatter, as discussed on other cards.

Test plugin:

```python
from errbot import BotPlugin, botcm
import ast

class Example(BotPlugin):
    @botcmd
    def say(self, mess, args):
        result = ast.literal_eval(args.strip('`'))
        yield result
        self.send_card(title='title ' + result,
                body='body ' + result,
                color='blue',
                in_reply_to=mess)
```

Test messages: 

```
!say `'hi #' 'team'`
!say `'hi @' 'here'`
```

The backticks and the space prevent Slack from mangling my message on its way out - smart quotes, highlighting etc.