### PR TITLE
Attach the original slack event object to Message

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -485,7 +485,11 @@ class SlackBackend(ErrBot):
 
         msg = Message(
             text,
-            extras={'attachments': event.get('attachments')})
+            extras={
+                'attachments': event.get('attachments'),
+                'slack_event': event,
+            },
+        )
 
         if channel.startswith('D'):
             if subtype == "bot_message":

--- a/tests/backend_tests/slack_tests.py
+++ b/tests/backend_tests/slack_tests.py
@@ -92,6 +92,24 @@ class SlackTests(unittest.TestCase):
 
         self.assertEqual(msg.extras['attachments'], [attachment])
 
+    def testSlackEventObjectAddedToExtras(self):
+        bot_id = 'B04HMXXXX'
+        bot_msg = {
+            'channel': 'C0XXXXY6P',
+            'icons': {'emoji': ':warning:', 'image_64': 'https://xx.com/26a0.png'},
+            'ts': '1444416645.000641',
+            'type': 'message',
+            'text': '',
+            'bot_id': bot_id,
+            'username': 'riemann',
+            'subtype': 'bot_message',
+        }
+
+        self.slack._dispatch_slack_message(bot_msg)
+        msg = self.slack.test_msgs.pop()
+
+        self.assertEqual(msg.extras['slack_event'], bot_msg)
+
     def testPrepareMessageBody(self):
         test_body = """
         hey, this is some code:


### PR DESCRIPTION
I set out to create what I believed would be a simple plugin; "detect when a user sends a message  into a specific slack channel, and if 30 minutes or more had passed since the last message appeared in that channel, send a slack card with a specific notice to the channel." This ended up being much more complicated than I thought using the `callback_message` method due to the different message subtypes coming through the streaming API to a channel at random times not initiated by a human in any way I can see.

This passes the original slack event object to the message via the extras dict. My current use case only requires the message subtype. Another option could be to create a `SlackMessage` with a subtype property that subclasses `Message`.

Thanks!