### PR TITLE
Add config option to set a custom Sentry Transport

### DIFF
--- a/docs/user_guide/sentry.rst
+++ b/docs/user_guide/sentry.rst
@@ -49,6 +49,9 @@ To setup Errbot with Sentry:
 * Open up your bot's config.py
 * Set **BOT_LOG_SENTRY** to *True* and fill in **SENTRY_DSN** with the DNS value obtained previously
 * Optionally adjust **SENTRY_LOGLEVEL** to the desired level
+* Optionally adjust **SENTRY_TRANSPORT** to the desired transport
 * Restart Errbot
+
+You can find a list of Sentry transport classes `here <https://docs.sentry.io/clients/python/transports/>`_.
 
 You should now see Exceptions and log messages show up in your Sentry stream.

--- a/errbot/bootstrap.py
+++ b/errbot/bootstrap.py
@@ -1,4 +1,5 @@
 from os import path, makedirs
+import importlib
 import logging
 import sys
 import ast
@@ -98,7 +99,21 @@ def setup_bot(backend_name, logger, config, restore=None):
             )
             exit(-1)
 
-        sentryhandler = SentryHandler(config.SENTRY_DSN, level=config.SENTRY_LOGLEVEL)
+        if hasattr(config, 'SENTRY_TRANSPORT') and isinstance(config.SENTRY_TRANSPORT, tuple):
+            try:
+                mod = importlib.import_module(config.SENTRY_TRANSPORT[1])
+                transport = getattr(mod, config.SENTRY_TRANSPORT[0])
+            except ImportError:
+                log.exception(
+                    "Unable to import selected SENTRY_TRANSPORT - {transport}".format(transport=config.SENTRY_TRANSPORT)
+                )
+                exit(-1)
+
+            sentryhandler = SentryHandler(config.SENTRY_DSN,
+                                          level=config.SENTRY_LOGLEVEL,
+                                          transport=transport)
+        else:
+            sentryhandler = SentryHandler(config.SENTRY_DSN, level=config.SENTRY_LOGLEVEL)
         logger.addHandler(sentryhandler)
 
     logger.setLevel(config.BOT_LOG_LEVEL)

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -128,6 +128,10 @@ BOT_LOG_SENTRY = False
 SENTRY_DSN = ''
 SENTRY_LOGLEVEL = BOT_LOG_LEVEL
 
+# Set an optional Sentry transport other than the default Threaded.
+# For more info, see https://docs.sentry.io/clients/python/transports/
+# SENTRY_TRANSPORT = ('RequestsHTTPTransport', 'raven.transport.requests')
+
 # Execute commands in asynchronous mode. In this mode, Errbot will spawn 10
 # separate threads to handle commands, instead of blocking on each
 # single command.


### PR DESCRIPTION
Ran into an issue the other day where I needed to set a custom Sentry Transport and was unable to. This is a first pass at how this might work. The implementation is a bit complex due to the need to dynamically import the transport class from raven, based on the configured transport provided by the user. 

List of transports and their classes can be found here: https://docs.sentry.io/clients/python/transports/

Example config option would be:

`SENTRY_TRANSPORT = ('RequestsHTTPTransport', 'raven.transport.requests')`