### PR TITLE
Make all config directory strings raw strings.

### DIFF
--- a/errbot/templates/initdir/config.py.tmpl
+++ b/errbot/templates/initdir/config.py.tmpl
@@ -8,7 +8,7 @@ import logging
 BACKEND = 'Text'  # Errbot will start in text mode (console only mode) and will answer commands from there.
 
 BOT_DATA_DIR = r'{{ data_dir }}'
-BOT_EXTRA_PLUGIN_DIR = '{{ extra_plugin_dir }}'
+BOT_EXTRA_PLUGIN_DIR = r'{{ extra_plugin_dir }}'
 
 BOT_LOG_FILE = r'{{ log_path }}'
 BOT_LOG_LEVEL = logging.DEBUG


### PR DESCRIPTION
This fixes issues on Windows, where backslashes
are used in directory paths.

Specifically, I received this error when trynig to run errbot on windows:
```
C:\Users\Robert\errbot>errbot
Starting errbot with a default system encoding other than 'utf-8' might cause you a heap of troubles. Your current encoding
 is set at 'cp1252'
I could not import your config from C:\Users\Robert\errbot\config.py, please check the error below...
Traceback (most recent call last):
  File "c:\users\robert\appdata\local\programs\python\python35-32\lib\site-packages\errbot\cli.py", line 77, in get_config
    config = __import__(path.splitext(path.basename(config_fullpath))[0])
  File "C:\Users\Robert\errbot\config.py", line 11
    BOT_EXTRA_PLUGIN_DIR = 'C:\Users\Robert\errbot\plugins'
                          ^
SyntaxError: (unicode error) 'unicodeescape' codec can't decode bytes in position 2-3: truncated \UXXXXXXXX escape
```