### PR TITLE
Fix typo of variable

### DIFF
--- a/errbot/cli.py
+++ b/errbot/cli.py
@@ -150,7 +150,7 @@ def main():
             if not os.path.isdir(base_dir):
                 print('Target directory %s must exist. Please create it.' % base_dir)
 
-            base_dir = os.path.abspath(base_bir)
+            base_dir = os.path.abspath(base_dir)
             data_dir = os.path.join(base_dir, 'data')
             extra_plugin_dir = os.path.join(base_dir, 'plugins')
             example_plugin_dir = os.path.join(extra_plugin_dir, 'err-example')


### PR DESCRIPTION
Latest master include typo of variable in cli.py.
So `errbot --init` can not initialize directory.

This PR fix it.

## Captured output
```
❯ git rev-parse HEAD
1950c1865299dfd9653e7aa39866ab5c4624bf9f
❯ mkdir test_project
❯ errbot --init test_project
The initialization of your errbot directory failed: name 'base_bir' is not defined
```