### PR TITLE
Add some slack functionality

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -772,6 +772,16 @@ class SlackBackend(ErrBot):
                     "An exception occurred while trying to send a card to %s.[%s]" % (to_humanreadable, card)
                 )
 
+
+    def _get_channel_id(self, msg: Message):
+        """Get relevant channel/person ID from a message"""
+        if msg.is_group:
+            to_channel_id = msg.to.id
+        else:
+            to_channel_id = msg.to.channelid
+
+        return to_channel_id
+
     def __hash__(self):
         return 0  # this is a singleton anyway
 

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -952,10 +952,7 @@ class SlackBackend(ErrBot):
     def _react(self, method: str, msg: Message, reaction: str) -> None:
         try:
             # this logic is from send_message
-            if msg.is_group:
-                to_channel_id = msg.to.id
-            else:
-                to_channel_id = msg.to.channelid
+            to_channel_id = self._get_channel_id(msg)
 
             ts = self._ts_for_message(msg)
 

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -818,6 +818,16 @@ class SlackBackend(ErrBot):
         result = self._bot.api_call('chat.update', data=data)
         return self._extract_message_object(result)
 
+    def delete_message(self, msg):
+        channel_id = self._get_channel_id(msg)
+
+        data = {
+            'ts': self._bot._ts_for_message(msg),
+            'channel': channel_id
+        }
+
+        return self._bot.api_call('chat.delete', data=data)
+
     def _get_channel_id(self, msg: Message):
         """Get relevant channel/person ID from a message"""
         if msg.is_group:

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -792,8 +792,10 @@ class SlackBackend(ErrBot):
             try:
                 msg.extras['thread_ts'] = self._ts_for_message(msg.parent)
             except KeyError:
-                # Gives to the user a more interesting explanation if we cannot find a ts from the parent.
-                raise Exception('The provided parent message is not a Slack message or does not contain a Slack timestamp.')
+                # Gives to the user a more interesting explanation if we
+                # cannot find a ts from the parent.
+                raise Exception('The provided parent message is not a Slack '
+                                'message or does not contain a Slack timestamp.')
 
         # Keep the thread_ts to answer to the same thread.
         if 'thread_ts' in msg.extras:

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -480,6 +480,24 @@ class SlackBackend(ErrBot):
 
         if 'message' in event:
             text = event['message'].get('text', '')
+        else:
+            text = event.get('text', '')
+
+        _, mentioned = self.process_mentions(text)
+        msg = self._extract_message_object(event)
+
+        self.callback_message(msg)
+
+        if mentioned:
+            self.callback_mention(msg, mentioned)
+
+    def _extract_message_object(self, event):
+        """Converts an event into a Message object"""
+        channel = event['channel']
+        subtype = event.get('subtype', None)
+
+        if 'message' in event:
+            text = event['message'].get('text', '')
             user = event['message'].get('user', event.get('bot_id'))
         else:
             text = event.get('text', '')
@@ -532,10 +550,7 @@ class SlackBackend(ErrBot):
             ts=self._ts_for_message(msg).replace('.', '')
         )
 
-        self.callback_message(msg)
-
-        if mentioned:
-            self.callback_mention(msg, mentioned)
+        return msg
 
     def _member_joined_channel_event_handler(self, event):
         """Event handler for the 'member_joined_channel' event"""

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -802,6 +802,22 @@ class SlackBackend(ErrBot):
         result = self._bot.api_call('chat.postMessage', data=data)
         return self._extract_message_object(result)
 
+    def update_message(self, msg, new_text, cards=None):
+        """Update a message that already exists"""
+        to_channel_id = self._get_channel_id(msg)
+
+        data = {
+            'text': new_text,
+            'channel': to_channel_id,
+            'attachments': json.dumps(cards) if cards else "",
+            'link_names': '1',
+            'as_user': 'true',
+            'ts': self._bot._ts_for_message(msg)
+        }
+
+        result = self._bot.api_call('chat.update', data=data)
+        return self._extract_message_object(result)
+
     def _get_channel_id(self, msg: Message):
         """Get relevant channel/person ID from a message"""
         if msg.is_group:


### PR DESCRIPTION
I submitted an issue/feature suggestion (https://github.com/errbotio/errbot/issues/1181) a while ago asking about interest in adding some slack functionality.

This pull request:

* Creates a new method to transform an `event` into a `Message`
* Adds ability to update/delete messages
* Adds ability to send multiple cards at once

These are things we've found useful at [HostedGraphite](https://www.hostedgraphite.com) for our ChatOps bot.

I hope this is okay but if it doesn't feel like it would fit in with the bot overall, I totally understand 😊 I've really enjoyed working with the codebase and it's made development much easier for us so I was hoping to contribute some of our home-grown improvements upstream.

Sidenote: I tried running the tox tests on OSX but they ran into an error about being unable to create a new thread and I assume codestyle tests that fail but aren't related to this PR are okay.