### PR TITLE
slack: Add markdown support for text and pretext

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -721,6 +721,8 @@ class SlackBackend(ErrBot):
         if card.fields:
             attachment['fields'] = [{'title': key, 'value': value, 'short': True} for key, value in card.fields]
 
+        attachment['mrkdwn_in'] = ['text', 'pretext']
+
         data = {
             'text': ' ',
             'channel': to_channel_id,


### PR DESCRIPTION
Add markdown support for text and pretext in slack cards.
Fixes #839

Signed-off-by: Roi Dayan <roi.dayan@gmail.com>