### PR TITLE
Cache global user list for HipChat to avoid large amounts of API calls

### DIFF
--- a/errbot/backends/hipchat.py
+++ b/errbot/backends/hipchat.py
@@ -154,7 +154,7 @@ class HipChatRoom(Room):
         return "<HipChatMUCRoom('{}')>".format(self.name)
 
     def __str__(self):
-        return self._name
+        return self.room['xmpp_jid']
 
     def join(self, username=None, password=None):
         """

--- a/errbot/backends/hipchat.py
+++ b/errbot/backends/hipchat.py
@@ -346,6 +346,7 @@ class HipchatClient(XMPPConnection):
     def __init__(self, *args, **kwargs):
         self.token = kwargs.pop('token')
         self.endpoint = kwargs.pop('endpoint')
+        self._cached_users = None
         verify = kwargs.pop('verify')
         if verify is None:
             verify = True
@@ -364,14 +365,17 @@ class HipchatClient(XMPPConnection):
 
         See also: https://www.hipchat.com/docs/apiv2/method/get_all_users
         """
-        result = self.hypchat.users(guests=True)
-        users = result['items']
-        next_link = 'next' in result['links']
-        while next_link:
-            result = result.next()
-            users += result['items']
+
+        if not self._cached_users:
+            result = self.hypchat.users(guests=True)
+            users = result['items']
             next_link = 'next' in result['links']
-        return users
+            while next_link:
+                result = result.next()
+                users += result['items']
+                next_link = 'next' in result['links']
+            self._cached_users = users
+        return self._cached_users
 
 
 class HipchatBackend(XMPPBackend):
@@ -549,6 +553,7 @@ class HipchatBackend(XMPPBackend):
         """
         users = [u for u in self.conn.users if u[criteria] == name]
         if not users:
+            log.debug('Failed to find user %s', name)
             return None
         userdetail = self.conn.hypchat.get_user("%s" % users[0]['id'])
         identifier = self.build_identifier(userdetail['xmpp_jid'])


### PR DESCRIPTION
Fix to resolve issue where large amount of calls to _find_user() was resulting in users() being called, which creates multiple calls to API.
After upgrading to latest version, I started hitting the throttle limit on every start while making a very large amount of repeated calls to users(). We have about 6 rooms with 10-20 participants each. 

Downside is that any modifications to users would no be picked up until the bot is restarted. Ideally, this would be time based cached that would expire, leading to periodic updates of user list. Can add this into request if desired.