### PR TITLE
Text mode is now persistent.

### DIFF
--- a/errbot/backends/text.py
+++ b/errbot/backends/text.py
@@ -165,61 +165,6 @@ class TextOccupant(TextPerson, RoomOccupant):
         return self.person.__hash__() + self.room.__hash__()
 
 
-class TextPlugin(BotPlugin):
-    """
-        Internal to TextBackend.
-    """
-
-    __errdoc__ = "Added commands for testing purposes"
-
-    @botcmd
-    def inroom(self, msg, args):
-        """
-           This puts you in a room with the bot.
-        """
-        self._bot._inroom = True
-        return 'Joined Room %s.' % self._bot._rooms[0]
-
-    @botcmd
-    def inperson(self, msg, args):
-        """
-           This puts you in a 1-1 chat with the bot.
-        """
-        self._bot._inroom = False
-        return 'Now in one-on-one with the bot.'
-
-    @botcmd
-    def asuser(self, msg, args):
-        """
-           This puts you in a room with the bot. You can specify a name otherwise it will default to 'luser'.
-        """
-        if args:
-            usr = args
-            if usr[0] != '@':
-                usr = '@' + usr
-            self._bot.user = self.build_identifier(usr)
-        else:
-            self._bot.user = self.build_identifier('@luser')
-        return 'You are now: %s' % self._bot.user
-
-    @botcmd
-    def asadmin(self, msg, args):
-        """
-           This puts you in a 1-1 chat with the bot.
-        """
-        self._bot.user = self.build_identifier(self.bot_config.BOT_ADMINS[0])
-        return 'You are now an admin: %s' % self._bot.user
-
-    @botcmd
-    def ml(self, msg, args):
-        """
-           Switch back and forth between normal mode and multiline mode. Use this if you want to test
-           commands spanning multiple lines. Note: in multiline, press enter twice to end and send the message.
-        """
-        self._bot._multiline = not self._bot._multiline
-        return 'Multiline mode, press enter twice to end messages' if self._bot._multiline else 'Normal one line mode.'
-
-
 INTRO = """
 ---
 You start as a **bot admin in a one-on-one conversation** with the bot.
@@ -287,9 +232,6 @@ class TextBackend(ErrBot):
 
     def serve_forever(self):
         self.readline_support()
-
-        # Add custom commands just for this backend.
-        self.inject_commands_from(TextPlugin(self, 'TextPlugin'))
 
         if not self._rooms:
             # artificially join a room if None were specified.

--- a/errbot/core_plugins/textcmds.plug
+++ b/errbot/core_plugins/textcmds.plug
@@ -1,0 +1,7 @@
+[Core]
+Name = TextCmds
+Module = textcmds
+Core = True
+
+[Documentation]
+Description = Commands only available in text mode to manage the chatting context (inperson, inroom, asadmin ...).

--- a/errbot/core_plugins/textcmds.py
+++ b/errbot/core_plugins/textcmds.py
@@ -1,0 +1,90 @@
+from errbot import BotPlugin, botcmd
+
+INROOM, USER, MULTILINE = 'inroom', 'user', 'multiline'
+
+
+class TextModeCmds(BotPlugin):
+    """
+        Internal to TextBackend.
+    """
+
+    __errdoc__ = "Added commands for testing purposes"
+
+    def activate(self):
+
+        # This won't activate the plugin in anything else than text mode.
+        if self.mode != 'text':
+            return
+
+        super().activate()
+
+        # Some defaults if it was never used before'.
+        if INROOM not in self:
+            self[INROOM] = False
+
+        if USER not in self:
+            self[USER] = self.build_identifier(self.bot_config.BOT_ADMINS[0])
+
+        if MULTILINE not in self:
+            self[MULTILINE] = False
+
+        # Restore the values to their live state.
+        self._bot._inroom = self[INROOM]
+        self._bot.user = self[USER]
+        self._bot._multiline = self[MULTILINE]
+
+    def deactivate(self):
+
+        # Save the live state.
+        self[INROOM] = self._bot._inroom
+        self[USER] = self._bot.user
+        self[MULTILINE] = self._bot._multiline
+
+        super().deactivate()
+
+    @botcmd
+    def inroom(self, msg, _):
+        """
+           This puts you in a room with the bot.
+        """
+        self._bot._inroom = True
+        return 'Joined Room %s.' % self._bot._rooms[0]
+
+    @botcmd
+    def inperson(self, msg, _):
+        """
+           This puts you in a 1-1 chat with the bot.
+        """
+        self._bot._inroom = False
+        return 'Now in one-on-one with the bot.'
+
+    @botcmd
+    def asuser(self, msg, args):
+        """
+           This puts you in a room with the bot. You can specify a name otherwise it will default to 'luser'.
+        """
+        if args:
+            usr = args
+            if usr[0] != '@':
+                usr = '@' + usr
+            self._bot.user = self.build_identifier(usr)
+        else:
+            self._bot.user = self.build_identifier('@luser')
+        return 'You are now: %s' % self._bot.user
+
+    @botcmd
+    def asadmin(self, msg, _):
+        """
+           This puts you in a 1-1 chat with the bot.
+        """
+        self._bot.user = self.build_identifier(self.bot_config.BOT_ADMINS[0])
+        return 'You are now an admin: %s' % self._bot.user
+
+    @botcmd
+    def ml(self, msg, _):
+        """
+           Switch back and forth between normal mode and multiline mode. Use this if you want to test
+           commands spanning multiple lines. Note: in multiline, press enter twice to end and send the message.
+        """
+        self._bot._multiline = not self._bot._multiline
+        return 'Multiline mode, press enter twice to end messages' if self._bot._multiline else 'Normal one line mode.'


### PR DESCRIPTION
The Text mode now persist the context of the chat (multiline, admin,
room etc...).

Usually when I test a plugin I want to restart from the same state if I
have to restart the bot. For example: I test a feature in a room or with
a specific user I don't want to redo !inroom !asuser at every restart.

This makes those commands persistents. It also cleanup the text backend
code my promoting the fake plugin from Text into a core plugin in
errbot.