### PR TITLE
Make Systemd example file auto startable

### DIFF
--- a/docs/code_examples/systemd.service
+++ b/docs/code_examples/systemd.service
@@ -9,3 +9,6 @@ WorkingDirectory=/path/to/errbot/
 User=errbot
 Restart=always
 KillSignal=SIGINT
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Without the `[Install]` section the service won't auto start after reboot.