### PR TITLE
fix: Command reply in Text backend

### DIFF
--- a/errbot/backends/text.py
+++ b/errbot/backends/text.py
@@ -399,4 +399,4 @@ class TextBackend(ErrBot):
         return self._rooms
 
     def prefix_groupchat_reply(self, message, identifier):
-        message.body = '@{0} {1}'.format(identifier.nick, message.body)
+        message.body = '{0} {1}'.format(identifier.person, message.body)


### PR DESCRIPTION
This fixes a minor annoyance in bot replies not using the correct username.

old behavior:
```
[#test/saviles ➡ #test] >>> !restart
@None This command requires bot-admin privileges

[#test/saviles ➡ #test] >>> !echo hi
@None hi

[#test/saviles ➡ #test] >>>
```

new behavior:
```
[#test/saviles ➡ #test] >>> !restart
@saviles This command requires bot-admin privileges

[#test/saviles ➡ #test] >>> !echo hi
@saviles hi

[#test/saviles ➡ #test] >>>
```