### PR TITLE
Send correct parameter for theme color

### DIFF
--- a/errbot/bootstrap.py
+++ b/errbot/bootstrap.py
@@ -82,7 +82,7 @@ def setup_bot(backend_name, logger, config, restore=None):
     if hasattr(config, 'BOT_LOG_FORMATTER'):
         format_logs(formatter=config.BOT_LOG_FORMATTER)
     else:
-        format_logs(config.TEXT_COLOR_THEME)
+        format_logs(theme_color=config.TEXT_COLOR_THEME)
 
         if config.BOT_LOG_FILE:
             hdlr = logging.FileHandler(config.BOT_LOG_FILE)


### PR DESCRIPTION
When loading the text backend, you start seeing the following output:
```
[@saviles ➡ @zombie] >>>  saviles  (e) errbot-6RMKkNNT  ~  data  apps  errbot  errbot
light
light
light
light
light
light
light
light
light
light
light
light
light
light
light
light
light
light
light
light
light
light
light
light
light
light
light
light
light
light
light
You must give at least one requirement to install (see "pip help install")
light
Requirement already satisfied: reunion in /home/saviles/data/git/github/reunion/src (from -r /home/saviles/data/git/github/err-meetings/requirements.txt (line 1))
light
────────────────────────────────────────────────────────────────────────────────
 You start as a bot admin in a one-on-one conversation with the bot.

    Context of the chat

• Use !inroom to switch to a room conversation.
• Use !inperson to switch back to a one-on-one conversation.
• Use !asuser to talk as a normal user.
• Use !asadmin to switch back as a bot admin.

    Preferences

• Use !ml to flip on/off the multiline mode (Enter twice at the end to send).
────────────────────────────────────────────────────────────────────────────────

[@saviles ➡ @zombie] >>> 
```

It turns out that changes along the way didn't send the proper parameter to `format_logs()`.
This fixes that.