### PR TITLE
Slack: compatibility with slackclient 1.0.5

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -518,14 +518,7 @@ class SlackBackend(ErrBot):
 
     def userid_to_username(self, id_):
         """Convert a Slack user ID to their user name"""
-        if hasattr(self.sc.server.users, 'get'):
-            # Slackclient > 1.0.2
-            user = self.sc.server.users.get(id_)
-        else:
-            try:
-                user = [user for user in self.sc.server.users if user.id == id_][0]
-            except IndexError:
-                user = None
+        user = self.sc.server.users.get(id_)
         if user is None:
             raise UserDoesNotExistError("Cannot find user with ID %s" % id_)
         return user.name
@@ -533,16 +526,7 @@ class SlackBackend(ErrBot):
     def username_to_userid(self, name):
         """Convert a Slack user name to their user ID"""
         name = name.lstrip('@')
-
-        if hasattr(self.sc.server.users, 'get'):
-            # Slackclient > 1.0.2
-            user = self.sc.server.users.get(name)
-        else:
-            try:
-                user = [user for user in self.sc.server.users if user.name == name][0]
-            except IndexError:
-                user = None
-
+        user = self.sc.server.users.find(name)
         if user is None:
             raise UserDoesNotExistError("Cannot find user %s" % name)
         return user.id

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ if __name__ == "__main__":
             'graphic':  ['PySide', ],
             'hipchat': ['hypchat', 'sleekxmpp', 'pyasn1', 'pyasn1-modules'],
             'IRC': ['irc', ],
-            'slack': ['slackclient>=1.0.0', ],
+            'slack': ['slackclient>=1.0.5', ],
             'telegram': ['python-telegram-bot', ],
             'XMPP': ['sleekxmpp', 'pyasn1', 'pyasn1-modules'],
         },


### PR DESCRIPTION
Slackclient introduced changes to their underlying client with this release which broke user ID lookups for errbot (see #949). With these changes user ID lookups will work with this new version.

Quick testing shows this also continues to work with 1.0.2 and 1.0.4 but not 1.0.3. Earlier versions were untested.
