### PR TITLE
Support breaking message body size into parts for Slack attachments.

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -728,7 +728,7 @@ class SlackBackend(ErrBot):
         footer = attachment.get("footer", "")
         for i in range(part_count):
             if part_count > 1:
-                attachment["footer"] = "{} [{} of {}]".format(footer, i + 1, part_count)
+                attachment["footer"] = "{} [{}/{}]".format(footer, i + 1, part_count)
             attachment["text"] = parts[i]
             data = {
                 'text': ' ',

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -724,10 +724,11 @@ class SlackBackend(ErrBot):
 
         limit = min(self.bot_config.MESSAGE_SIZE_LIMIT, SLACK_MESSAGE_LIMIT)
         parts = self.prepare_message_body(card.body, limit)
-
+        part_count = len(parts)
         footer = attachment.get("footer", "")
-        for i in range(len(parts)):
-            attachment["footer"] = "{} [{} of {}]".format(footer, i + 1, len(parts))
+        for i in range(part_count):
+            if part_count > 1:
+                attachment["footer"] = "{} [{} of {}]".format(footer, i + 1, part_count)
             attachment["text"] = parts[i]
             data = {
                 'text': ' ',


### PR DESCRIPTION
The slack backend already splits up large messages into `MESSAGE_SIZE_LIMIT` for the `send_message` method.  This patch uses the same logic for the `send_card` method.