### PR TITLE
Hipchat backend: Fix HipChat Server XMPP namespace

### DIFF
--- a/errbot/backends/hipchat.py
+++ b/errbot/backends/hipchat.py
@@ -464,7 +464,7 @@ class HipchatBackend(XMPPBackend):
         :returns:
             An instance of :class:`~HipChatRoom`.
         """
-        if room.endswith('@conf.hipchat.com'):
+        if room.endswith('@conf.hipchat.com') or room.endswith('@conf.btf.hipchat.com'):
             log.debug("Room specified by JID, looking up room name")
             rooms = self.conn.hypchat.rooms(expand='items').contents()
             try:


### PR DESCRIPTION
Unlike for the HipChat cloud version, the XMPP namespace for HipChat Server is 'conf.btf.hipchat.com'. Added that to HipchatClient.query_room() to get the HipChat backend to work with HipChat Server.

Ref: https://confluence.atlassian.com/hipchatkb/hipchat-server-xmpp-namespace-conf-btf-hipchat-com-759990317.html