### PR TITLE
slack: Fix crash on botmessage containing only attachments

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -470,10 +470,10 @@ class SlackBackend(ErrBot):
             return
 
         if 'message' in event:
-            text = event['message']['text']
+            text = event['message'].get('text', '')
             user = event['message'].get('user', event.get('bot_id'))
         else:
-            text = event['text']
+            text = event.get('text', '')
             user = event.get('user', event.get('bot_id'))
 
         text, mentioned = self.process_mentions(text)


### PR DESCRIPTION
This fixes the error reported by @rokcarl which occurs when a bot
(typically: an incoming webhook) sends a message containing attachments
but no `text` entry.

This implementation purposefully does not skip these messages entirely
but treats them as messages with empty text so that plugin authors can
still parse these messages to get to the included attachments (errbot
itself doesn't do anything with those though).

Fixes #938