### PR TITLE
Fix mentions in text backend

### DIFF
--- a/errbot/backends/text.py
+++ b/errbot/backends/text.py
@@ -286,8 +286,7 @@ class TextBackend(ErrBot):
 
                 self.callback_message(msg)
 
-                mentioned = [self.build_identifier(word) for word in re.findall(r"@[\w']+", entry)
-                             if word.startswith('@')]
+                mentioned = [self.build_identifier(word) for word in re.findall(r'(?<=\s)@[\w]+', entry)]
                 if mentioned:
                     self.callback_mention(msg, mentioned)
 

--- a/errbot/backends/text.py
+++ b/errbot/backends/text.py
@@ -286,7 +286,7 @@ class TextBackend(ErrBot):
 
                 self.callback_message(msg)
 
-                mentioned = [self.build_identifier(word[1:]) for word in re.findall(r"@[\w']+", entry)
+                mentioned = [self.build_identifier(word) for word in re.findall(r"@[\w']+", entry)
                              if word.startswith('@')]
                 if mentioned:
                     self.callback_mention(msg, mentioned)


### PR DESCRIPTION
When text appears with a `@` character, it would kill the bot.

```
[@saviles ➡ @zombie] >>> Breaking @backend
Traceback (most recent call last):
  File "/home/saviles/.local/share/virtualenvs/errbot-6RMKkNNT/bin/errbot", line 11, in <module>
    load_entry_point('errbot', 'console_scripts', 'errbot')()
  File "/home/saviles/data/git/github/errbot/errbot/cli.py", line 297, in main
    bootstrap(backend, root_logger, config, restore)
  File "/home/saviles/data/git/github/errbot/errbot/bootstrap.py", line 225, in bootstrap
    bot.serve_forever()
  File "/home/saviles/data/git/github/errbot/errbot/backends/text.py", line 289, in serve_forever
    mentioned = [self.build_identifier(word[1:]) for word in re.findall(r"@[\w']+", entry)
  File "/home/saviles/data/git/github/errbot/errbot/backends/text.py", line 290, in <listcomp>
    if word.startswith('@')]
  File "/home/saviles/data/git/github/errbot/errbot/backends/text.py", line 374, in build_identifier
    raise ValueError('An identifier for the Text backend needs to start with # for a room or @ for a person.')
ValueError: An identifier for the Text backend needs to start with # for a room or @ for a person.
```
This fixes it so it now it does not break:
```
[@saviles ➡ @zombie] >>> breaking @backend

[@saviles ➡ @zombie] >>> 

``