### PR TITLE
Make !repo search works out of the box

### DIFF
--- a/errbot/bootstrap.py
+++ b/errbot/bootstrap.py
@@ -17,7 +17,7 @@ HERE = path.dirname(path.abspath(__file__))
 CORE_BACKENDS = path.join(HERE, 'backends')
 CORE_STORAGE = path.join(HERE, 'storage')
 
-PLUGIN_DEFAULT_INDEX = 'https://repos.errbot.io/repos.json'
+PLUGIN_DEFAULT_INDEX = 'http://version.errbot.io/repos.json'
 
 
 def bot_config_defaults(config):


### PR DESCRIPTION
Why:

 *  https://repos.errbot.io/repos.json has no valid certificate
    thus out-of-box install just fails using !repo search

This change addreses the need by:

 * update default to point to less secure but at least working index
   http://version.errbot.io/repos.json