### PR TITLE
Add support for specifying a custom log formatter

### DIFF
--- a/errbot/bootstrap.py
+++ b/errbot/bootstrap.py
@@ -79,12 +79,15 @@ def setup_bot(backend_name, logger, config, restore=None):
 
     bot_config_defaults(config)
 
-    format_logs(config.TEXT_COLOR_THEME)
+    if hasattr(config, 'BOT_LOG_FORMATTER'):
+        format_logs(formatter=config.BOT_LOG_FORMATTER)
+    else:
+        format_logs(config.TEXT_COLOR_THEME)
 
-    if config.BOT_LOG_FILE:
-        hdlr = logging.FileHandler(config.BOT_LOG_FILE)
-        hdlr.setFormatter(logging.Formatter("%(asctime)s %(levelname)-8s %(name)-25s %(message)s"))
-        logger.addHandler(hdlr)
+        if config.BOT_LOG_FILE:
+            hdlr = logging.FileHandler(config.BOT_LOG_FILE)
+            hdlr.setFormatter(logging.Formatter("%(asctime)s %(levelname)-8s %(name)-25s %(message)s"))
+            logger.addHandler(hdlr)
 
     if hasattr(config, 'BOT_LOG_SENTRY') and config.BOT_LOG_SENTRY:
         try:

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -109,6 +109,9 @@ PLUGINS_CALLBACK_ORDER = (None, )
 # the user running Err.
 #AUTOINSTALL_DEPS = True
 
+# To use your own custom log formatter, uncomment and set BOT_LOG_FORMATTER
+# BOT_LOG_FORMATTER =
+
 # The location of the log file. If you set this to None, then logging will
 # happen to console only.
 BOT_LOG_FILE = BOT_DATA_DIR + '/err.log'

--- a/errbot/logs.py
+++ b/errbot/logs.py
@@ -51,19 +51,26 @@ def get_log_colors(theme_color=None):
     )
 
 
-def format_logs(theme_color=None):
+def format_logs(formatter=None, theme_color=None):
+    """
+    You may either use the formatter parameter to provide your own
+    custom formatter, or the theme_color parameter to use the
+    built in color scheme formatter.
+    """
+    if formatter:
+        console_hdlr.setFormatter(formatter)
     # if isatty and not True:
-    if isatty:
+    elif isatty:
         from colorlog import ColoredFormatter  # noqa
         log_format, colors_dict = get_log_colors(theme_color)
-        formatter = ColoredFormatter(
+        color_formatter = ColoredFormatter(
             "%(asctime)s %(log_color)s%(levelname)-8s%(reset)s " +
             log_format,
             datefmt="%H:%M:%S",
             reset=True,
             log_colors=colors_dict,
         )
-        console_hdlr.setFormatter(formatter)
+        console_hdlr.setFormatter(color_formatter)
     else:
         console_hdlr.setFormatter(logging.Formatter("%(asctime)s %(levelname)-8s %(name)-25s %(message)s"))
     root_logger.addHandler(console_hdlr)


### PR DESCRIPTION
Our deployment environment uses logs formatted as json, so to use this I needed to add the ability to specify a custom formatter.
