### PR TITLE
Slack: compatibility with slackclient > 1.0.2

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -518,18 +518,34 @@ class SlackBackend(ErrBot):
 
     def userid_to_username(self, id_):
         """Convert a Slack user ID to their user name"""
-        user = [user for user in self.sc.server.users if user.id == id_]
-        if not user:
+        if hasattr(self.sc.server.users, 'get'):
+            # Slackclient > 1.0.2
+            user = self.sc.server.users.get(id_)
+        else:
+            try:
+                user = [user for user in self.sc.server.users if user.id == id_][0]
+            except IndexError:
+                user = None
+        if user is None:
             raise UserDoesNotExistError("Cannot find user with ID %s" % id_)
-        return user[0].name
+        return user.name
 
     def username_to_userid(self, name):
         """Convert a Slack user name to their user ID"""
         name = name.lstrip('@')
-        user = [user for user in self.sc.server.users if user.name == name]
-        if not user:
+
+        if hasattr(self.sc.server.users, 'get'):
+            # Slackclient > 1.0.2
+            user = self.sc.server.users.get(name)
+        else:
+            try:
+                user = [user for user in self.sc.server.users if user.name == name][0]
+            except IndexError:
+                user = None
+
+        if user is None:
             raise UserDoesNotExistError("Cannot find user %s" % name)
-        return user[0].id
+        return user.id
 
     def channelid_to_channelname(self, id_):
         """Convert a Slack channel ID to its channel name"""


### PR DESCRIPTION
Slackclient changed their API with the 1.0.2 →  1.0.3 release (see https://github.com/slackapi/python-slackclient/pull/149) which resulted in bug #928. These changes make our slack backend work again with this newer version of slackclient while maintaining compatibility with older versions of the library.
