### PR TITLE
Fix for Render Test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,7 @@ if __name__ == "__main__":
                        'backends/styles/*.css',
                        'backends/images/*.svg',
                        'core_plugins/*.plug',
+                       'core_plugins/*.md',                       
                        'core_plugins/templates/*.md',
                        'storage/*.plug',
                        'templates/initdir/example.py',


### PR DESCRIPTION
Render test does not work because of the missing Markdown file from 'core_plugins' directory