### PR TITLE
Move from threadpool to multiprocessing.pool. 

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -7,7 +7,7 @@ import time
 import sys
 import pprint
 from functools import lru_cache
-from threadpool import WorkRequest
+from multiprocessing.pool import ThreadPool
 
 from markdown import Markdown
 from markdown.extensions.extra import ExtraExtension
@@ -667,7 +667,7 @@ class SlackBackend(ErrBot):
         stream = Stream(identifier, fsource, name, size, stream_type)
         log.debug("Requesting upload of {0} to {1} (size hint: {2}, stream type: {3})".format(name,
                   identifier.channelname, size, stream_type))
-        self.thread_pool.putRequest(WorkRequest(self._slack_upload, args=(stream,)))
+        self.thread_pool.apply_async(self._slack_upload, (stream,))
         return stream
 
     def send_card(self, card: Card):

--- a/errbot/backends/telegram_messenger.py
+++ b/errbot/backends/telegram_messenger.py
@@ -1,6 +1,6 @@
 import logging
 import sys
-from threadpool import WorkRequest
+from multiprocessing.pool import ThreadPool
 
 from errbot.backends.base import RoomError, Identifier, Person, RoomOccupant, Stream, ONLINE, Room
 from errbot.core import ErrBot
@@ -454,7 +454,7 @@ class TelegramBackend(ErrBot):
             stream = Stream(identifier, content, name, size, stream_type)
             log.debug("Requesting upload of {0} to {1} (size hint: {2}, stream type: {3})".format(name,
                       identifier, size, stream_type))
-            self.thread_pool.putRequest(WorkRequest(self._telegram_upload_stream, args=(stream,)))
+            self.thread_pool.apply_async(self._telegram_upload_stream, (stream,))
 
         return stream
 

--- a/errbot/flow.py
+++ b/errbot/flow.py
@@ -2,7 +2,7 @@ import logging
 from threading import RLock
 from typing import Mapping, List, Tuple, Union, Callable, Any
 
-from threadpool import ThreadPool, WorkRequest
+from multiprocessing.pool import ThreadPool
 from yapsy.IPlugin import IPlugin
 
 from errbot import Message
@@ -363,7 +363,7 @@ class FlowExecutor(object):
         with self._lock:
             if flow not in self.in_flight:
                 self.in_flight.append(flow)
-        self._pool.putRequest(WorkRequest(self.execute, args=(flow, )))
+        self._pool.apply_async(self.execute, (flow, ))
 
     def execute(self, flow: Flow):
         """

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ VERSION_FILE = os.path.join('errbot', 'version.py')
 deps = ['webtest',
         'setuptools',
         'bottle',
-        'threadpool',
         'rocket-errbot',
         'requests',
         'jinja2',


### PR DESCRIPTION
Threadpool is obsolete and recommends to switch to a modern alternative.

as proposed by @zoni in #965 i'm trying to switch from threadpool to multiprocessing.pool. i don't do that much python coding, so i'm not sure if `apply_async` is the correct replacement for putRequest. also i didn't find know how to run the tests. i started the bot with BOT_ASYNC = True and it worked