### PR TITLE
PyCodestyle: Ignore E252, W605

### DIFF
--- a/errbot/core.py
+++ b/errbot/core.py
@@ -243,9 +243,9 @@ class ErrBot(Backend, StoreMixin):
             prefixed = True
             longest = 0
             for prefix in self.bot_alt_prefixes:
-                l = len(prefix)
-                if tomatch.startswith(prefix) and l > longest:
-                    longest = l
+                length = len(prefix)
+                if tomatch.startswith(prefix) and length > longest:
+                    longest = length
             log.debug("Called with alternate prefix '{}'".format(text[:longest]))
             text = text[longest:]
 
@@ -253,9 +253,9 @@ class ErrBot(Backend, StoreMixin):
             for sep in self.bot_config.BOT_ALT_PREFIX_SEPARATORS:
                 # While unlikely, one may have separators consisting of
                 # more than one character
-                l = len(sep)
-                if text[:l] == sep:
-                    text = text[l:]
+                length = len(sep)
+                if text[:length] == sep:
+                    text = text[length:]
         elif msg.is_direct and self.bot_config.BOT_PREFIX_OPTIONAL_ON_CHAT:
             log.debug("Assuming '%s' to be a command because BOT_PREFIX_OPTIONAL_ON_CHAT is True" % text)
             # In order to keep noise down we surpress messages about the command

--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -492,9 +492,9 @@ class BotPluginManager(PluginManager, StoreMixin):
         if not self.is_plugin_blacklisted(name):
             logging.warning('Plugin %s is not blacklisted' % name)
             return 'Plugin %s is not blacklisted' % name
-        l = self.get_blacklisted_plugin()
-        l.remove(name)
-        self[self.BL_PLUGINS] = l
+        plugin = self.get_blacklisted_plugin()
+        plugin.remove(name)
+        self[self.BL_PLUGINS] = plugin
         log.info('Plugin %s removed from blacklist' % name)
         return 'Plugin %s removed from blacklist' % name
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ commands = py.test
 
 [testenv:codestyle]
 deps = pycodestyle
-commands = pycodestyle errbot tests
+commands = pycodestyle errbot tests --ignore=E252
 
 [testenv:pypi-lint]
 deps = docutils


### PR DESCRIPTION
Ignoring these rules is the best at the moment
as they'll break a lot of pending patches.

Fixes https://github.com/errbotio/errbot/issues/1204