### PR TITLE
errbot.utils.ValidationException moved to errbot.ValidationException in 5.0.0

### DIFF
--- a/errbot/templates/new_plugin.py.tmpl
+++ b/errbot/templates/new_plugin.py.tmpl
@@ -36,7 +36,7 @@ class {{ class_name }}(BotPlugin):
         """
         Triggers when the configuration is checked, shortly before activation
 
-        Raise a errbot.utils.ValidationException in case of an error
+        Raise a errbot.ValidationException in case of an error
 
         You should delete it if you're not using it to override any default behaviour
         """


### PR DESCRIPTION
Tiny change, but fixes the plugin scaffold template.

Reference: https://github.com/errbotio/errbot/blob/b76e4c47c8c967ec74a0d01b0910e063dbf8f181/CHANGES.rst#v500-2017-04-23