### PR TITLE
Fixing #1191 by changing to event.get method

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -504,7 +504,7 @@ class SlackBackend(ErrBot):
             if subtype == "bot_message":
                 msg.frm = SlackBot(
                     self.sc,
-                    bot_id=event['bot_id'],
+                    bot_id=event.get('bot_id'),
                     bot_username=event.get('username', '')
                 )
             else:

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -516,7 +516,7 @@ class SlackBackend(ErrBot):
             if subtype == "bot_message":
                 msg.frm = SlackRoomBot(
                     self.sc,
-                    bot_id=event['bot_id'],
+                    bot_id=event.get('bot_id'),
                     bot_username=event.get('username', ''),
                     channelid=event['channel'],
                     bot=self


### PR DESCRIPTION
This should fix https://github.com/errbotio/errbot/issues/1191

After this change, sending an admin warning to DnD'd slack admins does this:

[dnd_slack_admin.txt](https://github.com/errbotio/errbot/files/1958305/dnd_slack_admin.txt)
