### PR TITLE
Fixes error message in case of a non parsable arg_botcomd

### DIFF
--- a/errbot/__init__.py
+++ b/errbot/__init__.py
@@ -339,14 +339,18 @@ def arg_botcmd(*args,
                 # Some clients automatically convert consecutive dashes into a fancy
                 # hyphen, which breaks long-form arguments. Undo this conversion to
                 # provide a better user experience.
-                args = shlex.split(args.replace('—', '--'))
                 try:
+                    args = shlex.split(args.replace('—', '--'))
                     parsed_args = err_command_parser.parse_args(args)
                 except ArgumentParseError as e:
-                    yield "I'm sorry, I couldn't parse that; %s" % e
+                    yield "I'm sorry, I couldn't parse the arguments; %s" % e
                     yield err_command_parser.format_usage()
                     return
                 except HelpRequested:
+                    yield err_command_parser.format_help()
+                    return
+                except ValueError as ve:
+                    yield "I'm sorry, I couldn't parse this command; %s" % ve
                     yield err_command_parser.format_help()
                     return
 

--- a/tests/base_backend_test.py
+++ b/tests/base_backend_test.py
@@ -482,6 +482,18 @@ def test_arg_botcmd_returns_with_escaping(dummy_backend):
     assert 'Err" Bot' == dummy_backend.pop_message().body
 
 
+def test_arg_botcmd_returns_with_incorrect_escaping(dummy_backend):
+    first_name = 'Err"'
+    last_name = 'Bot'
+    dummy_backend.callback_message(
+        makemessage(
+            dummy_backend,
+            "!returns_first_name_last_name --first-name=%s --last-name=%s" % (first_name, last_name)
+        )
+    )
+    assert 'I couldn\'t parse this command; No closing quotation' in dummy_backend.pop_message().body
+
+
 def test_arg_botcmd_yields_first_name_last_name(dummy_backend):
     first_name = 'Err'
     last_name = 'Bot'
@@ -509,7 +521,7 @@ def test_arg_botcmd_doesnt_raise_systemerror(dummy_backend):
 
 def test_arg_botcdm_returns_errors_as_chat(dummy_backend):
     dummy_backend.callback_message(makemessage(dummy_backend, "!returns_first_name_last_name --invalid-parameter"))
-    assert "I'm sorry, I couldn't parse that; unrecognized arguments: --invalid-parameter" \
+    assert "I couldn't parse the arguments; unrecognized arguments: --invalid-parameter" \
         in dummy_backend.pop_message().body
 
 

--- a/tests/base_backend_test.py
+++ b/tests/base_backend_test.py
@@ -470,6 +470,18 @@ def test_arg_botcmd_returns_first_name_last_name(dummy_backend):
     assert "%s %s" % (first_name, last_name) == dummy_backend.pop_message().body
 
 
+def test_arg_botcmd_returns_with_escaping(dummy_backend):
+    first_name = 'Err\\"'
+    last_name = 'Bot'
+    dummy_backend.callback_message(
+        makemessage(
+            dummy_backend,
+            "!returns_first_name_last_name --first-name=%s --last-name=%s" % (first_name, last_name)
+        )
+    )
+    assert 'Err" Bot' == dummy_backend.pop_message().body
+
+
 def test_arg_botcmd_yields_first_name_last_name(dummy_backend):
     first_name = 'Err'
     last_name = 'Bot'


### PR DESCRIPTION
This clarify the behavior for #950.