### PR TITLE
fix(repo_manager): Use utc timestamps (#1)

### DIFF
--- a/errbot/repo_manager.py
+++ b/errbot/repo_manager.py
@@ -106,12 +106,12 @@ class BotRepoManager(StoreMixin):
             log.info('No repo index, creating it.')
             self[REPO_INDEX] = {LAST_UPDATE: 0}
 
-        if datetime.fromtimestamp(self[REPO_INDEX][LAST_UPDATE]) < datetime.now() - REPO_INDEXES_CHECK_INTERVAL:
+        if datetime.utcfromtimestamp(self[REPO_INDEX][LAST_UPDATE]) < datetime.utcnow() - REPO_INDEXES_CHECK_INTERVAL:
             log.info('Index is too old, update it.')
             self.index_update()
 
     def index_update(self):
-        index = {LAST_UPDATE: datetime.now().timestamp()}
+        index = {LAST_UPDATE: datetime.utcnow().timestamp()}
         for source in reversed(self.plugin_indexes):
             try:
                 if urlparse(source).scheme in ('http', 'https'):

--- a/errbot/repo_manager.py
+++ b/errbot/repo_manager.py
@@ -105,6 +105,7 @@ class BotRepoManager(StoreMixin):
         if REPO_INDEX not in self:
             log.info('No repo index, creating it.')
             self.index_update()
+            return
 
         if datetime.fromtimestamp(self[REPO_INDEX][LAST_UPDATE]) < datetime.now() - REPO_INDEXES_CHECK_INTERVAL:
             log.info('Index is too old, update it.')

--- a/errbot/repo_manager.py
+++ b/errbot/repo_manager.py
@@ -104,14 +104,14 @@ class BotRepoManager(StoreMixin):
     def check_for_index_update(self):
         if REPO_INDEX not in self:
             log.info('No repo index, creating it.')
-            self[REPO_INDEX] = {LAST_UPDATE: 0}
+            self.index_update()
 
-        if datetime.utcfromtimestamp(self[REPO_INDEX][LAST_UPDATE]) < datetime.utcnow() - REPO_INDEXES_CHECK_INTERVAL:
+        if datetime.fromtimestamp(self[REPO_INDEX][LAST_UPDATE]) < datetime.now() - REPO_INDEXES_CHECK_INTERVAL:
             log.info('Index is too old, update it.')
             self.index_update()
 
     def index_update(self):
-        index = {LAST_UPDATE: datetime.utcnow().timestamp()}
+        index = {LAST_UPDATE: datetime.now().timestamp()}
         for source in reversed(self.plugin_indexes):
             try:
                 if urlparse(source).scheme in ('http', 'https'):


### PR DESCRIPTION
In a fresh instance of errbot with no previous storage data, the `LAST_UPDATE` time is set to 0 to indicate it's never been checked. However, when you search or install a new repo, it checks to see if should do an update, but since it was using `datetime.fromtimestamp` it would fail (at least on Windows, this might be OS specific) since 0 is an invalid value. Now we just call `self.index_update()` when we don't have any previous state to avoid the issue.