### PR TITLE
irc: Fix maximal message length

### DIFF
--- a/errbot/backends/irc.py
+++ b/errbot/backends/irc.py
@@ -52,7 +52,13 @@ IRC_CHRS = CharacterTable(fg_black=NSC('\x0301'),
                           end_inline_code='')
 
 IRC_NICK_REGEX = r'[a-zA-Z\[\]\\`_\^\{\|\}][a-zA-Z0-9\[\]\\`_\^\{\|\}-]+'
-IRC_MESSAGE_SIZE_LIMIT = 510
+# According to the RFC the IRC message size can be at most 512 bytes
+# Out of these 2 bytes are necessary for '\r\n'.
+# At least 10 bytes for 'PRIVMSG <to> :'
+# (note that <to> is being taken care of in split_and_send_message
+#  using MESSAGE_SIZE_LIMIT_INCLUDES_ADDRESEE)
+# And one more byte for b'\x03' -- EXT - End Of Text
+IRC_MESSAGE_SIZE_LIMIT = 499
 
 try:
     import irc.connection
@@ -669,6 +675,7 @@ class IRCBackend(ErrBot):
                                   )
         self.md = irc_md()
         config.MESSAGE_SIZE_LIMIT = IRC_MESSAGE_SIZE_LIMIT
+        config.MESSAGE_SIZE_LIMIT_INCLUDES_ADDRESEE = True
 
     def send_message(self, msg):
         super().send_message(msg)

--- a/errbot/bootstrap.py
+++ b/errbot/bootstrap.py
@@ -42,7 +42,10 @@ def bot_config_defaults(config):
     if not hasattr(config, 'DIVERT_TO_PRIVATE'):
         config.DIVERT_TO_PRIVATE = ()
     if not hasattr(config, 'MESSAGE_SIZE_LIMIT'):
-        config.MESSAGE_SIZE_LIMIT = 10000  # Corresponds with what HipChat accepts
+        # Corresponds with what HipChat accepts
+        config.MESSAGE_SIZE_LIMIT = 10000
+    if not hasattr(config, 'MESSAGE_SIZE_LIMIT_INCLUDES_ADDRESEE'):
+        config.MESSAGE_SIZE_LIMIT_INCLUDES_ADDRESEE = False
     if not hasattr(config, 'GROUPCHAT_NICK_PREFIXED'):
         config.GROUPCHAT_NICK_PREFIXED = False
     if not hasattr(config, 'AUTOINSTALL_DEPS'):

--- a/errbot/core.py
+++ b/errbot/core.py
@@ -158,7 +158,14 @@ class ErrBot(Backend, StoreMixin):
         return self.send(identifier, text, in_reply_to, groupchat_nick_reply)
 
     def split_and_send_message(self, msg):
-        for part in split_string_after(msg.body, self.bot_config.MESSAGE_SIZE_LIMIT):
+        size_limit = self.bot_config.MESSAGE_SIZE_LIMIT
+
+        # If MESSAGE_SIZE_LIMIT_INCLUDES_ADDRESEE is set to True, lower the
+        # size_limit by the size of the string representation of the addressee
+        if self.bot_config.MESSAGE_SIZE_LIMIT_INCLUDES_ADDRESEE:
+            size_limit -= len(str(msg.to))
+
+        for part in split_string_after(msg.body, size_limit):
             partial_message = msg.clone()
             partial_message.body = part
             self.send_message(partial_message)


### PR DESCRIPTION
* The maximal message length has previously been set to 510 (probably in
  order to accomodate the b'\r\n' that are necessary for each IRC
  message). This turns out not to be enough, as the message starts with
  the obligatory `PRIVMSG <to> :` and ends with the EXT (b'\x03) mark.

* The size limit was therefore set to `499` in order to accomodate all
  these obligatory parts.

* Furthermore, a new configuration option has been added
  (`MESSAGE_SIZE_LIMIT_INCLUDES_ADDRESEE`), which takes care of the fact
  that `<to>` -- the addressee of the message -- comes directly after
  `PRIVMSG` and is thus part of the message. Note that this is currently
  only applied in the case of IRC.

* Fixes #989

Signed-off-by: mr.Shu <mr@shu.io>