### PR TITLE
Including the option to set a proxy when connecting using the SlackClient

### DIFF
--- a/docs/user_guide/configuration/slack.rst
+++ b/docs/user_guide/configuration/slack.rst
@@ -32,6 +32,18 @@ by setting up `BOT_IDENTITY` as follows::
     }
 
 
+Proxy setup
+-------------
+
+In case you need to use a Proxy to connect to Slack, 
+you can set the proxies with the token config.
+
+    BOT_IDENTITY = {
+        'token': 'xoxb-4426949411-aEM7...',
+        'proxies': {'http': 'some-http-proxy', 'https': 'some-https-proxy'}
+    }
+
+
 Bot admins
 ----------
 

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -291,6 +291,7 @@ class SlackBackend(ErrBot):
         super().__init__(config)
         identity = config.BOT_IDENTITY
         self.token = identity.get('token', None)
+        self.proxies = identity.get('proxies', None)
         if not self.token:
             log.fatal(
                 'You need to set your token (found under "Bot Integration" on Slack) in '
@@ -359,7 +360,11 @@ class SlackBackend(ErrBot):
         log.debug('Converted bot_alt_prefixes: %s', self.bot_config.BOT_ALT_PREFIXES)
 
     def serve_once(self):
-        self.sc = SlackClient(self.token)
+        if not self.proxies:
+            self.sc = SlackClient(self.token)
+        else:
+            self.sc = SlackClient(self.token, proxies=self.proxies)
+
         log.info("Verifying authentication token")
         self.auth = self.api_call("auth.test", raise_errors=False)
         if not self.auth['ok']:

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -170,6 +170,8 @@ BOT_IDENTITY = {
 
     ## Slack mode (comment the others above if using this mode)
     # 'token': 'xoxb-4426949411-aEM7...',
+    ## you can also include the proxy for the SlackClient connection
+    # 'proxies': {'http': 'some-http-proxy', 'https': 'some-https-proxy'}
 
     ## Telegram mode (comment the others above if using this mode)
     # 'token': '103419016:AAbcd1234...',


### PR DESCRIPTION
We are trying to use the Errbot, but in our infrastructure we use Proxy and to bypass this, I've that SlackClient already enables Proxy when starting the connection.

I included this option on the config and the serve_once code to be able to connect using proxy too.

Issue #1179 