### PR TITLE
add: `times` parameter to `start_poller`

### DIFF
--- a/docs/user_guide/plugin_development/scheduling.rst
+++ b/docs/user_guide/plugin_development/scheduling.rst
@@ -24,3 +24,20 @@ minute when your plugin gets activated:
         def activate(self):
             super().activate()
             self.start_poller(60, self.my_callback)
+
+
+It is also possible to specify the `times` parameter, which denotes how
+many times should the function be called, for instance
+
+.. code-block:: python
+   :emphasize-lines: 10
+
+    from errbot import BotPlugin
+
+    class PluginExample(BotPlugin):
+        def my_callback(self):
+            self.log.debug('I got called after a minute (and just once)')
+
+        def activate(self):
+            super().activate()
+            self.start_poller(60, self.my_callback, times=1)

--- a/tests/poller_plugin/poller_plugin.plug
+++ b/tests/poller_plugin/poller_plugin.plug
@@ -1,0 +1,6 @@
+[Core]
+Name = PollerPlugin
+Module = poller_plugin
+
+[Python]
+Version = 2+

--- a/tests/poller_plugin/poller_plugin.py
+++ b/tests/poller_plugin/poller_plugin.py
@@ -1,0 +1,15 @@
+from __future__ import absolute_import
+from errbot import BotPlugin, botcmd
+
+
+class PollerPlugin(BotPlugin):
+
+    def delayed_hello(self, frm):
+        self.send(frm, 'Hello world! was sent 5 seconds ago')
+
+    @botcmd
+    def hello(self, msg, args):
+        """Say hello to the world."""
+        self.start_poller(0.1, self.delayed_hello, times=1,
+                          kwargs={'frm': msg.frm})
+        return "Hello, world!"

--- a/tests/poller_test.py
+++ b/tests/poller_test.py
@@ -1,0 +1,14 @@
+from os import path
+import time
+
+CURRENT_FILE_DIR = path.dirname(path.realpath(__file__))
+extra_plugin_dir = path.join(CURRENT_FILE_DIR, 'poller_plugin')
+
+
+def test_delayed_hello(testbot):
+    assert 'Hello, world!' in testbot.exec_command('!hello')
+    time.sleep(1)
+    delayed_msg = 'Hello world! was sent 5 seconds ago'
+    assert delayed_msg in testbot.pop_message(timeout=1)
+    # Assert that only one message has been enqueued
+    assert testbot.bot.outgoing_message_queue.empty()


### PR DESCRIPTION
* Add a `times` parameter to `start_poller` which denotes how many times
  a method should be polled.

* Add a bit of documentation on the new `times` parameter.

Signed-off-by: mr.Shu <mr@shu.io>