### PR TITLE
utils.py cleanup.

### DIFF
--- a/docs/user_guide/plugin_development/exceptions.rst
+++ b/docs/user_guide/plugin_development/exceptions.rst
@@ -43,7 +43,7 @@ When handling exceptions, follow these steps:
     not re-raising it, we prevent that automatic "Computer says nooo.
     ..." message from being sent
 
-Also, note that there is a ``utils.ValidationException`` class which you
+Also, note that there is a ``errbot.ValidationException`` class which you
 can use inside your helper methods to raise meaningful errors and handle
 them accordingly.
 
@@ -51,7 +51,7 @@ Here's an example:
 
 .. code-block:: python
 
-    from errbot import BotPlugin, arg_botcmd, utils
+    from errbot import BotPlugin, arg_botcmd, ValidationException
 
     class FooBot(BotPlugin):
         """An example bot"""
@@ -61,7 +61,7 @@ Here's an example:
             """Add your first name if it doesn't contain any digits"""
             try:
                 FooBot.validate_first_name(first_name)
-            except utils.ValidationException as exc:
+            except ValidationException as exc:
                 self.log.exception(
                     'first_name=%s contained a digit' % first_name
                 )
@@ -74,7 +74,7 @@ Here's an example:
         @staticmethod
         def validate_first_name(first_name):
             if any(char.isdigit() for char in first_name):
-                raise utils.ValidationException(
+                raise ValidationException(
                     "first_name=%s contained a digit" % first_name
                 )
 

--- a/errbot/__init__.py
+++ b/errbot/__init__.py
@@ -11,7 +11,7 @@ from typing import Callable, Any, Tuple
 
 from .core_plugins.wsview import bottle_app, WebView
 from .backends.base import Message, ONLINE, OFFLINE, AWAY, DND  # noqa
-from .botplugin import BotPlugin, SeparatorArgParser, ShlexArgParser, CommandError, Command  # noqa
+from .botplugin import BotPlugin, SeparatorArgParser, ShlexArgParser, CommandError, Command, ValidationException  # noqa
 from .flow import FlowRoot, BotFlow, Flow, FLOW_END
 from .core_plugins.wsview import route, view  # noqa
 from . import core

--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -6,10 +6,6 @@ from typing import Any, Mapping, BinaryIO, List, Sequence, Tuple
 from abc import abstractproperty, abstractmethod
 from collections import deque, defaultdict
 
-import inspect
-
-from errbot.utils import deprecated
-
 try:
     from abc import ABC
 except ImportError:

--- a/errbot/core.py
+++ b/errbot/core.py
@@ -30,7 +30,7 @@ from .backends.base import Backend, Room, Identifier, Message
 from .storage import StoreMixin
 from .streaming import Tee
 from .templating import tenv
-from .utils import split_string_after, get_class_that_defined_method
+from .utils import split_string_after
 
 log = logging.getLogger(__name__)
 
@@ -653,8 +653,15 @@ class ErrBot(Backend, StoreMixin):
         pat = re.compile(r'!({})'.format('|'.join(ununderscore_keys)))
         return re.sub(pat, self.prefix + '\1', command.__doc__)
 
+    @staticmethod
+    def get_plugin_class_from_method(meth):
+        for cls in inspect.getmro(type(meth.__self__)):
+            if meth.__name__ in cls.__dict__:
+                return cls
+        return None
+
     def get_command_classes(self):
-        return (get_class_that_defined_method(command)
+        return (self.get_plugin_class_from_method(command)
                 for command in self.all_commands.values())
 
     def shutdown(self):

--- a/errbot/core_plugins/help.py
+++ b/errbot/core_plugins/help.py
@@ -2,7 +2,6 @@ import textwrap
 
 from errbot import BotPlugin, botcmd
 from errbot.version import VERSION
-from errbot.utils import get_class_that_defined_method
 
 
 class Help(BotPlugin):
@@ -29,7 +28,7 @@ class Help(BotPlugin):
 
         cls_commands = {}
         for (name, command) in self._bot.all_commands.items():
-            cls = get_class_that_defined_method(command)
+            cls = self._bot.get_plugin_class_from_method(command)
             cls = str.__module__ + '.' + cls.__name__  # makes the fuul qualified name
             commands = cls_commands.get(cls, [])
             if not self.bot_config.HIDE_RESTRICTED_COMMANDS or self._bot.check_command_access(mess, name)[0]:
@@ -79,7 +78,7 @@ class Help(BotPlugin):
         if not args:
             cls_commands = {}
             for (name, command) in self._bot.all_commands.items():
-                cls = get_class_that_defined_method(command)
+                cls = self._bot.get_plugin_class_from_method(command)
                 commands = cls_commands.get(cls, [])
                 if not self.bot_config.HIDE_RESTRICTED_COMMANDS or may_access_command(mess, name):
                     commands.append((name, command))
@@ -107,7 +106,7 @@ class Help(BotPlugin):
             commands = [
                 (name, command) for (name, command)
                 in self._bot.all_commands.items() if
-                get_name(get_class_that_defined_method(command)) == args]
+                get_name(self._bot.get_plugin_class_from_method(command)) == args]
 
             description = '\n**{name}**\n\n*{doc}*\n\n'.format(
                 name=cls.__name__,

--- a/errbot/core_plugins/utils.py
+++ b/errbot/core_plugins/utils.py
@@ -1,7 +1,10 @@
 from os import path
 
 from errbot import BotPlugin, botcmd
-from errbot.utils import tail
+
+
+def tail(f, window=20):
+    return ''.join(f.readlines()[-window:])
 
 
 class Utils(BotPlugin):

--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -12,7 +12,7 @@ from yapsy import PluginInfo
 
 from errbot.flow import BotFlow
 from .botplugin import BotPlugin
-from .utils import version2array, collect_roots, ensure_sys_path_contains
+from .utils import version2array, collect_roots
 from .templating import remove_plugin_templates_path, add_plugin_templates_path
 from .version import VERSION
 from yapsy.PluginManager import PluginManager
@@ -44,6 +44,19 @@ class IncompatiblePluginException(PluginActivationException):
 
 class PluginConfigurationException(PluginActivationException):
     pass
+
+
+def _ensure_sys_path_contains(paths):
+    """ Ensure that os.path contains paths
+       :param base_paths:
+            a list of base paths to walk from
+            elements can be a string or a list/tuple of strings
+    """
+    for entry in paths:
+        if isinstance(entry, (list, tuple)):
+            _ensure_sys_path_contains(entry)
+        elif entry is not None and entry not in sys.path:
+            sys.path.append(entry)
 
 
 def populate_doc(plugin):
@@ -370,7 +383,7 @@ class BotPluginManager(PluginManager, StoreMixin):
                 log.debug("Add %s to sys.path", entry)
                 sys.path.append(entry)
         # so plugins can relatively import their repos
-        ensure_sys_path_contains(repo_roots)
+        _ensure_sys_path_contains(repo_roots)
 
         errors = {}
         if autoinstall_deps:

--- a/errbot/repo_manager.py
+++ b/errbot/repo_manager.py
@@ -16,7 +16,7 @@ import re
 
 from errbot.plugin_manager import check_dependencies
 from errbot.storage import StoreMixin
-from .utils import which
+from .utils import ON_WINDOWS
 
 log = logging.getLogger(__name__)
 
@@ -59,6 +59,26 @@ def tokenizeJsonEntry(json_dict):
     Returns all the words in a repo entry.
     """
     return set(find_words.findall(' '.join((word.lower() for word in json_dict.values()))))
+
+
+def which(program):
+    if ON_WINDOWS:
+        program += '.exe'
+
+    def is_exe(file_path):
+        return os.path.isfile(file_path) and os.access(file_path, os.X_OK)
+
+    fpath, fname = os.path.split(program)
+    if fpath:
+        if is_exe(program):
+            return program
+    else:
+        for path in os.environ["PATH"].split(os.pathsep):
+            exe_file = os.path.join(path, program)
+            if is_exe(exe_file):
+                return exe_file
+
+    return None
 
 
 class BotRepoManager(StoreMixin):

--- a/errbot/streaming.py
+++ b/errbot/streaming.py
@@ -1,14 +1,28 @@
 
 import os
 import io
+from itertools import starmap, repeat
 from threading import Thread
 from .backends.base import STREAM_WAITING_TO_START, STREAM_TRANSFER_IN_PROGRESS
 import logging
-from .utils import repeatfunc
 
 CHUNK_SIZE = 4096
 
 log = logging.getLogger(__name__)
+
+
+def repeatfunc(func, times=None, *args):  # from the itertools receipes
+    """Repeat calls to func with specified arguments.
+
+    Example:  repeatfunc(random.random)
+
+    :param args: params to the function to call.
+    :param times: number of times to repeat.
+    :param func:  the function to repeatedly call.
+    """
+    if times is None:
+        return starmap(func, repeat(args))
+    return starmap(func, repeat(args, times))
 
 
 class Tee(object):

--- a/errbot/utils.py
+++ b/errbot/utils.py
@@ -106,7 +106,6 @@ def version2array(version):
     return response
 
 
-
 def unescape_xml(text):
     """
     Removes HTML or XML character references and entities from a text string.

--- a/errbot/utils.py
+++ b/errbot/utils.py
@@ -9,7 +9,6 @@ import time
 from platform import system
 from functools import wraps
 from html import entities
-from itertools import starmap, repeat
 
 log = logging.getLogger(__name__)
 
@@ -67,46 +66,11 @@ def format_timedelta(timedelta):
         return '%i hours and %i minutes' % (hours, minutes)
 
 
-BAR_WIDTH = 15.0
-
-
-def drawbar(value, max_):
-    if max_:
-        value_in_chr = int(round((value * BAR_WIDTH / max_)))
-    else:
-        value_in_chr = 0
-    return '[' + '█' * value_in_chr + '▒' * int(round(BAR_WIDTH - value_in_chr)) + ']'
-
-
 # Introspect to know from which plugin a command is implemented
 def get_class_for_method(meth):
     for cls in inspect.getmro(type(meth.__self__)):
         if meth.__name__ in cls.__dict__:
             return cls
-    return None
-
-
-def tail(f, window=20):
-    return ''.join(f.readlines()[-window:])
-
-
-def which(program):
-    if ON_WINDOWS:
-        program += '.exe'
-
-    def is_exe(file_path):
-        return os.path.isfile(file_path) and os.access(file_path, os.X_OK)
-
-    fpath, fname = os.path.split(program)
-    if fpath:
-        if is_exe(program):
-            return program
-    else:
-        for path in os.environ["PATH"].split(os.pathsep):
-            exe_file = os.path.join(path, program)
-            if is_exe(exe_file):
-                return exe_file
-
     return None
 
 
@@ -141,38 +105,6 @@ def version2array(version):
 
     return response
 
-
-class ValidationException(Exception):
-    pass
-
-
-def recurse_check_structure(sample, to_check):
-    sample_type = type(sample)
-    to_check_type = type(to_check)
-
-    # Skip this check if the sample is None because it will always be something
-    # other than NoneType when changed from the default. Raising ValidationException
-    # would make no sense then because it would defeat the whole purpose of having
-    # that key in the sample when it could only ever be None.
-    if sample is not None and sample_type != to_check_type:
-        raise ValidationException(
-            '%s [%s] is not the same type as %s [%s]' % (sample, sample_type, to_check, to_check_type))
-
-    if sample_type in (list, tuple):
-        for element in to_check:
-            recurse_check_structure(sample[0], element)
-        return
-
-    if sample_type == dict:
-        for key in sample:
-            if key not in to_check:
-                raise ValidationException("%s doesn't contain the key %s" % (to_check, key))
-        for key in to_check:
-            if key not in sample:
-                raise ValidationException("%s contains an unknown key %s" % (to_check, key))
-        for key in sample:
-            recurse_check_structure(sample[key], to_check[key])
-        return
 
 
 def unescape_xml(text):
@@ -209,12 +141,6 @@ REINSERT_EOLS = re.compile(r'</p>|</li>|<br/>', re.I)
 ZAP_TAGS = re.compile(r'<[^>]+>')
 
 
-def utf8(key):
-    if type(key) == str:
-        return key.encode()  # it defaults to utf-8
-    return key
-
-
 def rate_limited(min_interval):
     """
     decorator to rate limit a function.
@@ -249,20 +175,6 @@ def split_string_after(str_, n):
     """
     for start in range(0, len(str_), n):
         yield str_[start:start + n]
-
-
-def repeatfunc(func, times=None, *args):  # from the itertools receipes
-    """Repeat calls to func with specified arguments.
-
-    Example:  repeatfunc(random.random)
-
-    :param args: params to the function to call.
-    :param times: number of times to repeat.
-    :param func:  the function to repeatedly call.
-    """
-    if times is None:
-        return starmap(func, repeat(args))
-    return starmap(func, repeat(args, times))
 
 
 def find_roots(path, file_sig='*.plug'):
@@ -310,34 +222,3 @@ def collect_roots(base_paths, file_sig='*.plug'):
         elif path_or_list is not None:
             result |= find_roots(path_or_list, file_sig)
     return result
-
-
-def ensure_sys_path_contains(paths):
-    """ Ensure that os.path contains paths
-       :param base_paths:
-            a list of base paths to walk from
-            elements can be a string or a list/tuple of strings
-    """
-    for entry in paths:
-        if isinstance(entry, (list, tuple)):
-            ensure_sys_path_contains(entry)
-        elif entry is not None and entry not in sys.path:
-            sys.path.append(entry)
-
-
-def get_class_that_defined_method(meth):
-    for cls in inspect.getmro(type(meth.__self__)):
-        if meth.__name__ in cls.__dict__:
-            return cls
-    return None
-
-
-def compat_str(s):
-    """ Detect if s is a string and convert it to unicode if it is bytes.
-        :param s: the string to ensure compatibility from."""
-    if isinstance(s, str):
-        return s
-    elif isinstance(s, bytes):
-        return s.decode('utf-8')
-    else:
-        return str(s)

--- a/tests/fail_config_plugin/failp.py
+++ b/tests/fail_config_plugin/failp.py
@@ -1,5 +1,4 @@
-from errbot import BotPlugin
-from errbot.utils import ValidationException
+from errbot import BotPlugin, ValidationException
 
 
 class FailP(BotPlugin):

--- a/tests/plugin_config_test.py
+++ b/tests/plugin_config_test.py
@@ -1,7 +1,58 @@
 from os import path
-
+from errbot.botplugin import _recurse_check_plugin_configuration, ValidationException
+import pytest
 
 extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), 'config_plugin')
+
+
+def test_recurse_check_structure_valid():
+    sample = dict(string="Foobar", list=["Foo", "Bar"], dict={'foo': "Bar"}, none=None, true=True, false=False)
+    to_check = dict(string="Foobar", list=["Foo", "Bar", "Bas"], dict={'foo': "Bar"}, none=None, true=True,
+                    false=False)
+    _recurse_check_plugin_configuration(sample, to_check)
+
+
+def test_recurse_check_structure_missingitem():
+    sample = dict(string="Foobar", list=["Foo", "Bar"], dict={'foo': "Bar"}, none=None, true=True, false=False)
+    to_check = dict(string="Foobar", list=["Foo", "Bar"], dict={'foo': "Bar"}, none=None, true=True)
+    with pytest.raises(ValidationException):
+        _recurse_check_plugin_configuration(sample, to_check)
+
+
+def test_recurse_check_structure_extrasubitem():
+    sample = dict(string="Foobar", list=["Foo", "Bar"], dict={'foo': "Bar"}, none=None, true=True, false=False)
+    to_check = dict(string="Foobar", list=["Foo", "Bar", "Bas"], dict={'foo': "Bar", 'Bar': "Foo"}, none=None,
+                    true=True, false=False)
+    with pytest.raises(ValidationException):
+        _recurse_check_plugin_configuration(sample, to_check)
+
+
+def test_recurse_check_structure_missingsubitem():
+    sample = dict(string="Foobar", list=["Foo", "Bar"], dict={'foo': "Bar"}, none=None, true=True, false=False)
+    to_check = dict(string="Foobar", list=["Foo", "Bar", "Bas"], dict={}, none=None, true=True, false=False)
+    with pytest.raises(ValidationException):
+        _recurse_check_plugin_configuration(sample, to_check)
+
+
+def test_recurse_check_structure_wrongtype_1():
+    sample = dict(string="Foobar", list=["Foo", "Bar"], dict={'foo': "Bar"}, none=None, true=True, false=False)
+    to_check = dict(string=None, list=["Foo", "Bar"], dict={'foo': "Bar"}, none=None, true=True, false=False)
+    with pytest.raises(ValidationException):
+        _recurse_check_plugin_configuration(sample, to_check)
+
+
+def test_recurse_check_structure_wrongtype_2():
+    sample = dict(string="Foobar", list=["Foo", "Bar"], dict={'foo': "Bar"}, none=None, true=True, false=False)
+    to_check = dict(string="Foobar", list={'foo': "Bar"}, dict={'foo': "Bar"}, none=None, true=True, false=False)
+    with pytest.raises(ValidationException):
+        _recurse_check_plugin_configuration(sample, to_check)
+
+
+def test_recurse_check_structure_wrongtype_3():
+    sample = dict(string="Foobar", list=["Foo", "Bar"], dict={'foo': "Bar"}, none=None, true=True, false=False)
+    to_check = dict(string="Foobar", list=["Foo", "Bar"], dict=["Foo", "Bar"], none=None, true=True, false=False)
+    with pytest.raises(ValidationException):
+        _recurse_check_plugin_configuration(sample, to_check)
 
 
 def test_failed_config(testbot):

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -69,7 +69,6 @@ def test_storage():
     assert len(persistent_object) == 0
 
 
-
 def test_split_string_after_returns_original_string_when_chunksize_equals_string_size():
     str_ = 'foobar2000' * 2
     splitter = split_string_after(str_, len(str_))

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -44,12 +44,6 @@ def test_formattimedelta():
     assert '1 hours and 13 minutes' == format_timedelta(td)
 
 
-def test_drawbar():
-    assert drawbar(5, 10) == '[████████▒▒▒▒▒▒▒]'
-    assert drawbar(0, 10) == '[▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒]'
-    assert drawbar(10, 10) == '[███████████████]'
-
-
 def unescape_test():
     assert unescape_xml('&#32;') == ' '
 
@@ -74,55 +68,6 @@ def test_storage():
     assert key not in persistent_object
     assert len(persistent_object) == 0
 
-
-def test_recurse_check_structure_valid():
-    sample = dict(string="Foobar", list=["Foo", "Bar"], dict={'foo': "Bar"}, none=None, true=True, false=False)
-    to_check = dict(string="Foobar", list=["Foo", "Bar", "Bas"], dict={'foo': "Bar"}, none=None, true=True,
-                    false=False)
-    recurse_check_structure(sample, to_check)
-
-
-def test_recurse_check_structure_missingitem():
-    sample = dict(string="Foobar", list=["Foo", "Bar"], dict={'foo': "Bar"}, none=None, true=True, false=False)
-    to_check = dict(string="Foobar", list=["Foo", "Bar"], dict={'foo': "Bar"}, none=None, true=True)
-    with pytest.raises(ValidationException):
-        recurse_check_structure(sample, to_check)
-
-
-def test_recurse_check_structure_extrasubitem():
-    sample = dict(string="Foobar", list=["Foo", "Bar"], dict={'foo': "Bar"}, none=None, true=True, false=False)
-    to_check = dict(string="Foobar", list=["Foo", "Bar", "Bas"], dict={'foo': "Bar", 'Bar': "Foo"}, none=None,
-                    true=True, false=False)
-    with pytest.raises(ValidationException):
-        recurse_check_structure(sample, to_check)
-
-
-def test_recurse_check_structure_missingsubitem():
-    sample = dict(string="Foobar", list=["Foo", "Bar"], dict={'foo': "Bar"}, none=None, true=True, false=False)
-    to_check = dict(string="Foobar", list=["Foo", "Bar", "Bas"], dict={}, none=None, true=True, false=False)
-    with pytest.raises(ValidationException):
-        recurse_check_structure(sample, to_check)
-
-
-def test_recurse_check_structure_wrongtype_1():
-    sample = dict(string="Foobar", list=["Foo", "Bar"], dict={'foo': "Bar"}, none=None, true=True, false=False)
-    to_check = dict(string=None, list=["Foo", "Bar"], dict={'foo': "Bar"}, none=None, true=True, false=False)
-    with pytest.raises(ValidationException):
-        recurse_check_structure(sample, to_check)
-
-
-def test_recurse_check_structure_wrongtype_2():
-    sample = dict(string="Foobar", list=["Foo", "Bar"], dict={'foo': "Bar"}, none=None, true=True, false=False)
-    to_check = dict(string="Foobar", list={'foo': "Bar"}, dict={'foo': "Bar"}, none=None, true=True, false=False)
-    with pytest.raises(ValidationException):
-        recurse_check_structure(sample, to_check)
-
-
-def test_recurse_check_structure_wrongtype_3():
-    sample = dict(string="Foobar", list=["Foo", "Bar"], dict={'foo': "Bar"}, none=None, true=True, false=False)
-    to_check = dict(string="Foobar", list=["Foo", "Bar"], dict=["Foo", "Bar"], none=None, true=True, false=False)
-    with pytest.raises(ValidationException):
-        recurse_check_structure(sample, to_check)
 
 
 def test_split_string_after_returns_original_string_when_chunksize_equals_string_size():


### PR DESCRIPTION
I just applied a couple principles:

- This should not be an API of Errbot
- If not used in Errbot, it is removed
- If is it used only once in Errbot, it is moved to the spot where it is
used
- If it is used a couple times in Errbot and doesn't have a natural spot
within the source tree, it stays.