### PR TITLE
Use literalinclude of code samples in testing docs

### DIFF
--- a/docs/code_examples/plugin_development/myplugin.plug
+++ b/docs/code_examples/plugin_development/myplugin.plug
@@ -1,0 +1,6 @@
+[Core]
+Name = MyPlugin
+Module = myplugin
+
+[Documentation]
+Description = my plugin

--- a/docs/code_examples/plugin_development/myplugin.py
+++ b/docs/code_examples/plugin_development/myplugin.py
@@ -1,0 +1,17 @@
+from errbot import BotPlugin, botcmd
+
+class MyPlugin(BotPlugin):
+    @botcmd
+    def mycommand(self, message, args):
+        return self.mycommand_helper()
+
+    @botcmd
+    def mycommand_another(self, message, args):
+        return self.mycommand_another_helper()
+
+    @staticmethod
+    def mycommand_helper():
+        return "This is my awesome command"
+
+    def mycommand_another_helper(self):
+        return "This is another awesome command"

--- a/docs/code_examples/plugin_development/test_myplugin.py
+++ b/docs/code_examples/plugin_development/test_myplugin.py
@@ -1,0 +1,23 @@
+import myplugin
+
+pytest_plugins = ["errbot.backends.test"]
+extra_plugin_dir = '.'
+
+def test_mycommand(testbot):
+    testbot.push_message('!mycommand')
+    assert 'This is my awesome command' in testbot.pop_message()
+
+def test_mycommand_another(testbot):
+    testbot.push_message('!mycommand another')
+    assert 'This is another awesome command' in testbot.pop_message()
+
+def test_mycommand_helper():
+    expected = "This is my awesome command"
+    result = myplugin.MyPlugin.mycommand_helper()
+    assert result == expected
+
+def test_mycommand_another_helper():
+    plugin = testbot._bot.plugin_manager.get_plugin_obj_by_name('MyPlugin')
+    expected = "This is another awesome command"
+    result = plugin.mycommand_another_helper()
+    assert result == expected


### PR DESCRIPTION
Trying to simplify the testing docs code samples.