### PR TITLE
Telegram Person ID comes as Int and should be a String

### DIFF
--- a/errbot/backends/telegram_messenger.py
+++ b/errbot/backends/telegram_messenger.py
@@ -75,7 +75,7 @@ class TelegramIdentifier(Identifier):
 
 class TelegramPerson(TelegramIdentifier, Person):
     def __init__(self, id, first_name=None, last_name=None, username=None):
-        super().__init__(id)
+        super().__init__(str(id))
         self._first_name = first_name
         self._last_name = last_name
         self._username = username

--- a/errbot/backends/telegram_messenger.py
+++ b/errbot/backends/telegram_messenger.py
@@ -56,7 +56,7 @@ class TelegramBotFilter(object):
 
 class TelegramIdentifier(Identifier):
     def __init__(self, id):
-        self._id = id
+        self._id = str(id)
 
     @property
     def id(self):
@@ -75,7 +75,7 @@ class TelegramIdentifier(Identifier):
 
 class TelegramPerson(TelegramIdentifier, Person):
     def __init__(self, id, first_name=None, last_name=None, username=None):
-        super().__init__(str(id))
+        super().__init__(id)
         self._first_name = first_name
         self._last_name = last_name
         self._username = username


### PR DESCRIPTION
Fix issue where ADMIN commands were not working once Person ID was a int and should be a string.

Error when issueing a admin command:
`2016-12-13 22:26:11,980 INFO     errbot.plugins.ACLS       type of get_acl_usr(msg): <class 'int'>
2016-12-13 22:26:11,982 ERROR    errbot.core               Exception in a filter command, blocking the command in doubt
Traceback (most recent call last):
  File "/app/venv/lib/python3.4/site-packages/errbot/core.py", line 344, in _process_command_filters
    msg, cmd, args = cmd_filter(msg, cmd, args, dry_run)
  File "/app/venv/lib/python3.4/site-packages/errbot/core_plugins/acls.py", line 104, in acls
    if not glob(get_acl_usr(msg), self.bot_config.BOT_ADMINS):
  File "/app/venv/lib/python3.4/site-packages/errbot/core_plugins/acls.py", line 23, in glob
    return any(fnmatch.fnmatchcase(text, pattern) for pattern in patterns)
  File "/app/venv/lib/python3.4/site-packages/errbot/core_plugins/acls.py", line 23, in <genexpr>
    return any(fnmatch.fnmatchcase(text, pattern) for pattern in patterns)
  File "/app/venv/lib/python3.4/fnmatch.py", line 71, in fnmatchcase
    return match(name) is not None
TypeError: expected string or buffer
`