### PR TITLE
HipChat.send to chat rooms fails because of Identifier

### DIFF
--- a/errbot/backends/hipchat.py
+++ b/errbot/backends/hipchat.py
@@ -154,7 +154,7 @@ class HipChatRoom(Room):
         return "<HipChatMUCRoom('{}')>".format(self.name)
 
     def __str__(self):
-        return self._name
+        return self.room['xmpp_jid']
 
     def join(self, username=None, password=None):
         """


### PR DESCRIPTION
Fix hipchat issue where .send to a chatroom fails because the XMPP messages recipient is set to room name instead of JID. Modify __str__ representation to return JID, which is used in Identity builder

Before change, the XMPP mto wound up being a string and would fail:
2017-06-20 20:26:33,506 WARNING  errbot.backends.xmpp      Received error message: <message type="error" from="Test Alerts" to="xxxxx_xxxxx@chat.hipchat.com/none||proxy|pubproxy-c600.hipchat.com|5292"><body>URL: none</body><error code="400" type="modify"><jid-malformed xmlns="urn:ietf:params:xml:ns:xmpp-stanzas" /></error></message>
2017-06-20 20:28:46,308 INFO     sleekxmpp.basexmpp        event=make_message mto=**"Test Alerts"** mbody="(alert) [test] test" msubject="None" mtype="groupchat" mfrom="None" mnick="None"

After:
2017-06-20 20:38:08,603 INFO     sleekxmpp.basexmpp        event=make_message mto="xxxxx_test_alerts@conf.hipchat.com" mbody="(alert) [test] test" msubject="None" mtype="chat" mfrom="None" mnick="None"

I am not entirely sure what else is impacted by changing the HipChatRoom.__str__ representation, but at most (hypchat implications?)

But this seems to work for me without any issues