### PR TITLE
Add support for multiple subcommands

### DIFF
--- a/errbot/core.py
+++ b/errbot/core.py
@@ -271,21 +271,18 @@ class ErrBot(Backend, StoreMixin):
         command = None
         args = ''
         if not only_check_re_command:
-            if len(text_split) > 1:
-                command = (text_split[0] + '_' + text_split[1]).lower()
-                with self._gbl:
-                    if command in self.commands:
-                        cmd = command
-                        args = ' '.join(text_split[2:])
+            i = len(text_split)
+            while cmd is None:
+                command = '_'.join(text_split[:i])
 
-            if not cmd:
-                command = text_split[0].lower()
-                args = ' '.join(text_split[1:])
                 with self._gbl:
                     if command in self.commands:
                         cmd = command
-                        if len(text_split) > 1:
-                            args = ' '.join(text_split[1:])
+                        args = ' '.join(text_split[i:])
+                    else:
+                        i -= 1
+                if i == 0:
+                    break
 
             if command == self.bot_config.BOT_PREFIX:  # we did "!!" so recall the last command
                 if len(user_cmd_history):

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -335,3 +335,18 @@ def test_callback_no_command(testbot):
     testbot.bot.plugin_manager.update_plugin_places([], extra_plugin_dir)
     testbot.exec_command('!plugin activate TestCommandNotFoundFilter')
     assert expected_str == testbot.exec_command(cmd)
+
+
+def test_subcommands(testbot):
+    # test single subcommand (method is run_subcommands())
+    cmd = '!run subcommands with these args'
+    cmd_underscore = '!run_subcommands with these args'
+    expected_args = 'with these args'
+    assert expected_args == testbot.exec_command(cmd)
+    assert expected_args == testbot.exec_command(cmd_underscore)
+
+    # test multiple subcmomands (method is run_lots_of_subcommands())
+    cmd = '!run lots of subcommands with these args'
+    cmd_underscore = '!run_lots_of_subcommands with these args'
+    assert expected_args == testbot.exec_command(cmd)
+    assert expected_args == testbot.exec_command(cmd_underscore)

--- a/tests/dummy_plugin/dummy.py
+++ b/tests/dummy_plugin/dummy.py
@@ -19,3 +19,13 @@ class DummyTest(BotPlugin):
     def re_bar(self, msg, match):
         """This runs re_foo."""
         return 'bar'
+
+    @botcmd
+    def run_subcommands(self, msg, args):
+        """Tests a simple subcommand"""
+        return args
+
+    @botcmd
+    def run_lots_of_subcommands(self, msg, args):
+        """Tests multiple subcommands"""
+        return args


### PR DESCRIPTION
Currently, Errbot only supports a single subcommand. For example, consider these two plugin methods:

```python
def run_subcommand(...):

def run_my_subcommand(...):
```
The first can be run as "!run subcommand \<args\>" but the second must be "!run my_subcommand \<args\>" because only the first "_" is considered when parsing subcommands. This PR allows arbitrarily long subcommands, as long as they match a plugin command. Users could write "!run my subcommand \<args\>" successfully.

Includes a unit test.