### PR TITLE
Allow SUPPRESS_CMD_NOT_FOUND=True without crashing

### DIFF
--- a/errbot/core_plugins/cnf_filter.py
+++ b/errbot/core_plugins/cnf_filter.py
@@ -21,7 +21,7 @@ class CommandNotFoundFilter(BotPlugin):
             return msg, cmd, args
 
         if self.bot_config.SUPPRESS_CMD_NOT_FOUND:
-            log.debug("Surpressing command not found feedback")
+            self.log.debug("Surpressing command not found feedback")
         else:
             if msg.body.find(' ') > 0:
                 command = msg.body[:msg.body.index(' ')]

--- a/errbot/core_plugins/cnf_filter.py
+++ b/errbot/core_plugins/cnf_filter.py
@@ -21,7 +21,7 @@ class CommandNotFoundFilter(BotPlugin):
             return msg, cmd, args
 
         if self.bot_config.SUPPRESS_CMD_NOT_FOUND:
-            self.log.debug("Surpressing command not found feedback")
+            self.log.debug("Suppressing command not found feedback")
         else:
             if msg.body.find(' ') > 0:
                 command = msg.body[:msg.body.index(' ')]


### PR DESCRIPTION
Fixed a typo that made the bot crash when the configuration option SUPPRESS_CMD_NOT_FOUND was set to True.