### PR TITLE
Simple readline support for text backend

### DIFF
--- a/errbot/backends/text.py
+++ b/errbot/backends/text.py
@@ -88,6 +88,15 @@ class TextBackend(ErrBot):
     def __init__(self, config):
         super().__init__(config)
         log.debug("Text Backend Init.")
+
+        try:
+            # Load readline for better editing/history behaviour
+            import readline
+        except ImportError:
+            # Readline is Unix-only
+            log.debug("Python readline module is not available")
+            pass
+
         self.bot_identifier = self.build_identifier('Err')
         self.demo_mode = self.bot_config.TEXT_DEMO_MODE if hasattr(self.bot_config, 'TEXT_DEMO_MODE') else False
         self._rooms = set()


### PR DESCRIPTION
This enables use of usual shell-like line editing behaviours and provides an in-memory command history for the text backend. (eg. arrow keys, word forward/back, history search)

Readline is unix-only: noops when the module isn't available.

Can possibly expand in future to provide tab completion or persistent history, but this is an easy starting point.