### PR TITLE
utf open changes.rst

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,9 @@ if __name__ == "__main__":
 
     args = set(sys.argv)
 
-    changes = open('CHANGES.rst', 'r', encoding='utf-8').read()
+    changes_file = open('CHANGES.rst', 'r', encoding='utf-8')
+    changes = changes_file.read()
+    changes_file.close()
 
     if changes.find(VERSION) == -1:
         raise Exception('You forgot to put a release note in CHANGES.rst ?!')

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ def read_version():
 
 
 def read(fname, encoding='ascii'):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read().decode(encoding)
+    return open(os.path.join(os.path.dirname(__file__), fname), 'r', encoding=encoding).read()
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -68,8 +68,8 @@ def read_version():
     return variables['VERSION']
 
 
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+def read(fname, encoding='ascii'):
+    return open(os.path.join(os.path.dirname(__file__), fname)).read().decode(encoding)
 
 
 if __name__ == "__main__":
@@ -78,8 +78,7 @@ if __name__ == "__main__":
 
     args = set(sys.argv)
 
-    with open('CHANGES.rst', 'r', encoding='utf-8') as changes_file:
-        changes = changes_file.read()
+    changes = read('CHANGES.rst', 'utf8')
 
     if changes.find(VERSION) == -1:
         raise Exception('You forgot to put a release note in CHANGES.rst ?!')

--- a/setup.py
+++ b/setup.py
@@ -78,8 +78,8 @@ if __name__ == "__main__":
 
     args = set(sys.argv)
 
-    changes_file = open('CHANGES.rst', 'r', encoding='utf-8')
-    changes = changes_file.read()
+    open('CHANGES.rst', 'r', encoding='utf-8') as changes_file:
+        changes = changes_file.read()
     changes_file.close()
 
     if changes.find(VERSION) == -1:

--- a/setup.py
+++ b/setup.py
@@ -78,9 +78,8 @@ if __name__ == "__main__":
 
     args = set(sys.argv)
 
-    open('CHANGES.rst', 'r', encoding='utf-8') as changes_file:
+    with open('CHANGES.rst', 'r', encoding='utf-8') as changes_file:
         changes = changes_file.read()
-    changes_file.close()
 
     if changes.find(VERSION) == -1:
         raise Exception('You forgot to put a release note in CHANGES.rst ?!')

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ if __name__ == "__main__":
 
     args = set(sys.argv)
 
-    changes = read('CHANGES.rst')
+    changes = open('CHANGES.rst', 'r', encoding='utf-8').read()
 
     if changes.find(VERSION) == -1:
         raise Exception('You forgot to put a release note in CHANGES.rst ?!')


### PR DESCRIPTION
due to the é character in CHANGES.rst which causes compile time error in my environment.

```
Collecting https://github.com/errbotio/errbot/archive/master.zip
  Downloading https://github.com/errbotio/errbot/archive/master.zip (1.4MB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-8y2onk3m-build/setup.py", line 81, in <module>
        changes = read('CHANGES.rst')
      File "/tmp/pip-8y2onk3m-build/setup.py", line 72, in read
        return open(os.path.join(os.path.dirname(__file__), fname)).read()
      File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 139: ordinal not in range(128)
```