### PR TITLE
plugin_manager: check enabled core_plugins prior to plugin load

### DIFF
--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -421,6 +421,7 @@ class BotPluginManager(PluginManager, StoreMixin):
             for candidate in candidates:
                 if not check_enabled_core_plugin(candidate[2].name, candidate[2].details, self.core_plugins):
                     self.removePluginCandidate(candidate)
+                    log.debug("%s plugin will not be loaded because it is not listed in CORE_PLUGINS", candidate[2].name)
 
         self.all_candidates = [candidate[2] for candidate in self.getPluginCandidates()]
 

--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -275,11 +275,6 @@ class BotPluginManager(PluginManager, StoreMixin):
         name = plugin_info.name
         config = self.get_plugin_configuration(name)
 
-        if self.core_plugins is not None:
-            if not check_enabled_core_plugin(name, plugin_info.details, self.core_plugins):
-                log.warning('Core plugin "%s" has been skipped because it is not in CORE_PLUGINS in config.py.' % name)
-                return None
-
         if not check_python_plug_section(name, plugin_info.details):
             log.error('%s failed python version check.', name)
             return None
@@ -418,6 +413,14 @@ class BotPluginManager(PluginManager, StoreMixin):
                 "removing all data and plugins from your bot and then trying again."
             )
             raise
+
+        # Checks if CORE_PLUGINS is defined in config. If so, iterate through plugin candidates and remove any
+        # that are not defined in the config before loading them.
+        if self.core_plugins is not None:
+            candidates = self.getPluginCandidates()
+            for candidate in candidates:
+                if not check_enabled_core_plugin(candidate[2].name, candidate[2].details, self.core_plugins):
+                    self.removePluginCandidate(candidate)
 
         self.all_candidates = [candidate[2] for candidate in self.getPluginCandidates()]
 


### PR DESCRIPTION
Fixes #1116 

All tests but one passed, the `multi_plugin` test.

`1 failed, 199 passed, 1 warnings in 102.84 seconds`

```
testbot = <errbot.backends.test.TestBot object at 0x115b5f518>

    def test_first(testbot):
>       assert 'Multi2' == testbot.exec_command('!multi2-myname')
E       assert 'Multi2' == 'Command "multi2-myname" ...e" or "!multi1-myname" ?'
E         - Multi2
E         + Command "multi2-myname" not found.
E         +  Did you mean "!myname" or "!multi1-myname" ?

tests/multi_plugin_test.py:14: AssertionError
```

```
MESSAGE:
Multi1.myname clashes with WhateverName.myname so it has been renamed multi1-myname
...
MESSAGE:
Command "multi2-myname" not found.

Did you mean "!myname" or "!multi1-myname" ?
```
