### PR TITLE
Fixes HipChat user ACLs when in a room

### DIFF
--- a/errbot/backends/hipchat.py
+++ b/errbot/backends/hipchat.py
@@ -103,6 +103,7 @@ class HipChatRoomOccupant(XMPPRoomOccupant):
     def aclattr(self):
         return self._aclattr
 
+
 class HipChatRoom(Room):
     """
     This class represents a Multi-User Chatroom.
@@ -412,7 +413,11 @@ class HipchatBackend(XMPPBackend):
 
     def _build_room_occupant(self, txtrep):
         node, domain, resource = split_identifier(txtrep)
-        return self.roomoccupant_factory(node, domain, resource, self.query_room(node + '@' + domain), aclattr = self._find_user(resource, 'name'))
+        return self.roomoccupant_factory(node,
+                                         domain,
+                                         resource,
+                                         self.query_room(node + '@' + domain),
+                                         aclattr=self._find_user(resource, 'name'))
 
     def callback_message(self, msg):
         super().callback_message(msg)

--- a/errbot/backends/hipchat.py
+++ b/errbot/backends/hipchat.py
@@ -6,7 +6,7 @@ import sys
 from functools import lru_cache
 
 from errbot.backends.base import Room, RoomDoesNotExistError, RoomOccupant
-from errbot.backends.xmpp import XMPPRoomOccupant, XMPPBackend, XMPPConnection
+from errbot.backends.xmpp import XMPPRoomOccupant, XMPPBackend, XMPPConnection, split_identifier
 
 from markdown import Markdown
 from markdown.extensions.extra import ExtraExtension
@@ -77,7 +77,7 @@ class HipChatRoomOccupant(XMPPRoomOccupant):
     https://www.hipchat.com/docs/apiv2/method/get_all_participants
     with the link to self expanded.
     """
-    def __init__(self, node=None, domain=None, resource=None, room=None, hipchat_user=None):
+    def __init__(self, node=None, domain=None, resource=None, room=None, hipchat_user=None, aclattr=None):
         """
         :param hipchat_user:
             A user object as returned by
@@ -94,8 +94,14 @@ class HipChatRoomOccupant(XMPPRoomOccupant):
                 node_domain = hipchat_user['xmpp_jid']
                 resource = hipchat_user['name']
             node, domain = node_domain.split('@')
+
+        self._aclattr = aclattr
+
         super().__init__(node, domain, resource, room)
 
+    @property
+    def aclattr(self):
+        return self._aclattr
 
 class HipChatRoom(Room):
     """
@@ -403,6 +409,10 @@ class HipchatBackend(XMPPBackend):
             server=self.server,
             verify=self.api_verify,
         )
+
+    def _build_room_occupant(self, txtrep):
+        node, domain, resource = split_identifier(txtrep)
+        return self.roomoccupant_factory(node, domain, resource, self.query_room(node + '@' + domain), aclattr = self._find_user(resource, 'name'))
 
     def callback_message(self, msg):
         super().callback_message(msg)


### PR DESCRIPTION
When in a room, the ACL plugin tries to compare ACLs against the MUC
from JID which does not directly correlate to the actual JID of the user.
Here I am using the aclattr property to set the user's JID which the
ACL plugin will use to match against.