### PR TITLE
Fix #1079: Add property channelname on SlackRoom

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -1030,6 +1030,10 @@ class SlackRoom(Room):
         return "#%s" % self.name
 
     @property
+    def channelname(self):
+        return self._name
+
+    @property
     def _channel(self):
         """
         The channel object exposed by SlackClient


### PR DESCRIPTION
This fixess issue #1079.

When sending a file to a identifier instance of SlackRoom, channelname
property is not defined.