### PR TITLE
fix: Change default admin name

### DIFF
--- a/errbot/templates/initdir/config.py.tmpl
+++ b/errbot/templates/initdir/config.py.tmpl
@@ -13,4 +13,4 @@ BOT_EXTRA_PLUGIN_DIR = r'{{ extra_plugin_dir }}'
 BOT_LOG_FILE = r'{{ log_path }}'
 BOT_LOG_LEVEL = logging.DEBUG
 
-BOT_ADMINS = ('CHANGE ME', )  # !! Don't leave that to "CHANGE ME" if you connect your errbot to a chat system !!
+BOT_ADMINS = ('@CHANGE_ME', )  # !! Don't leave that to "@CHANGE_ME" if you connect your errbot to a chat system !!


### PR DESCRIPTION
This should allow users attempting to start errbot after running
`--init` are at least able to run in Test mode without any additional
changes.

It basically prevents users from seeing the following error as their first experience when running errbot:

```
Traceback (most recent call last):
  File "/home/saviles/.local/share/virtualenvs/errbot-6RMKkNNT/lib/python3.6/site-packages/yapsy/PluginManager.py", line 512, in loadPlugins
    plugin_info.plugin_object = self.instanciateElement(element)
  File "/home/saviles/data/git/github/errbot/errbot/specific_plugin_manager.py", line 59, in instanciateElement
    return element(self._config)
  File "/home/saviles/data/git/github/errbot/errbot/backends/text.py", line 214, in __init__
    self.user = self.build_identifier(self.bot_config.BOT_ADMINS[0])
  File "/home/saviles/data/git/github/errbot/errbot/backends/text.py", line 374, in build_identifier
    raise ValueError('An identifier for the Text backend needs to start with # for a room or @ for a person.')
ValueError: An identifier for the Text backend needs to start with # for a room or @ for a person.
12:13:48 ERROR    errbot.bootstrap          Unable to load or configure the backend.
Traceback (most recent call last):
  File "/home/saviles/data/git/github/errbot/errbot/bootstrap.py", line 135, in setup_bot
    bot = backendpm.get_plugin_by_name(backend_name)
  File "/home/saviles/data/git/github/errbot/errbot/specific_plugin_manager.py", line 86, in get_plugin_by_name
    raise Exception('Error loading plugin %s:\nError:\n%s\n' % (name, formatted_error))
Exception: Error loading plugin Text:
Error:
<class 'ValueError'>:
  File "/home/saviles/.local/share/virtualenvs/errbot-6RMKkNNT/lib/python3.6/site-packages/yapsy/PluginManager.py", line 512, in loadPlugins
    plugin_info.plugin_object = self.instanciateElement(element)
  File "/home/saviles/data/git/github/errbot/errbot/specific_plugin_manager.py", line 59, in instanciateElement
    return element(self._config)
  File "/home/saviles/data/git/github/errbot/errbot/backends/text.py", line 214, in __init__
    self.user = self.build_identifier(self.bot_config.BOT_ADMINS[0])
  File "/home/saviles/data/git/github/errbot/errbot/backends/text.py", line 374, in build_identifier
    raise ValueError('An identifier for the Text backend needs to start with # for a room or @ for a person.')
```

Alternatively we should probably also 