### PR TITLE
Fixing Hipchat backend for send_card to correctly look up room name

### DIFF
--- a/errbot/backends/hipchat.py
+++ b/errbot/backends/hipchat.py
@@ -480,7 +480,7 @@ class HipchatBackend(XMPPBackend):
         if not card.is_group:
             raise ValueError('Private notifications/cards are impossible to send on 1 to 1 messages on hipchat.')
         log.debug("room id = %s" % card.to)
-        room = self.conn.hypchat.get_room(str(card.to))
+        room = self.query_room(str(card.to)).room
 
         data = {'message': '-' if not card.body else self.md.convert(card.body),
                 'notify': False,


### PR DESCRIPTION
Uses query_room to get the room object from the API. This way we avoid
the 404 room not found errors since card.to is the full HipChat XMPP
room name.