### PR TITLE
Doc/fix typos

### DIFF
--- a/docs/user_guide/flow_development/advanced.rst
+++ b/docs/user_guide/flow_development/advanced.rst
@@ -4,7 +4,7 @@ Advanced Flow Definitions
 Storing something in the flow context
 -------------------------------------
 
-Flows have a state the plugins can use to store some.. contextual information.
+Flows have a state the plugins can use to store some contextual information.
 Let's take back out simple linear flow:
 
 .. code-block:: python
@@ -20,7 +20,7 @@ You can represent this flow like this:
 .. figure::  basics_1.svg
    :align:   center
 
-You can store something in the context in for example in ``!first`` and retrieve in ``!second``. Like this:
+You can store something in the context, for example in ``!first`` and retrieve it in ``!second``. Like this:
 
 .. code-block:: python
 
@@ -33,7 +33,7 @@ You can store something in the context in for example in ``!first`` and retrieve
     def second(self, msg, args):
         return msg.ctx['mydata'] + ' World!'
 
-msg.ctx is a dictionary created every time a flow starts.
+``msg.ctx`` is a dictionary created every time a flow starts.
 
 Making a step execute automatically
 -----------------------------------
@@ -41,8 +41,8 @@ Making a step execute automatically
 In our previous example, if ``msg.ctx['mydata']`` is populated, we can arguably expect that Errbot should not wait for
 the user to enter ``!second`` to execute it and just proceed by itself.
 
-You can do that by defining a **predicate**, this is a simple function that reply ``True`` if the conditions are OK
-to proceed to the next step. The function takes only one parameter, the context, the same one you get from msg.ctx.
+You can do that by defining a **predicate**, which is a simple function that returns ``True`` if the conditions
+to proceed to the next step are met. The function takes only one parameter, the context, the same one you get from ``msg.ctx``.
 
 .. code-block:: python
 
@@ -54,15 +54,13 @@ to proceed to the next step. The function takes only one parameter, the context,
         third_step = second_step.connect('third')
 
 
-Now, after starting the flow with ``!flows start example`` the state will be:
-
-You can represent this flow like this:
+Now, after starting the flow with ``!flows start example``, the state will be:
 
 .. figure::  basics_3.svg
    :align:   center
 
 Errbot will wait for ``!first``. But then, once the user executes ``!first``, it will see that the predicate between
-``!first`` and ``!second`` is verified so will go on and execute ``!second``, displaying 'Hello World' and proceed to wait
+``!first`` and ``!second`` is verified, so will go on and execute ``!second``, displaying 'Hello World' and proceed to wait
 for ``!third``:
 
 .. figure::  basics_4.svg
@@ -95,7 +93,7 @@ In manual mode, the bot will tell the user about his 2 possible options to conti
 Making a looping graph
 ----------------------
 
-You can also perfectly reexecute a part of a graph in a "loop", you can branch directly the node object
+You can also perfectly reexecute a part of a graph in a "loop". You can branch directly the node object
 instead of the command name in that case.
 
 .. code-block:: python
@@ -112,4 +110,4 @@ You can represent this flow like this:
 .. figure::  advanced_2.svg
    :align:   center
 
-The typical use case is to ask repetitively something to the user.
+The typical use case is to repeatedly ask something to the user.

--- a/docs/user_guide/flow_development/basics.rst
+++ b/docs/user_guide/flow_development/basics.rst
@@ -34,7 +34,7 @@ as flow decorator:
             """ Docs for the flow example comes here """
             # [...]
 
-Errbot will pass the root of the flow as the only parameter to you flow definition so you can build your graph
+Errbot will pass the root of the flow as the only parameter to your flow definition so you can build your graph
 from there.
 
 
@@ -42,7 +42,7 @@ Making a simple graph
 ---------------------
 
 Within your flow, you can connect commands together.
-For example to make a simple linear flow between !first, !second and !third:
+For example, to make a simple linear flow between ``!first``, ``!second`` and ``!third``:
 
 .. code-block:: python
 
@@ -72,7 +72,7 @@ Once you have executed ``!first``, you will be in that state:
 .. figure::  basics_2.svg
    :align:   center
 
-The bot will tell you that it expect ``!second`` etc.
+The bot will tell you that it expects ``!second``, etc.
 
 .. figure::  basics_4.svg
    :align:   center
@@ -80,10 +80,10 @@ The bot will tell you that it expect ``!second`` etc.
 Making a flow start automatically
 ---------------------------------
 
-Now, usually flows are linked to a first action you users want to do. For example: ``!poll new``, ``!vm create``,
-``!report init`` or first commands like that that suggests that you will have a follow up.
+Now, usually flows are linked to a first action your users want to do. For example: ``!poll new``, ``!vm create``,
+``!report init`` or first commands like that that suggests that you will have a follow-up.
 
-To trigger automatically a flow on those first commands you can use ``auto_trigger``.
+To trigger a flow automatically on those first commands, you can use ``auto_trigger``.
 
 .. code-block:: python
 
@@ -104,14 +104,14 @@ BUT, when a user will execute a ``!first`` command, the bot will instantly insta
 .. figure::  basics_2.svg
    :align:   center
 
-And tell the user that !second is the follow up.
+And tell the user that ``!second`` is the follow-up.
 
 Flow ending
 -----------
 
-If a node has no more children and a user passed it, it will automatically ends the flow.
+If a node has no more children and a user passed it, it will automatically end the flow.
 
-Sometimes, with loops etc, you might want to explicitly mark an END FlowNode with a predicate, you can do it like this,
+Sometimes, with loops etc., you might want to explicitly mark an END FlowNode with a predicate. You can do it like this,
 for example for a guessing game plugin:
 
 .. figure::  end.svg

--- a/docs/user_guide/flow_development/concepts.rst
+++ b/docs/user_guide/flow_development/concepts.rst
@@ -4,7 +4,7 @@ Flows Concepts
 Static structure
 ----------------
 
-Flows are represented as graphs. Those graphs have a root (FlowRoot) which is basically their entry point and
+Flows are represented as graphs. Those graphs have a root (FlowRoot), which is basically their entry point, and
 are composed of nodes (FlowNodes). Every node represents an Errbot command.
 
 .. figure::  concept.svg
@@ -17,20 +17,20 @@ This defines a simple flow where for example this sequence of commands is possib
 
     !command1 !command2 !command3 !command1 !command2 !command3 !last_command
 
-On the connections of thos nodes (⟶), you can attach **predicates**, predicates are simple conditions to allow
+On the connections of those nodes (⟶), you can attach **predicates**, predicates are simple conditions to allow
 the flow to continue without any user intervention.
 
 Execution
 ---------
 
-At execution time, Errbot will keep track of who started the flow and at what step (node) it is currently.
-On top of that Errbot will initialize a context for the entire conversation. The context is a simple python dictionary
-and it is attached to only one conversation. Think of this like the persistence for plugins but linked to
+At execution time, Errbot will keep track of who started the flow, and at what step (node) it is currently.
+On top of that, Errbot will initialize a context for the entire conversation. The context is a simple Python dictionary
+and it is attached to only one conversation. Think of this like the persistence for plugins, but linked to
 a conversation only.
 
 If you don't specify any predicate when you build your flow, every single step is "manual". It means that Errbot will
-wait for the user to execute one of the possible command at every step to advance along the graph.
+wait for the user to execute one of the possible commands at every step to advance along the graph.
 
-Predicates can be used to trigger automatically a command. Predicates are simple functions saying to Errbot,
+Predicates can be used to trigger a command automatically. Predicates are simple functions saying to Errbot,
 "this command has enough in the context to be able to executed without any user intervention".
 At any time if a predicate is verified after a step is executed, Errbot will proceed and execute the next step.

--- a/docs/user_guide/flow_development/index.rst
+++ b/docs/user_guide/flow_development/index.rst
@@ -11,7 +11,7 @@ chatroom::
   Bot: Flow poll_setup started, you can continue with:
        !poll newoption <your option>
 
-  User: !poll addoption Greek
+  User: !poll newoption Greek
 
   Bot: Option added, current options:
        - Greek
@@ -20,7 +20,7 @@ chatroom::
        !poll newoption <your option>
        !poll start
 
-  User: !poll addoption French
+  User: !poll newoption French
 
   Bot: Option added, current options:
        - Greek

--- a/docs/user_guide/flow_development/index.rst
+++ b/docs/user_guide/flow_development/index.rst
@@ -3,7 +3,7 @@ Flow development
 
 Flows are a feature in Errbot to enable plugin designers to chain several plugin commands together in a "conversation".
 
-For example, imagine interacting with the bot that needs more that one command, like setting up a poll in a
+For example, imagine interacting with a bot that needs more that one command, like setting up a poll in a
 chatroom::
 
   User: !poll new Where do we go for lunch ?


### PR DESCRIPTION
Quick review of the flow_development documentation:

* Fixed minor typos and omissions;
* Used code formatting where appropriate;
* Improved punctuation for readability.

Also fix inconsistent bot interaction in the initial Flow example
(The bot gives `!newoption` as the command, 
the user replies with `!addoption`.)