### PR TITLE
Switch argument santization to regex.

### DIFF
--- a/errbot/__init__.py
+++ b/errbot/__init__.py
@@ -346,7 +346,10 @@ def arg_botcmd(*args,
                 # Same happens with quotations marks, which are required for parsing
                 # complex strings in arguments
                 try:
-                    args = shlex.split(args.replace('—', '--').replace('“', '"').replace('”', '"'))
+                    #Map of strings to replace with sanitized versions
+                    sanitizers = {'—': '--', '“': '"', '”': '"'}
+                    sanitizer_re = re.compile('|'.join(re.escape(ii) for ii in sanitizers))
+                    args = sanitizer_re.sub(lambda mm: sanitizers[mm.group()], args)
                     parsed_args = err_command_parser.parse_args(args)
                 except ArgumentParseError as e:
                     yield "I'm sorry, I couldn't parse the arguments; %s" % e

--- a/errbot/__init__.py
+++ b/errbot/__init__.py
@@ -28,6 +28,14 @@ webview = view  # this allows to use the templating system
 # TODO: Remove, this is for backend backward compatibility
 sys.modules["errbot.errBot"] = core
 
+# Some clients automatically convert consecutive dashes into a fancy
+# hyphen, which breaks long-form arguments. Undo this conversion to
+# provide a better user experience.
+# Same happens with quotations marks, which are required for parsing
+# complex strings in arguments
+# Map of characters to sanitized equivalents
+ARG_BOTCMD_CHARACTER_REPLACEMENTS = {'—': '--', '“': '"', '”': '"'}
+
 
 class ArgumentParseError(Exception):
     """Raised when ArgumentParser couldn't parse given arguments."""
@@ -340,16 +348,11 @@ def arg_botcmd(*args,
             @wraps(func)
             def wrapper(self, msg, args):
 
-                # Some clients automatically convert consecutive dashes into a fancy
-                # hyphen, which breaks long-form arguments. Undo this conversion to
-                # provide a better user experience.
-                # Same happens with quotations marks, which are required for parsing
-                # complex strings in arguments
+                # Attempt to sanitize arguments of bad characters
                 try:
-                    #Map of strings to replace with sanitized versions
-                    sanitizers = {'—': '--', '“': '"', '”': '"'}
-                    sanitizer_re = re.compile('|'.join(re.escape(ii) for ii in sanitizers))
-                    args = sanitizer_re.sub(lambda mm: sanitizers[mm.group()], args)
+                    sanitizer_re = re.compile('|'.join(re.escape(ii) for ii in ARG_BOTCMD_CHARACTER_REPLACEMENTS))
+                    args = sanitizer_re.sub(lambda mm: ARG_BOTCMD_CHARACTER_REPLACEMENTS[mm.group()], args)
+                    args = shlex.split(args)
                     parsed_args = err_command_parser.parse_args(args)
                 except ArgumentParseError as e:
                     yield "I'm sorry, I couldn't parse the arguments; %s" % e


### PR DESCRIPTION
This refactors the argument sanitization changes in #1094 to build a single regex statement for replace problematic characters, which is more easily extensible by adding entries into a dictionary as opposed to stringing `replace` calls together. I'm happy to refactor/adjust as requested, since this is a bit more complicated than the original version.