### PR TITLE
Make hipchat room string representation return the jabber-id

### DIFF
--- a/errbot/backends/hipchat.py
+++ b/errbot/backends/hipchat.py
@@ -154,7 +154,7 @@ class HipChatRoom(Room):
         return "<HipChatMUCRoom('{}')>".format(self.name)
 
     def __str__(self):
-        return self._name
+        return self.jid
 
     def join(self, username=None, password=None):
         """


### PR DESCRIPTION
This is needed to allow usage of a ```HipChatRoom``` in the ```from``` field of messages