### PR TITLE
Adding a callback allow plugins to catch unhandled messages

### DIFF
--- a/errbot/__init__.py
+++ b/errbot/__init__.py
@@ -484,8 +484,7 @@ def cmdfilter(*args, **kwargs):
     def decorate(func):
         if not hasattr(func, '_err_command_filter'):  # don't override generated functions
             func._err_command_filter = True
-        if 'catch_unprocessed' in kwargs:
-            func.catch_unprocessed = kwargs['catch_unprocessed']
+        func.catch_unprocessed = kwargs.get('catch_unprocessed', False)
         return func
 
     if len(args):

--- a/errbot/__init__.py
+++ b/errbot/__init__.py
@@ -484,6 +484,8 @@ def cmdfilter(*args, **kwargs):
     def decorate(func):
         if not hasattr(func, '_err_command_filter'):  # don't override generated functions
             func._err_command_filter = True
+        if 'catch_unprocessed' in kwargs:
+            func.catch_unprocessed = kwargs['catch_unprocessed']
         return func
 
     if len(args):

--- a/errbot/core.py
+++ b/errbot/core.py
@@ -329,7 +329,7 @@ class ErrBot(Backend, StoreMixin):
         elif not only_check_re_command:
             log.debug("Command not found")
             for cmd_filter in self.command_filters:
-                if getattr(cmd_filter.__self__, 'catch_unprocessed', False):
+                if getattr(cmd_filter, 'catch_unprocessed', False):
                     reply = cmd_filter(mess, cmd, args, False, emptycmd=True)
                     if reply:
                         self.send_simple_reply(mess, reply)

--- a/errbot/core.py
+++ b/errbot/core.py
@@ -331,6 +331,8 @@ class ErrBot(Backend, StoreMixin):
             if suppress_cmd_not_found:
                 log.debug("Surpressing command not found feedback")
             else:
+                """ Allow command to fall-through to plugin overrides """
+                self._dispatch_to_plugins('callback_command_not_found', mess)
                 reply = self.unknown_command(mess, command, args)
                 if reply is None:
                     reply = self.MSG_UNKNOWN_COMMAND % {'command': command}
@@ -613,6 +615,15 @@ class ErrBot(Backend, StoreMixin):
     def callback_stream(self, stream):
         log.info("Initiated an incoming transfer %s" % stream)
         Tee(stream, self.plugin_manager.get_all_active_plugin_objects()).start()
+
+    def callback_command_not_found(self, mess):
+        """
+            Dispatch message to all plugins if a command was not found.
+
+            This will allow users to do additional processing on the message
+            if it was not handled by any other plugin.
+        """
+        self._dispatch_to_plugins('callback_command_not_found', mess)
 
     def signal_connect_to_all_plugins(self):
         for bot in self.plugin_manager.get_all_active_plugin_objects():

--- a/errbot/core.py
+++ b/errbot/core.py
@@ -612,15 +612,6 @@ class ErrBot(Backend, StoreMixin):
         log.info("Initiated an incoming transfer %s" % stream)
         Tee(stream, self.plugin_manager.get_all_active_plugin_objects()).start()
 
-    def callback_command_not_found(self, mess):
-        """
-            Dispatch message to all plugins if a command was not found.
-
-            This will allow users to do additional processing on the message
-            if it was not handled by any other plugin.
-        """
-        self._dispatch_to_plugins('callback_command_not_found', mess)
-
     def signal_connect_to_all_plugins(self):
         for bot in self.plugin_manager.get_all_active_plugin_objects():
             if hasattr(bot, 'callback_connect'):

--- a/errbot/core_plugins/cnf_filter.py
+++ b/errbot/core_plugins/cnf_filter.py
@@ -2,16 +2,7 @@ from errbot import BotPlugin, cmdfilter
 
 
 class CommandNotFoundFilter(BotPlugin):
-    """
-    Allow overriding behavior when a command is not found.
-    Attribute "catch_unprocessed" causes filter to be executed when a command
-    is not found.
-    """
-    def __init__(self, *args, **kwargs):
-        super(CommandNotFoundFilter, self).__init__(*args, **kwargs)
-        self.catch_unprocessed = True
-
-    @cmdfilter
+    @cmdfilter(catch_unprocessed=True)
     def cnf_filter(self, msg, cmd, args, dry_run, emptycmd=False):
         """
         Check if command exists.  If not, signal plugins.  This plugin

--- a/errbot/core_plugins/cnf_filter.py
+++ b/errbot/core_plugins/cnf_filter.py
@@ -33,9 +33,9 @@ class CommandNotFoundFilter(BotPlugin):
             log.debug("Surpressing command not found feedback")
         else:
             if msg.body.find(' ') > 0:
-                command = msg.body[:msg.body.index(' ')].replace(self._bot.bot_config.BOT_PREFIX, '', 1)
+                command = msg.body[:msg.body.index(' ')]
             else:
-                command = msg.body.replace(self._bot.bot_config.BOT_PREFIX, '', 1)
+                command = msg.body
 
             prefixes = self._bot.bot_config.BOT_ALT_PREFIXES + (self._bot.bot_config.BOT_PREFIX,)
             for prefix in prefixes:

--- a/errbot/core_plugins/cnf_filter.py
+++ b/errbot/core_plugins/cnf_filter.py
@@ -29,7 +29,7 @@ class CommandNotFoundFilter(BotPlugin):
         if not emptycmd:
             return msg, cmd, args
 
-        if self._bot.bot_config.SUPPRESS_CMD_NOT_FOUND:
+        if self.bot_config.SUPPRESS_CMD_NOT_FOUND:
             log.debug("Surpressing command not found feedback")
         else:
             if msg.body.find(' ') > 0:
@@ -37,10 +37,10 @@ class CommandNotFoundFilter(BotPlugin):
             else:
                 command = msg.body
 
-            prefixes = self._bot.bot_config.BOT_ALT_PREFIXES + (self._bot.bot_config.BOT_PREFIX,)
+            prefixes = self.bot_config.BOT_ALT_PREFIXES + (self.bot_config.BOT_PREFIX,)
             for prefix in prefixes:
-                if command[0] == prefix:
-                    command = command[1:]
+                if command.startswith(prefix):
+                    command = command.replace(prefix, '', 1)
                     break
 
             reply = self._bot.unknown_command(msg, command, args)

--- a/tests/cnf_callback_plugin/command_not_found.plug
+++ b/tests/cnf_callback_plugin/command_not_found.plug
@@ -1,0 +1,3 @@
+[Core]
+Name = command_not_found
+Module = command_not_found

--- a/tests/cnf_callback_plugin/command_not_found.py
+++ b/tests/cnf_callback_plugin/command_not_found.py
@@ -1,0 +1,5 @@
+from errbot import BotPlugin, botcmd
+class TestCommandNotFound(BotPlugin):
+    def callback_command_not_found(self, msg):
+        self.send(msg.frm, "Command fell through: {}".format(msg))
+

--- a/tests/commandnotfound_plugin/commandnotfound.py
+++ b/tests/commandnotfound_plugin/commandnotfound.py
@@ -2,11 +2,7 @@ from errbot import BotPlugin, cmdfilter
 
 
 class TestCommandNotFoundFilter(BotPlugin):
-    def __init__(self, *args, **kwargs):
-        super(TestCommandNotFoundFilter, self).__init__(*args, **kwargs)
-        self.catch_unprocessed = True
-
-    @cmdfilter
+    @cmdfilter(catch_unprocessed=True)
     def command_not_found(self, msg, cmd, args, dry_run, emptycmd=False):
         if not emptycmd:
             return msg, cmd, args

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -321,8 +321,13 @@ def test_no_suggest_on_re_commands(testbot):
     # Don't suggest a regexp command.
     assert '!re bar' not in testbot.pop_message()
 
+
 def test_callback_no_command(testbot):
-    extra_plugin_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'commandnotfound_plugin')
+    extra_plugin_dir = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        'commandnotfound_plugin'
+    )
+
     cmd = '!this_is_not_a_real_command_at_all'
     expected_str = "Command fell through: {}".format(cmd)
 

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -320,3 +320,12 @@ def test_no_suggest_on_re_commands(testbot):
     testbot.push_message('!re_ba')
     # Don't suggest a regexp command.
     assert '!re bar' not in testbot.pop_message()
+
+def test_callback_no_command(testbot):
+    extra_plugin_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'cnf_callback_plugin')
+    cmd = '!this_is_not_a_real_command_at_all'
+    expected_str = "Command fell through: {}".format(cmd)
+
+    testbot.bot.plugin_manager.update_plugin_places([], extra_plugin_dir)
+    testbot.exec_command('!plugin activate command_not_found')
+    assert expected_str == testbot.exec_command(cmd)

--- a/tests/core_plugins_test.py
+++ b/tests/core_plugins_test.py
@@ -1,7 +1,9 @@
 import os
 
 extra_plugin_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'room_plugin')
-extra_config = {'CORE_PLUGINS': ('Help', 'Utils', 'CommandNotFoundFilter'), 'BOT_ALT_PREFIXES': ('!',), 'BOT_PREFIX': '$'}
+extra_config = {'CORE_PLUGINS': ('Help', 'Utils', 'CommandNotFoundFilter'),
+                'BOT_ALT_PREFIXES': ('!',),
+                'BOT_PREFIX': '$'}
 
 
 def test_help_is_still_here(testbot):


### PR DESCRIPTION
I would like the ability to define a plugin callback that will catch any unhandled messages.

The goal is to allow a plugin to implement its own fuzzy matching, contextual services, or tasks (ie: user dictionary) where creating multiple plugins would be impractical.