### PR TITLE
Remove smart quotes for argument parsing

### DIFF
--- a/errbot/__init__.py
+++ b/errbot/__init__.py
@@ -343,8 +343,10 @@ def arg_botcmd(*args,
                 # Some clients automatically convert consecutive dashes into a fancy
                 # hyphen, which breaks long-form arguments. Undo this conversion to
                 # provide a better user experience.
+                # Same happens with quotations marks, which are required for parsing
+                # complex strings in arguments
                 try:
-                    args = shlex.split(args.replace('—', '--'))
+                    args = shlex.split(args.replace('—', '--').replace('“', '"').replace('”', '"'))
                     parsed_args = err_command_parser.parse_args(args)
                 except ArgumentParseError as e:
                     yield "I'm sorry, I couldn't parse the arguments; %s" % e


### PR DESCRIPTION
Slack replaces all quotation marks with smart quotation marks, which interferes with parsing commands via the argparse interface. This PR fixes this by stripping smart quotation marks from the arguments.