### PR TITLE
Remove argument 'times' in BotPluginBase.start_poller

### DIFF
--- a/errbot/botplugin.py
+++ b/errbot/botplugin.py
@@ -231,7 +231,6 @@ class BotPluginBase(StoreMixin):
 
     def stop_poller(self,
                     method: Callable[..., None],
-                    times: int=None,
                     args: Tuple=None,
                     kwargs: Mapping=None):
         if not kwargs:

--- a/tests/poller_plugin/poller_plugin.py
+++ b/tests/poller_plugin/poller_plugin.py
@@ -13,3 +13,14 @@ class PollerPlugin(BotPlugin):
         self.start_poller(0.1, self.delayed_hello, times=1,
                           kwargs={'frm': msg.frm})
         return "Hello, world!"
+
+    def delayed_hello_loop(self, frm):
+        self.send(frm, 'Hello world! was sent 5 seconds ago')
+        self.stop_poller(self.delayed_hello_loop, args=(frm, ))
+
+    @botcmd
+    def hello_loop(self, msg, args):
+        """Say hello to the world."""
+        self.start_poller(0.1, self.delayed_hello_loop,
+                          args=(msg.frm, ))
+        return "Hello, world!"

--- a/tests/poller_test.py
+++ b/tests/poller_test.py
@@ -12,3 +12,12 @@ def test_delayed_hello(testbot):
     assert delayed_msg in testbot.pop_message(timeout=1)
     # Assert that only one message has been enqueued
     assert testbot.bot.outgoing_message_queue.empty()
+
+
+def test_delayed_hello_loop(testbot):
+    assert 'Hello, world!' in testbot.exec_command('!hello_loop')
+    time.sleep(1)
+    delayed_msg = 'Hello world! was sent 5 seconds ago'
+    assert delayed_msg in testbot.pop_message(timeout=1)
+    # Assert that only one message has been enqueued
+    assert testbot.bot.outgoing_message_queue.empty()


### PR DESCRIPTION
Fixes #1119  by removing unused argument in `BotPluginBase.start_poller`
