### PR TITLE
Show version when using git version

### DIFF
--- a/errbot/core_plugins/help.py
+++ b/errbot/core_plugins/help.py
@@ -1,4 +1,5 @@
 import textwrap
+import subprocess
 
 from errbot import BotPlugin, botcmd
 from errbot.version import VERSION
@@ -9,11 +10,28 @@ class Help(BotPlugin):
                     'about that specific command.'
     MSG_HELP_UNDEFINED_COMMAND = 'That command is not defined.'
 
+    def is_git_directory(self, path='.'):
+        try:
+            git_call = subprocess.Popen(["get", "tag"], stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
+        except:
+            return None
+        tags, _ = git_call.communicate()
+        return_code = git_call.returncode
+        if return_code != 0:
+            return None
+        else:
+            tags = tags.rstrip(b"\n")
+            return tags.split(b"\n").pop(-1)
+
     # noinspection PyUnusedLocal
     @botcmd(template='about')
     def about(self, mess, args):
         """Return information about this Errbot instance and version"""
-        return {'version': VERSION}
+        git_version = self.is_git_directory()
+        if git_version:
+            return {'version': "{} GIT CHECKOUT".format(git_version.decode("utf-8"))}
+        else:
+            return {'version': VERSION}
 
     # noinspection PyUnusedLocal
     @botcmd

--- a/errbot/core_plugins/help.py
+++ b/errbot/core_plugins/help.py
@@ -12,7 +12,7 @@ class Help(BotPlugin):
 
     def is_git_directory(self, path='.'):
         try:
-            git_call = subprocess.Popen(["get", "tag"], stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
+            git_call = subprocess.Popen(["git", "tag"], stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
         except:
             return None
         tags, _ = git_call.communicate()


### PR DESCRIPTION
When you are using Errbot by a git checkout the version will always be `9.9.9` when you type `!about`

With this PR we return the latest tag and add `GIT CHECKOUT` to clarify that it is a git checkout.

preferably I want to use git but I don't know the thoughts about an extra python library in the core files only for those who want the git checkout. 

This version is a sort of idea. feel free to edit/improve