### PR TITLE
Added email property for slack backend SlackPerson class

### DIFF
--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -69,6 +69,16 @@ class Person(Identifier):
         """
         pass
 
+    @property
+    @abstractmethod
+    def email(self) -> str:
+        """
+        Some backends have the email of a user.
+
+        :return: the email of this user if available.
+        """
+        pass
+
 
 class RoomOccupant(Identifier):
     @property

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -153,6 +153,15 @@ class SlackPerson(Person):
         return f'@{self.username}'
 
     @property
+    def email(self):
+        """Convert a Slack user ID to their user email"""
+        user = self._sc.server.users.find(self._userid)
+        if user is None:
+            log.error("Cannot find user with ID %s" % self._userid)
+            return "<%s>" % self._userid
+        return user.email
+
+    @property
     def fullname(self):
         """Convert a Slack user ID to their user name"""
         user = self._sc.server.users.find(self._userid)

--- a/errbot/backends/test.py
+++ b/errbot/backends/test.py
@@ -40,11 +40,12 @@ class TestPerson(Person):
     methods exposed by this class.
     """
 
-    def __init__(self, person, client=None, nick=None, fullname=None):
+    def __init__(self, person, client=None, nick=None, fullname=None, email=None):
         self._person = person
         self._client = client
         self._nick = nick
         self._fullname = fullname
+        self._email = email
 
     @property
     def person(self):
@@ -69,6 +70,11 @@ class TestPerson(Person):
         """This needs to return a long display name for this identifier e.g. Guillaume Binet.
         Returns None is unspecified"""
         return self._fullname
+    @property
+    def email(self):
+        """This needs to return an email for this identifier e.g. Guillaume.Binet@gmail.com.
+        Returns None is unspecified"""
+        return self._email
 
     aclattr = person
 

--- a/errbot/backends/test.py
+++ b/errbot/backends/test.py
@@ -70,6 +70,7 @@ class TestPerson(Person):
         """This needs to return a long display name for this identifier e.g. Guillaume Binet.
         Returns None is unspecified"""
         return self._fullname
+
     @property
     def email(self):
         """This needs to return an email for this identifier e.g. Guillaume.Binet@gmail.com.

--- a/errbot/core_plugins/utils.py
+++ b/errbot/core_plugins/utils.py
@@ -30,6 +30,7 @@ class Utils(BotPlugin):
         resp += f"| nick     | `{frm.nick}`\n"
         resp += f"| fullname | `{frm.fullname}`\n"
         resp += f"| client   | `{frm.client}`\n\n"
+        resp += f"| email    | `{frm.email}`\n\n"
 
         #  extra info if it is a MUC
         if hasattr(frm, 'room'):

--- a/errbot/core_plugins/utils.py
+++ b/errbot/core_plugins/utils.py
@@ -29,8 +29,8 @@ class Utils(BotPlugin):
         resp += f"| person   | `{frm.person}`\n"
         resp += f"| nick     | `{frm.nick}`\n"
         resp += f"| fullname | `{frm.fullname}`\n"
-        resp += f"| client   | `{frm.client}`\n\n"
-        resp += f"| email    | `{frm.email}`\n\n"
+        resp += f"| client   | `{frm.client}`\n"
+        resp += f"| email    | `{frm.email}`\n"
 
         #  extra info if it is a MUC
         if hasattr(frm, 'room'):


### PR DESCRIPTION
It's useful to return slack user email together with other slack user information. In enterprise slack edition company users register in slack with company email but can change other attributes freely. Email is the only user identification which can be mapped to user account.