### PR TITLE
add: Function `delay_call` for `BotPlugin`

### DIFF
--- a/docs/user_guide/plugin_development/scheduling.rst
+++ b/docs/user_guide/plugin_development/scheduling.rst
@@ -24,3 +24,22 @@ minute when your plugin gets activated:
         def activate(self):
             super().activate()
             self.start_poller(60, self.my_callback)
+
+Delaying a function call
+------------------------
+
+It can also be sometimes useful to delay a call to a function for some
+time. This can be done using :meth:`~errbot.botplugin.BotPlugin.delay_call`
+
+.. code-block:: python
+   :emphasize-lines: 10
+
+    from errbot import BotPlugin
+
+    class PluginExample(BotPlugin):
+        def my_callback(self, frm):
+            self.log.debug('I got called after a minute')
+
+        def activate(self):
+            super().activate()
+            self.delay_call(60, self.my_callback)

--- a/errbot/botplugin.py
+++ b/errbot/botplugin.py
@@ -266,6 +266,16 @@ class BotPluginBase(StoreMixin):
                 log.exception('A poller crashed')
             self.program_next_poll(interval, method, args, kwargs)
 
+    def delay_call(self,
+                   delay: float,
+                   method: Callable[..., None],
+                   args: Tuple=None,
+                   kwargs: Mapping=None):
+        t = Timer(interval=delay, function=method, args=args, kwargs=kwargs)
+        t.setName('A delayed call to %s' % type(method.__self__).__name__)
+        t.setDaemon(True)  # so it is not locking on exit
+        t.start()
+
     def create_dynamic_plugin(self, name: str, commands: Tuple[Command], doc: str=''):
         """
             Creates a plugin dynamically and exposes its commands right away.
@@ -664,6 +674,22 @@ class BotPlugin(BotPluginBase):
 
         """
         super().stop_poller(method, args, kwargs)
+
+    def delay_call(self,
+                   delay: float,
+                   method: Callable[..., None],
+                   args: Tuple=None,
+                   kwargs: Mapping=None):
+        """
+            Delay execution of a method for a given amount of seconds.
+
+            :param kwargs: kwargs for the method to callback.
+            :param args: args for the method to callback.
+            :param method: method to callback.
+            :param delay: the delay in seconds.
+
+        """
+        super().delay_call(delay, method, args, kwargs)
 
 
 class ArgParserBase(object):


### PR DESCRIPTION
* Add function `delay_call` which delays the execution of a provided
  method for a given number of seconds to `BotPlugin`

* Add a bit of documentation on the newly added `delay_call` function.

Signed-off-by: mr.Shu <mr@shu.io>