### PR TITLE
callback all unknown commands filters.

### DIFF
--- a/errbot/core.py
+++ b/errbot/core.py
@@ -328,10 +328,12 @@ class ErrBot(Backend, StoreMixin):
             log.debug("Command not found")
             for cmd_filter in self.command_filters:
                 if getattr(cmd_filter, 'catch_unprocessed', False):
-                    reply = cmd_filter(mess, cmd, args, False, emptycmd=True)
-                    if reply:
-                        self.send_simple_reply(mess, reply)
-                        return True
+                    try:
+                        reply = cmd_filter(mess, cmd, args, False, emptycmd=True)
+                        if reply:
+                            self.send_simple_reply(mess, reply)
+                    except Exception:
+                        log.exception("Exception in a command filter command.")
         return True
 
     def _process_command_filters(self, msg, cmd, args, dry_run=False):

--- a/errbot/core.py
+++ b/errbot/core.py
@@ -332,6 +332,7 @@ class ErrBot(Backend, StoreMixin):
                         reply = cmd_filter(mess, cmd, args, False, emptycmd=True)
                         if reply:
                             self.send_simple_reply(mess, reply)
+                        # continue processing the other unprocessed cmd filters.
                     except Exception:
                         log.exception("Exception in a command filter command.")
         return True


### PR DESCRIPTION
This changes the behavior of the unknown command filters.
As you can disable the core unknown command plugin, it is better to callback all those and let the user choose which one should be active.