### PR TITLE
Bump slackclient to 1.2.0 with support to reconnect

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+v5.2.0 (2018-04-05)
+-------------------
+
+fixes:
+
+- Message: Allow partial message size
+- Slack: include the option to set Proxy when connecting using SlackClient
+- Slack: fix member joined channel event handler
+
 v5.1.3 (2017-10-15)
 -------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,12 +1,3 @@
-v5.2.0 (2018-04-05)
--------------------
-
-fixes:
-
-- Message: Allow partial message size
-- Slack: include the option to set Proxy when connecting using SlackClient
-- Slack: fix member joined channel event handler
-
 v5.1.3 (2017-10-15)
 -------------------
 

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -373,7 +373,7 @@ class SlackBackend(ErrBot):
         self.bot_identifier = SlackPerson(self.sc, self.auth["user_id"])
 
         log.info("Connecting to Slack real-time-messaging API")
-        if self.sc.rtm_connect():
+        if self.sc.rtm_connect(auto_reconnect=True):
             log.info("Connected")
             # Block on reads instead of using the busy loop suggested in slackclient docs
             # https://github.com/slackapi/python-slackclient/issues/46#issuecomment-165674808

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ if __name__ == "__main__":
             'graphic':  ['PySide', ],
             'hipchat': ['hypchat', 'sleekxmpp', 'pyasn1', 'pyasn1-modules'],
             'IRC': ['irc', ],
-            'slack': ['slackclient>=1.0.5', ],
+            'slack': ['slackclient>=1.2.0', ],
             'telegram': ['python-telegram-bot', ],
             'XMPP': ['sleekxmpp', 'pyasn1', 'pyasn1-modules'],
         },


### PR DESCRIPTION
When using slackclient an error is happening that the client is reconnecting after a while.
[SlackClient issue](https://github.com/slackapi/python-slackclient/issues/118)
On the slack client page they recommend a change to allow an automatic reconnect. 

@gbin 