### PR TITLE
card template: remove broken colour rendering

### DIFF
--- a/errbot/templates/card.md
+++ b/errbot/templates/card.md
@@ -25,13 +25,9 @@
 {% if card.image %}
 
 ![{{ card.image }}]({{ card.image }}) {{ card.body }}
-{: color='{{card.text_color}}' bgcolor='{{card.color}}' }
-
 {% else %}
 
 {{ card.body }}
-{: color='{{card.text_color}}' bgcolor='{{card.color}}' }
-
 {% endif %}
 
 {% for key,_ in card.fields %}| {{ key }} {% endfor %}


### PR DESCRIPTION
This gets rendered verbatim in Jabber at least for me, if this is useful somewhere it might be better to only change it for XMPP. I could also not manage to understand how this should work properly.