### PR TITLE
Format codebase according to modern style rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ nohup.out
 /.coverage
 /data
 /config.py.*
+.pytest_cache
 
 # tools
 /tools/Home.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: false
 language: python
 matrix:
   include:
+    - python: 3.6
+      env: TOXENV=black
     - python: 3.4
       env: TOXENV=py34
     - python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,18 @@ matrix:
   include:
     - python: 3.6
       env: TOXENV=black
+    - python: 3.6
+      env: TOXENV=codestyle
+    - python: 3.6
+      env: TOXENV=isort
+    - python: 3.6
+      env: TOXENV=pypi-lint
     - python: 3.4
       env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
-    - python: 3.6
-      env: TOXENV=pypi-lint
-    - python: 3.6
-      env: TOXENV=codestyle
 
 install: pip install tox
 before_script: cp tests/config-travisci.py config.py

--- a/conftest.py
+++ b/conftest.py
@@ -1,1 +1,1 @@
-pytest_plugins = ['errbot.backends.test']
+pytest_plugins = ["errbot.backends.test"]

--- a/errbot/__init__.py
+++ b/errbot/__init__.py
@@ -11,14 +11,28 @@ from typing import Callable, Any, Tuple
 
 from .core_plugins.wsview import bottle_app, WebView
 from .backends.base import Message, ONLINE, OFFLINE, AWAY, DND  # noqa
-from .botplugin import BotPlugin, SeparatorArgParser, ShlexArgParser, CommandError, Command, ValidationException  # noqa
+from .botplugin import BotPlugin, SeparatorArgParser, ShlexArgParser, CommandError, Command, ValidationException
 from .flow import FlowRoot, BotFlow, Flow, FLOW_END
 from .core_plugins.wsview import route, view  # noqa
 from . import core
 
-__all__ = ['BotPlugin', 'CommandError', 'Command', 'webhook', 'webroute', 'webview', 'cmdfilter',
-           'botcmd', 're_botcmd', 'arg_botcmd', 'botflow', 'BotFlow', 'FlowRoot', 'Flow', 'FLOW_END',
-           ]
+__all__ = [
+    "BotPlugin",
+    "CommandError",
+    "Command",
+    "webhook",
+    "webroute",
+    "webview",
+    "cmdfilter",
+    "botcmd",
+    "re_botcmd",
+    "arg_botcmd",
+    "botflow",
+    "BotFlow",
+    "FlowRoot",
+    "Flow",
+    "FLOW_END",
+]
 
 log = logging.getLogger(__name__)
 
@@ -34,7 +48,7 @@ sys.modules["errbot.errBot"] = core
 # Same happens with quotations marks, which are required for parsing
 # complex strings in arguments
 # Map of characters to sanitized equivalents
-ARG_BOTCMD_CHARACTER_REPLACEMENTS = {'—': '--', '“': '"', '”': '"'}
+ARG_BOTCMD_CHARACTER_REPLACEMENTS = {"—": "--", "“": '"', "”": '"'}
 
 
 class ArgumentParseError(Exception):
@@ -61,27 +75,29 @@ class ArgumentParser(argparse.ArgumentParser):
         raise HelpRequested()
 
 
-def _tag_botcmd(func,
-                hidden=None,
-                name=None,
-                split_args_with='',
-                admin_only=False,
-                historize=True,
-                template=None,
-                flow_only=False,
-                _re=False,
-                syntax=None,         # botcmd_only
-                pattern=None,        # re_cmd only
-                flags=0,              # re_cmd only
-                matchall=False,      # re_cmd_only
-                prefixed=True,       # re_cmd_only
-                _arg=False,
-                command_parser=None,  # arg_cmd only
-                re_cmd_name_help=None):  # re_cmd_only
+def _tag_botcmd(
+    func,
+    hidden=None,
+    name=None,
+    split_args_with="",
+    admin_only=False,
+    historize=True,
+    template=None,
+    flow_only=False,
+    _re=False,
+    syntax=None,  # botcmd_only
+    pattern=None,  # re_cmd only
+    flags=0,  # re_cmd only
+    matchall=False,  # re_cmd_only
+    prefixed=True,  # re_cmd_only
+    _arg=False,
+    command_parser=None,  # arg_cmd only
+    re_cmd_name_help=None,  # re_cmd_only
+):
     """
     Mark a method as a bot command.
     """
-    if not hasattr(func, '_err_command'):  # don't override generated functions
+    if not hasattr(func, "_err_command"):  # don't override generated functions
         func._err_command = True
         func._err_command_name = name or func.__name__
         func._err_command_split_args_with = split_args_with
@@ -109,15 +125,17 @@ def _tag_botcmd(func,
     return func
 
 
-def botcmd(*args,
-           hidden: bool=None,
-           name: str=None,
-           split_args_with: str='',
-           admin_only: bool=False,
-           historize: bool=True,
-           template: str=None,
-           flow_only: bool=False,
-           syntax: str=None) -> Callable[[BotPlugin, Message, Any], Any]:
+def botcmd(
+    *args,
+    hidden: bool = None,
+    name: str = None,
+    split_args_with: str = "",
+    admin_only: bool = False,
+    historize: bool = True,
+    template: str = None,
+    flow_only: bool = False,
+    syntax: str = None
+) -> Callable[[BotPlugin, Message, Any], Any]:
     """
     Decorator for bot command functions
 
@@ -146,33 +164,39 @@ def botcmd(*args,
     be a string or list (depending on your value of `split_args_with`) of parameters that
     were given to the command by the user.
     """
+
     def decorator(func):
-        return _tag_botcmd(func,
-                           _re=False,
-                           _arg=False,
-                           hidden=hidden,
-                           name=name or func.__name__,
-                           split_args_with=split_args_with,
-                           admin_only=admin_only,
-                           historize=historize,
-                           template=template,
-                           syntax=syntax,
-                           flow_only=flow_only)
+        return _tag_botcmd(
+            func,
+            _re=False,
+            _arg=False,
+            hidden=hidden,
+            name=name or func.__name__,
+            split_args_with=split_args_with,
+            admin_only=admin_only,
+            historize=historize,
+            template=template,
+            syntax=syntax,
+            flow_only=flow_only,
+        )
+
     return decorator(args[0]) if args else decorator
 
 
-def re_botcmd(*args,
-              hidden: bool=None,
-              name: str=None,
-              admin_only: bool=False,
-              historize: bool=True,
-              template: str=None,
-              pattern: str=None,
-              flags: int=0,
-              matchall: bool=False,
-              prefixed: bool=True,
-              flow_only: bool=False,
-              re_cmd_name_help: str=None) -> Callable[[BotPlugin, Message, Any], Any]:
+def re_botcmd(
+    *args,
+    hidden: bool = None,
+    name: str = None,
+    admin_only: bool = False,
+    historize: bool = True,
+    template: str = None,
+    pattern: str = None,
+    flags: int = 0,
+    matchall: bool = False,
+    prefixed: bool = True,
+    flow_only: bool = False,
+    re_cmd_name_help: str = None
+) -> Callable[[BotPlugin, Message, Any], Any]:
     """
     Decorator for regex-based bot command functions
 
@@ -208,21 +232,25 @@ def re_botcmd(*args,
     be a :class:`re.MatchObject` containing the result of applying the regular expression on the
     user's input.
     """
+
     def decorator(func):
-        return _tag_botcmd(func,
-                           _re=True,
-                           _arg=False,
-                           hidden=hidden,
-                           name=name or func.__name__,
-                           admin_only=admin_only,
-                           historize=historize,
-                           template=template,
-                           pattern=pattern,
-                           flags=flags,
-                           matchall=matchall,
-                           prefixed=prefixed,
-                           flow_only=flow_only,
-                           re_cmd_name_help=re_cmd_name_help)
+        return _tag_botcmd(
+            func,
+            _re=True,
+            _arg=False,
+            hidden=hidden,
+            name=name or func.__name__,
+            admin_only=admin_only,
+            historize=historize,
+            template=template,
+            pattern=pattern,
+            flags=flags,
+            matchall=matchall,
+            prefixed=prefixed,
+            flow_only=flow_only,
+            re_cmd_name_help=re_cmd_name_help,
+        )
+
     return decorator(args[0]) if args else decorator
 
 
@@ -253,20 +281,24 @@ def botmatch(*args, **kwargs):
         def yes_or_no(self, msg, match):
             pass
     """
+
     def decorator(func, pattern):
-        return _tag_botcmd(func,
-                           _re=True,
-                           _arg=False,
-                           prefixed=False,
-                           hidden=kwargs.get('hidden', None),
-                           name=kwargs.get('name', func.__name__),
-                           admin_only=kwargs.get('admin_only', False),
-                           flow_only=kwargs.get('flow_only', False),
-                           historize=kwargs.get('historize', True),
-                           template=kwargs.get('template', None),
-                           pattern=pattern,
-                           flags=kwargs.get('flags', 0),
-                           matchall=kwargs.get('matchall', False))
+        return _tag_botcmd(
+            func,
+            _re=True,
+            _arg=False,
+            prefixed=False,
+            hidden=kwargs.get("hidden", None),
+            name=kwargs.get("name", func.__name__),
+            admin_only=kwargs.get("admin_only", False),
+            flow_only=kwargs.get("flow_only", False),
+            historize=kwargs.get("historize", True),
+            template=kwargs.get("template", None),
+            pattern=pattern,
+            flags=kwargs.get("flags", 0),
+            matchall=kwargs.get("matchall", False),
+        )
+
     if len(args) == 2:
         return decorator(*args)
     if len(args) == 1:
@@ -274,15 +306,17 @@ def botmatch(*args, **kwargs):
     raise ValueError("botmatch: You need to pass the pattern as parameter to the decorator.")
 
 
-def arg_botcmd(*args,
-               hidden: bool=None,
-               name: str=None,
-               admin_only: bool=False,
-               historize: bool=True,
-               template: str=None,
-               flow_only: bool=False,
-               unpack_args: bool=True,
-               **kwargs) -> Callable[[BotPlugin, Message, Any], Any]:
+def arg_botcmd(
+    *args,
+    hidden: bool = None,
+    name: str = None,
+    admin_only: bool = False,
+    historize: bool = True,
+    template: str = None,
+    flow_only: bool = False,
+    unpack_args: bool = True,
+    **kwargs
+) -> Callable[[BotPlugin, Message, Any], Any]:
     """
     Decorator for argparse-based bot command functions
 
@@ -338,19 +372,16 @@ def arg_botcmd(*args,
 
     def decorator(func):
 
-        if not hasattr(func, '_err_command'):
+        if not hasattr(func, "_err_command"):
 
-            err_command_parser = ArgumentParser(
-                prog=name or func.__name__,
-                description=func.__doc__,
-            )
+            err_command_parser = ArgumentParser(prog=name or func.__name__, description=func.__doc__)
 
             @wraps(func)
             def wrapper(self, msg, args):
 
                 # Attempt to sanitize arguments of bad characters
                 try:
-                    sanitizer_re = re.compile('|'.join(re.escape(ii) for ii in ARG_BOTCMD_CHARACTER_REPLACEMENTS))
+                    sanitizer_re = re.compile("|".join(re.escape(ii) for ii in ARG_BOTCMD_CHARACTER_REPLACEMENTS))
                     args = sanitizer_re.sub(lambda mm: ARG_BOTCMD_CHARACTER_REPLACEMENTS[mm.group()], args)
                     args = shlex.split(args)
                     parsed_args = err_command_parser.parse_args(args)
@@ -379,16 +410,18 @@ def arg_botcmd(*args,
                 else:
                     yield func(self, msg, *func_args, **func_kwargs)
 
-            _tag_botcmd(wrapper,
-                        _re=False,
-                        _arg=True,
-                        hidden=hidden,
-                        name=name or wrapper.__name__,
-                        admin_only=admin_only,
-                        historize=historize,
-                        template=template,
-                        flow_only=flow_only,
-                        command_parser=err_command_parser)
+            _tag_botcmd(
+                wrapper,
+                _re=False,
+                _arg=True,
+                hidden=hidden,
+                name=name or wrapper.__name__,
+                admin_only=admin_only,
+                historize=historize,
+                template=template,
+                flow_only=flow_only,
+                command_parser=err_command_parser,
+            )
         else:
             # the function has already been wrapped
             # alias it so we can update it's arguments below
@@ -397,7 +430,7 @@ def arg_botcmd(*args,
         wrapper._err_command_parser.add_argument(*args, **kwargs)
         wrapper.__doc__ = wrapper._err_command_parser.format_help()
         fmt = wrapper._err_command_parser.format_usage()
-        wrapper._err_command_syntax = fmt[len('usage: ') + len(wrapper._err_command_parser.prog) + 1:-1]
+        wrapper._err_command_syntax = fmt[len("usage: ") + len(wrapper._err_command_parser.prog) + 1:-1]
 
         return wrapper
 
@@ -405,7 +438,7 @@ def arg_botcmd(*args,
 
 
 def _tag_webhook(func, uri_rule, methods, form_param, raw):
-    log.info("webhooks:  Flag to bind %s to %30s" % (uri_rule, getattr(func, '__name__', func)))
+    log.info("webhooks:  Flag to bind %s to %30s" % (uri_rule, getattr(func, "__name__", func)))
     func._err_webhook_uri_rule = uri_rule
     func._err_webhook_methods = methods
     func._err_webhook_form_param = form_param
@@ -414,13 +447,12 @@ def _tag_webhook(func, uri_rule, methods, form_param, raw):
 
 
 def _uri_from_func(func):
-    return r'/' + func.__name__
+    return r"/" + func.__name__
 
 
-def webhook(*args,
-            methods: Tuple[str]=('POST', 'GET'),
-            form_param: str=None,
-            raw: bool=False) -> Callable[[BotPlugin, Any], str]:
+def webhook(
+    *args, methods: Tuple[str] = ("POST", "GET"), form_param: str = None, raw: bool = False
+) -> Callable[[BotPlugin, Any], str]:
     """
     Decorator for webhooks
 
@@ -455,24 +487,23 @@ def webhook(*args,
     """
 
     if not args:  # default uri_rule but with kwargs.
-        return lambda func: _tag_webhook(func,
-                                         _uri_from_func(func),
-                                         methods=methods,
-                                         form_param=form_param,
-                                         raw=raw)
+        return lambda func: _tag_webhook(func, _uri_from_func(func), methods=methods, form_param=form_param, raw=raw)
 
     if isinstance(args[0], str):  # first param is uri_rule.
-        return lambda func: _tag_webhook(func,
-                                         args[0] if args[0] == '/'
-                                         else args[0].rstrip('/'),  # trailing / is also be stripped on incoming.
-                                         methods=methods,
-                                         form_param=form_param,
-                                         raw=raw)
-    return _tag_webhook(args[0],  # naked decorator so the first parameter is a function.
-                        _uri_from_func(args[0]),
-                        methods=methods,
-                        form_param=form_param,
-                        raw=raw)
+        return lambda func: _tag_webhook(
+            func,
+            args[0] if args[0] == "/" else args[0].rstrip("/"),  # trailing / is also be stripped on incoming.
+            methods=methods,
+            form_param=form_param,
+            raw=raw,
+        )
+    return _tag_webhook(
+        args[0],  # naked decorator so the first parameter is a function.
+        _uri_from_func(args[0]),
+        methods=methods,
+        form_param=form_param,
+        raw=raw,
+    )
 
 
 def cmdfilter(*args, **kwargs):
@@ -509,10 +540,11 @@ def cmdfilter(*args, **kwargs):
     and send that through in order to make it appear as if the user
     issued a different command.
     """
+
     def decorate(func):
-        if not hasattr(func, '_err_command_filter'):  # don't override generated functions
+        if not hasattr(func, "_err_command_filter"):  # don't override generated functions
             func._err_command_filter = True
-        func.catch_unprocessed = kwargs.get('catch_unprocessed', False)
+        func.catch_unprocessed = kwargs.get("catch_unprocessed", False)
         return func
 
     if len(args):
@@ -526,8 +558,9 @@ def botflow(*args, **kwargs):
 
     TODO(gbin): example / docs
     """
+
     def decorate(func):
-        if not hasattr(func, '_err_flow'):  # don't override generated functions
+        if not hasattr(func, "_err_flow"):  # don't override generated functions
             func._err_flow = True
         return func
 

--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -2,13 +2,12 @@ import io
 import logging
 import random
 import time
-from typing import Any, Mapping, BinaryIO, List, Sequence, Tuple
 from abc import ABC, abstractmethod
-from collections import deque, defaultdict
-
+from collections import defaultdict, deque
+from typing import Any, BinaryIO, List, Mapping, Sequence, Tuple
 
 # Can't use __name__ because of Yapsy
-log = logging.getLogger('errbot.backends.base')
+log = logging.getLogger("errbot.backends.base")
 
 
 class Identifier(ABC):
@@ -73,6 +72,7 @@ class Person(Identifier):
 
 
 class RoomOccupant(Identifier):
+
     @property
     @abstractmethod
     def room(self) -> Any:  # this is oom defined below
@@ -89,7 +89,7 @@ class Room(Identifier):
     This class represents a Multi-User Chatroom.
     """
 
-    def join(self, username: str=None, password: str=None) -> None:
+    def join(self, username: str = None, password: str = None) -> None:
         """
         Join the room.
 
@@ -98,7 +98,7 @@ class Room(Identifier):
         """
         raise NotImplementedError("It should be implemented specifically for your backend")
 
-    def leave(self, reason: str=None) -> None:
+    def leave(self, reason: str = None) -> None:
         """
         Leave the room.
 
@@ -221,15 +221,17 @@ class Message(object):
     the bot.
     """
 
-    def __init__(self,
-                 body: str='',
-                 frm: Identifier=None,
-                 to: Identifier=None,
-                 parent: 'Message'=None,
-                 delayed: bool=False,
-                 partial: bool=False,
-                 extras: Mapping=None,
-                 flow=None):
+    def __init__(
+        self,
+        body: str = "",
+        frm: Identifier = None,
+        to: Identifier = None,
+        parent: "Message" = None,
+        delayed: bool = False,
+        partial: bool = False,
+        extras: Mapping = None,
+        flow=None,
+    ):
         """
         :param body:
             The markdown body of the message.
@@ -329,7 +331,7 @@ class Message(object):
         return self._parent
 
     @parent.setter
-    def parent(self, parent: 'Message'):
+    def parent(self, parent: "Message"):
         self._parent = parent
 
     @property
@@ -376,18 +378,21 @@ class Card(Message):
         Slack or Hipchat it will be rendered natively, otherwise it will be sent as a regular message formatted with
         the card.md template.
     """
-    def __init__(self,
-                 body: str='',
-                 frm: Identifier=None,
-                 to: Identifier=None,
-                 parent: Message=None,
-                 summary: str=None,
-                 title: str='',
-                 link: str=None,
-                 image: str=None,
-                 thumbnail: str=None,
-                 color: str=None,
-                 fields: Tuple[Tuple[str, str]]=()):
+
+    def __init__(
+        self,
+        body: str = "",
+        frm: Identifier = None,
+        to: Identifier = None,
+        parent: Message = None,
+        summary: str = None,
+        title: str = "",
+        link: str = None,
+        image: str = None,
+        thumbnail: str = None,
+        color: str = None,
+        fields: Tuple[Tuple[str, str]] = (),
+    ):
         """
         Creates a Card.
         :param body: main text of the card in markdown.
@@ -437,19 +442,19 @@ class Card(Message):
 
     @property
     def text_color(self):
-        if self._color in ('black', 'blue'):
-            return 'white'
-        return 'black'
+        if self._color in ("black", "blue"):
+            return "white"
+        return "black"
 
     @property
     def fields(self):
         return self._fields
 
 
-ONLINE = 'online'
-OFFLINE = 'offline'
-AWAY = 'away'
-DND = 'dnd'
+ONLINE = "online"
+OFFLINE = "offline"
+AWAY = "away"
+DND = "dnd"
 
 
 class Presence(object):
@@ -460,14 +465,11 @@ class Presence(object):
        when the presence of people changes.
     """
 
-    def __init__(self,
-                 identifier: Identifier,
-                 status: str=None,
-                 message: str=None):
+    def __init__(self, identifier: Identifier, status: str = None, message: str = None):
         if identifier is None:
-            raise ValueError('Presence: identifiers is None')
+            raise ValueError("Presence: identifiers is None")
         if status is None and message is None:
-            raise ValueError('Presence: at least a new status or a new status message mustbe present')
+            raise ValueError("Presence: at least a new status or a new status message mustbe present")
         self._identifier = identifier
         self._status = status
         self._message = message
@@ -498,7 +500,7 @@ class Presence(object):
         return self._message
 
     def __str__(self):
-        response = ''
+        response = ""
         if self._identifier:
             response += 'identifier: "%s" ' % self._identifier
         if self._status:
@@ -511,14 +513,14 @@ class Presence(object):
         return str(self.__str__())
 
 
-STREAM_WAITING_TO_START = 'pending'
-STREAM_TRANSFER_IN_PROGRESS = 'in progress'
-STREAM_SUCCESSFULLY_TRANSFERED = 'success'
-STREAM_PAUSED = 'paused'
-STREAM_ERROR = 'error'
-STREAM_REJECTED = 'rejected'
+STREAM_WAITING_TO_START = "pending"
+STREAM_TRANSFER_IN_PROGRESS = "in progress"
+STREAM_SUCCESSFULLY_TRANSFERED = "success"
+STREAM_PAUSED = "paused"
+STREAM_ERROR = "error"
+STREAM_REJECTED = "rejected"
 
-DEFAULT_REASON = 'unknown'
+DEFAULT_REASON = "unknown"
 
 
 class Stream(io.BufferedReader):
@@ -529,12 +531,9 @@ class Stream(io.BufferedReader):
        when an incoming stream is requested.
     """
 
-    def __init__(self,
-                 identifier: Identifier,
-                 fsource: BinaryIO,
-                 name: str=None,
-                 size: int=None,
-                 stream_type: str=None):
+    def __init__(
+        self, identifier: Identifier, fsource: BinaryIO, name: str = None, size: int = None, stream_type: str = None
+    ):
         super().__init__(fsource)
         self._identifier = identifier
         self._name = name
@@ -619,7 +618,7 @@ class Stream(io.BufferedReader):
             raise ValueError("Invalid state, the stream is not in progress.")
         self._status = STREAM_SUCCESSFULLY_TRANSFERED
 
-    def clone(self, new_fsource: BinaryIO) -> 'Stream':
+    def clone(self, new_fsource: BinaryIO) -> "Stream":
         """
             Creates a clone and with an alternative stream
         """
@@ -638,30 +637,29 @@ class Backend(ABC):
 
     cmd_history = defaultdict(lambda: deque(maxlen=10))  # this will be a per user history
 
-    MSG_ERROR_OCCURRED = 'Sorry for your inconvenience. ' \
-                         'An unexpected error occurred.'
+    MSG_ERROR_OCCURRED = "Sorry for your inconvenience. An unexpected error occurred."
 
     def __init__(self, _):
         """ Those arguments will be directly those put in BOT_IDENTITY
         """
         log.debug("Backend init.")
-        self._reconnection_count = 0          # Increments with each failed (re)connection
-        self._reconnection_delay = 1          # Amount of seconds the bot will sleep on the
+        self._reconnection_count = 0  # Increments with each failed (re)connection
+        self._reconnection_delay = 1  # Amount of seconds the bot will sleep on the
         #                                     # next reconnection attempt
-        self._reconnection_max_delay = 600    # Maximum delay between reconnection attempts
+        self._reconnection_max_delay = 600  # Maximum delay between reconnection attempts
         self._reconnection_multiplier = 1.75  # Delay multiplier
-        self._reconnection_jitter = (0, 3)    # Random jitter added to delay (min, max)
+        self._reconnection_jitter = (0, 3)  # Random jitter added to delay (min, max)
 
     @abstractmethod
     def send_message(self, msg: Message) -> None:
         """Should be overridden by backends with a super().send_message() call."""
 
     @abstractmethod
-    def change_presence(self, status: str=ONLINE, message: str='') -> None:
+    def change_presence(self, status: str = ONLINE, message: str = "") -> None:
         """Signal a presence change for the bot. Should be overridden by backends with a super().send_message() call."""
 
     @abstractmethod
-    def build_reply(self, msg: Message, text: str=None, private: bool=False, threaded: bool=False):
+    def build_reply(self, msg: Message, text: str = None, private: bool = False, threaded: bool = False):
         """ Should be implemented by the backend """
 
     @abstractmethod
@@ -706,7 +704,8 @@ class Backend(ABC):
 
             log.info(
                 "Reconnecting in {delay} seconds ({count} attempted reconnections so far)".format(
-                    delay=self._reconnection_delay, count=self._reconnection_count)
+                    delay=self._reconnection_delay, count=self._reconnection_count
+                )
             )
             try:
                 self._delay_reconnect()
@@ -761,8 +760,9 @@ class Backend(ABC):
         """
         # Default implementation (XMPP-like check using an extra config).
         # Most of the backends should have a better way to determine this.
-        return (msg.is_direct and msg.frm == self.bot_identifier) or \
-               (msg.is_group and msg.frm.nick == self.bot_config.CHATROOM_FN)
+        return (msg.is_direct and msg.frm == self.bot_identifier) or (
+            msg.is_group and msg.frm.nick == self.bot_config.CHATROOM_FN
+        )
 
     def serve_once(self) -> None:
         """

--- a/errbot/backends/graphic.py
+++ b/errbot/backends/graphic.py
@@ -2,18 +2,20 @@ import logging
 import os
 import re
 import sys
+
 from jinja2 import Environment, FileSystemLoader
 
 import errbot
-from errbot.backends.base import Message, ONLINE
-from errbot.backends.text import TextBackend   # we use that as we emulate MUC there already
+from errbot.backends.base import ONLINE, Message
+from errbot.backends.text import TextBackend  # we use that as we emulate MUC there already
 from errbot.rendering import xhtml
 
-CARD_TMPL = Environment(loader=FileSystemLoader(os.path.dirname(__file__)),
-                        autoescape=True).get_template('graphic_card.html')
+CARD_TMPL = Environment(loader=FileSystemLoader(os.path.dirname(__file__)), autoescape=True).get_template(
+    "graphic_card.html"
+)
 
 # Can't use __name__ because of Yapsy
-log = logging.getLogger('errbot.backends.graphic')
+log = logging.getLogger("errbot.backends.graphic")
 
 try:
     from PySide import QtCore, QtGui, QtWebKit
@@ -21,9 +23,11 @@ try:
     from PySide.QtCore import Qt
 except ImportError:
     log.exception("Could not start the graphical backend")
-    log.fatal(""" To install graphic support use:
+    log.fatal(
+        """ To install graphic support use:
     pip install errbot[graphic]
-    """)
+    """
+    )
     sys.exit(-1)
 
 
@@ -48,7 +52,7 @@ class CommandBox(QtGui.QPlainTextEdit, object):
     def updateCompletion(self, commands):
         if self.completer:
             self.completer.activated.disconnect(self.onAutoComplete)
-        self.completer = QCompleter([(self.prefix + name).replace('_', ' ', 1) for name in commands], self)
+        self.completer = QCompleter([(self.prefix + name).replace("_", " ", 1) for name in commands], self)
         self.completer.setCaseSensitivity(Qt.CaseInsensitive)
         self.completer.setWidget(self)
         self.completer.activated.connect(self.onAutoComplete)
@@ -73,8 +77,11 @@ class CommandBox(QtGui.QPlainTextEdit, object):
             event.ignore()
             return
 
-        if self.autocompleteStart is not None and not event.text().isalnum() and \
-                not (key == Qt.Key_Backspace and self.textCursor().position() > self.autocompleteStart):
+        if (
+            self.autocompleteStart is not None
+            and not event.text().isalnum()
+            and not (key == Qt.Key_Backspace and self.textCursor().position() > self.autocompleteStart)
+        ):
             self.completer.popup().hide()
             self.autocompleteStart = None
 
@@ -97,12 +104,12 @@ class CommandBox(QtGui.QPlainTextEdit, object):
         if key == Qt.Key_Up:
             if self.history_index > 0:
                 self.history_index -= 1
-                self.setPlainText('%s%s' % (self.prefix, ' '.join(self.history[self.history_index])))
+                self.setPlainText("%s%s" % (self.prefix, " ".join(self.history[self.history_index])))
                 return
         elif key == Qt.Key_Down:
             if self.history_index < len(self.history) - 1:
                 self.history_index += 1
-                self.setPlainText('%s%s' % (self.prefix, ' '.join(self.history[self.history_index])))
+                self.setPlainText("%s%s" % (self.prefix, " ".join(self.history[self.history_index])))
                 return
         elif key == QtCore.Qt.Key_Return and (ctrl or alt):
             self.newCommand.emit(self.toPlainText())
@@ -110,21 +117,21 @@ class CommandBox(QtGui.QPlainTextEdit, object):
         super().keyPressEvent(*args, **kwargs)
 
 
-urlfinder = re.compile(r'http([^.\s]+\.[^.\s]*)+[^.\s]{2,}')
+urlfinder = re.compile(r"http([^.\s]+\.[^.\s]*)+[^.\s]{2,}")
 
-backends_path = os.path.join(os.path.dirname(errbot.__file__), 'backends')
+backends_path = os.path.join(os.path.dirname(errbot.__file__), "backends")
 
-images_path = os.path.join(backends_path, 'images')
-prompt_path = os.path.join(images_path, 'prompt.svg')
-icon_path = os.path.join(images_path, 'errbot.svg')
-bg_path = os.path.join(images_path, 'errbot-bg.svg')
+images_path = os.path.join(backends_path, "images")
+prompt_path = os.path.join(images_path, "prompt.svg")
+icon_path = os.path.join(images_path, "errbot.svg")
+bg_path = os.path.join(images_path, "errbot-bg.svg")
 
-style_path = os.path.join(backends_path, 'styles')
-css_path = os.path.join(style_path, 'style.css')
-demo_css_path = os.path.join(style_path, 'style-demo.css')
+style_path = os.path.join(backends_path, "styles")
+css_path = os.path.join(style_path, "style.css")
+demo_css_path = os.path.join(style_path, "style-demo.css")
 
-TOP = '<html><body style="background-image: url(\'file://%s\');">' % bg_path
-BOTTOM = '</body></html>'
+TOP = "<html><body style=\"background-image: url('file://%s');\">" % bg_path
+BOTTOM = "</body></html>"
 
 
 class ChatApplication(QtGui.QApplication):
@@ -134,12 +141,12 @@ class ChatApplication(QtGui.QApplication):
         self.bot = bot
         super().__init__(sys.argv)
         self.mainW = QtGui.QWidget()
-        self.mainW.setWindowTitle('Errbot')
+        self.mainW.setWindowTitle("Errbot")
         self.mainW.setWindowIcon(QtGui.QIcon(icon_path))
         vbox = QtGui.QVBoxLayout()
         help_label = QtGui.QLabel("ctrl or alt+space for autocomplete -- ctrl or alt+Enter to send your message")
         self.input = CommandBox(bot.cmd_history[str(bot.user)], bot.all_commands, bot.bot_config.BOT_PREFIX)
-        self.demo_mode = hasattr(bot.bot_config, 'TEXT_DEMO_MODE') and bot.bot_config.TEXT_DEMO_MODE
+        self.demo_mode = hasattr(bot.bot_config, "TEXT_DEMO_MODE") and bot.bot_config.TEXT_DEMO_MODE
         font = QtGui.QFont("Arial", QtGui.QFont.Bold)
         font.setPointSize(30 if self.demo_mode else 15)
         self.input.setFont(font)
@@ -175,9 +182,9 @@ class ChatApplication(QtGui.QApplication):
         size = 50 if self.demo_mode else 25
         user = '<img src="file://%s" height=%d />' % (prompt_path, size)
         bot = '<img src="file://%s" height=%d/>' % (icon_path, size)
-        self.buffer += '<div class="%s">%s<br/>%s</div>' % ('receiving' if receiving else 'sending',
-                                                            bot if receiving else user,
-                                                            text)
+        self.buffer += '<div class="%s">%s<br/>%s</div>' % (
+            "receiving" if receiving else "sending", bot if receiving else user, text
+        )
 
         self.update_webpage()
 
@@ -192,6 +199,7 @@ class ChatApplication(QtGui.QApplication):
 
 
 class GraphicBackend(TextBackend):
+
     def __init__(self, config):
         super().__init__(config)
         # create window and components
@@ -209,8 +217,7 @@ class GraphicBackend(TextBackend):
         msg.to = self.bot_identifier  # To me only
         self.callback_message(msg)
         # implements the mentions.
-        mentioned = [self.build_identifier(word[1:]) for word in re.findall(r"@[\w']+", text)
-                     if word.startswith('@')]
+        mentioned = [self.build_identifier(word[1:]) for word in re.findall(r"@[\w']+", text) if word.startswith("@")]
         if mentioned:
             self.callback_mention(msg, mentioned)
 
@@ -222,7 +229,7 @@ class GraphicBackend(TextBackend):
         return msg  # rebuild a pure html snippet to include directly in the console html
 
     def send_message(self, msg):
-        if hasattr(msg, 'body') and msg.body and not msg.body.isspace():
+        if hasattr(msg, "body") and msg.body and not msg.body.isspace():
             content = self.md.convert(msg.body)
             log.debug("html:\n%s", content)
             self.app.newAnswer.emit(content)
@@ -230,7 +237,7 @@ class GraphicBackend(TextBackend):
     def send_card(self, card):
         self.app.newAnswer.emit(CARD_TMPL.render(card=card))
 
-    def change_presence(self, status: str = ONLINE, message: str = '') -> None:
+    def change_presence(self, status: str = ONLINE, message: str = "") -> None:
         pass
 
     def serve_forever(self):
@@ -245,8 +252,8 @@ class GraphicBackend(TextBackend):
 
     @property
     def mode(self):
-        return 'graphic'
+        return "graphic"
 
     def prefix_groupchat_reply(self, message, identifier):
         super().prefix_groupchat_reply(message, identifier)
-        message.body = '@{0} {1}'.format(identifier.nick, message.body)
+        message.body = "@{0} {1}".format(identifier.nick, message.body)

--- a/errbot/backends/irc.py
+++ b/errbot/backends/irc.py
@@ -1,57 +1,56 @@
 from __future__ import absolute_import
+
 import logging
+import re
+import struct
+import subprocess
 import sys
 import threading
-import subprocess
-import struct
-import re
 
 from markdown import Markdown
 from markdown.extensions.extra import ExtraExtension
 
-from errbot.backends.base import Message, Room, RoomError, \
-    RoomNotJoinedError, Stream, \
-    RoomOccupant, ONLINE, Person
+from errbot.backends.base import ONLINE, Message, Person, Room, RoomError, RoomNotJoinedError, RoomOccupant, Stream
 from errbot.core import ErrBot
+from errbot.rendering.ansiext import NSC, AnsiExtension, CharacterTable, enable_format
 from errbot.utils import rate_limited
-from errbot.rendering.ansiext import AnsiExtension, enable_format, \
-    CharacterTable, NSC
-
 
 # Can't use __name__ because of Yapsy
-log = logging.getLogger('errbot.backends.irc')
+log = logging.getLogger("errbot.backends.irc")
 
-IRC_CHRS = CharacterTable(fg_black=NSC('\x0301'),
-                          fg_red=NSC('\x0304'),
-                          fg_green=NSC('\x0303'),
-                          fg_yellow=NSC('\x0308'),
-                          fg_blue=NSC('\x0302'),
-                          fg_magenta=NSC('\x0306'),
-                          fg_cyan=NSC('\x0310'),
-                          fg_white=NSC('\x0300'),
-                          fg_default=NSC('\x03'),
-                          bg_black=NSC('\x03,01'),
-                          bg_red=NSC('\x03,04'),
-                          bg_green=NSC('\x03,03'),
-                          bg_yellow=NSC('\x03,08'),
-                          bg_blue=NSC('\x03,02'),
-                          bg_magenta=NSC('\x03,06'),
-                          bg_cyan=NSC('\x03,10'),
-                          bg_white=NSC('\x03,00'),
-                          bg_default=NSC('\x03,'),
-                          fx_reset=NSC('\x03'),
-                          fx_bold=NSC('\x02'),
-                          fx_italic=NSC('\x1D'),
-                          fx_underline=NSC('\x1F'),
-                          fx_not_italic=NSC('\x0F'),
-                          fx_not_underline=NSC('\x0F'),
-                          fx_normal=NSC('\x0F'),
-                          fixed_width='',
-                          end_fixed_width='',
-                          inline_code='',
-                          end_inline_code='')
+IRC_CHRS = CharacterTable(
+    fg_black=NSC("\x0301"),
+    fg_red=NSC("\x0304"),
+    fg_green=NSC("\x0303"),
+    fg_yellow=NSC("\x0308"),
+    fg_blue=NSC("\x0302"),
+    fg_magenta=NSC("\x0306"),
+    fg_cyan=NSC("\x0310"),
+    fg_white=NSC("\x0300"),
+    fg_default=NSC("\x03"),
+    bg_black=NSC("\x03,01"),
+    bg_red=NSC("\x03,04"),
+    bg_green=NSC("\x03,03"),
+    bg_yellow=NSC("\x03,08"),
+    bg_blue=NSC("\x03,02"),
+    bg_magenta=NSC("\x03,06"),
+    bg_cyan=NSC("\x03,10"),
+    bg_white=NSC("\x03,00"),
+    bg_default=NSC("\x03,"),
+    fx_reset=NSC("\x03"),
+    fx_bold=NSC("\x02"),
+    fx_italic=NSC("\x1D"),
+    fx_underline=NSC("\x1F"),
+    fx_not_italic=NSC("\x0F"),
+    fx_not_underline=NSC("\x0F"),
+    fx_normal=NSC("\x0F"),
+    fixed_width="",
+    end_fixed_width="",
+    inline_code="",
+    end_inline_code="",
+)
 
-IRC_NICK_REGEX = r'[a-zA-Z\[\]\\`_\^\{\|\}][a-zA-Z0-9\[\]\\`_\^\{\|\}-]+'
+IRC_NICK_REGEX = r"[a-zA-Z\[\]\\`_\^\{\|\}][a-zA-Z0-9\[\]\\`_\^\{\|\}-]+"
 IRC_MESSAGE_SIZE_LIMIT = 510
 
 try:
@@ -59,16 +58,18 @@ try:
     from irc.client import ServerNotConnectedError, NickMask
     from irc.bot import SingleServerIRCBot
 except ImportError:
-    log.fatal("""You need the IRC support to use IRC, you can install it with:
+    log.fatal(
+        """You need the IRC support to use IRC, you can install it with:
     pip install errbot[IRC]
-    """)
+    """
+    )
     sys.exit(-1)
 
 
 def irc_md():
     """This makes a converter from markdown to mirc color format.
     """
-    md = Markdown(output_format='irc', extensions=[ExtraExtension(), AnsiExtension()])
+    md = Markdown(output_format="irc", extensions=[ExtraExtension(), AnsiExtension()])
     md.stripTopLevelTags = False
     return md
 
@@ -104,9 +105,9 @@ class IRCPerson(Person):
 
     @property
     def aclattr(self):
-        return IRCBackend.aclpattern.format(nick=self._nickmask.nick,
-                                            user=self._nickmask.user,
-                                            host=self._nickmask.host)
+        return IRCBackend.aclpattern.format(
+            nick=self._nickmask.nick, user=self._nickmask.user, host=self._nickmask.host
+        )
 
     def __unicode__(self):
         return str(self._nickmask)
@@ -206,16 +207,13 @@ class IRCRoom(Room):
             reason = ""
 
         self.connection.part(self.room, reason)
-        log.info("Leaving room {} with reason '{}'".format(self.room, reason if reason is not None else ''))
+        log.info("Leaving room {} with reason '{}'".format(self.room, reason if reason is not None else ""))
 
     def create(self):
         """
         Not supported on this back-end. Will join the room to ensure it exists, instead.
         """
-        logging.warning(
-            "IRC back-end does not support explicit creation, joining room "
-            "instead to ensure it exists."
-        )
+        logging.warning("IRC back-end does not support explicit creation, joining room " "instead to ensure it exists.")
         self.join()
 
     def destroy(self):
@@ -233,8 +231,7 @@ class IRCRoom(Room):
             Returns `True` if the room exists, `False` otherwise.
         """
         logging.warning(
-            "IRC back-end does not support determining if a room exists. "
-            "Returning the result of joined instead."
+            "IRC back-end does not support determining if a room exists. " "Returning the result of joined instead."
         )
         return self.joined
 
@@ -289,8 +286,10 @@ class IRCRoom(Room):
             for nick in self._bot.conn.channels[self.room].users():
                 occupants.append(IRCRoomOccupant(nick, room=self.room))
         except KeyError:
-            raise RoomNotJoinedError("Must be in a room in order to \
-                                     see occupants.")
+            raise RoomNotJoinedError(
+                "Must be in a room in order to \
+                                     see occupants."
+            )
         return occupants
 
     def invite(self, *args):
@@ -313,21 +312,23 @@ class IRCRoom(Room):
 
 class IRCConnection(SingleServerIRCBot):
 
-    def __init__(self,
-                 bot,
-                 nickname,
-                 server,
-                 port=6667,
-                 ssl=False,
-                 bind_address=None,
-                 ipv6=False,
-                 password=None,
-                 username=None,
-                 nickserv_password=None,
-                 private_rate=1,
-                 channel_rate=1,
-                 reconnect_on_kick=5,
-                 reconnect_on_disconnect=5):
+    def __init__(
+        self,
+        bot,
+        nickname,
+        server,
+        port=6667,
+        ssl=False,
+        bind_address=None,
+        ipv6=False,
+        password=None,
+        username=None,
+        nickserv_password=None,
+        private_rate=1,
+        channel_rate=1,
+        reconnect_on_kick=5,
+        reconnect_on_disconnect=5,
+    ):
         self.use_ssl = ssl
         self.use_ipv6 = ipv6
         self.bind_address = bind_address
@@ -354,16 +355,17 @@ class IRCConnection(SingleServerIRCBot):
         # Decode all input to UTF-8, but use a replacement character for
         # unrecognized byte sequences
         # (as described at https://pypi.python.org/pypi/irc)
-        self.connection.buffer_class.errors = 'replace'
+        self.connection.buffer_class.errors = "replace"
 
         connection_factory_kwargs = {}
         if self.use_ssl:
             import ssl
-            connection_factory_kwargs['wrapper'] = ssl.wrap_socket
+
+            connection_factory_kwargs["wrapper"] = ssl.wrap_socket
         if self.bind_address is not None:
-            connection_factory_kwargs['bind_address'] = self.bind_address
+            connection_factory_kwargs["bind_address"] = self.bind_address
         if self.use_ipv6:
-            connection_factory_kwargs['ipv6'] = True
+            connection_factory_kwargs["ipv6"] = True
 
         connection_factory = irc.connection.Factory(**connection_factory_kwargs)
         self.connection.connect(*args, connect_factory=connection_factory, **kwargs)
@@ -374,8 +376,8 @@ class IRCConnection(SingleServerIRCBot):
         # try to identify with NickServ if there is a NickServ password in the
         # config
         if self.nickserv_password:
-            msg = 'identify %s' % self.nickserv_password
-            self.send_private_message('NickServ', msg)
+            msg = "identify %s" % self.nickserv_password
+            self.send_private_message("NickServ", msg)
 
         # Must be done in a background thread, otherwise the join room
         # from the ChatRoom plugin joining channels from CHATROOM_PRESENCE
@@ -385,10 +387,10 @@ class IRCConnection(SingleServerIRCBot):
         t.start()
 
     def _pubmsg(self, e, notice=False):
-        msg = Message(e.arguments[0], extras={'notice': notice})
+        msg = Message(e.arguments[0], extras={"notice": notice})
         room_name = e.target
-        if room_name[0] != '#' and room_name[0] != '$':
-            raise Exception('[%s] is not a room' % room_name)
+        if room_name[0] != "#" and room_name[0] != "$":
+            raise Exception("[%s] is not a room" % room_name)
         room = IRCRoom(room_name, self.bot)
         msg.frm = IRCRoomOccupant(e.source, room)
         msg.to = room
@@ -403,7 +405,7 @@ class IRCConnection(SingleServerIRCBot):
             self.bot.callback_mention(msg, mentions)
 
     def _privmsg(self, e, notice=False):
-        msg = Message(e.arguments[0], extras={'notice': notice})
+        msg = Message(e.arguments[0], extras={"notice": notice})
         msg.frm = IRCPerson(e.source)
         msg.to = IRCPerson(e.target)
         self.bot.callback_message(msg)
@@ -429,7 +431,8 @@ class IRCConnection(SingleServerIRCBot):
         def reconnect_channel(name):
             log.info("Reconnecting to %s after having beeing kicked" % name)
             self.bot.query_room(name).join()
-        t = threading.Timer(self._reconnect_on_kick, reconnect_channel, [e.target, ])
+
+        t = threading.Timer(self._reconnect_on_kick, reconnect_channel, [e.target])
         t.daemon = True
         t.start()
 
@@ -452,13 +455,7 @@ class IRCConnection(SingleServerIRCBot):
     def send_stream_request(self, identifier, fsource, name=None, size=None, stream_type=None):
         # Creates a new connection
         dcc = self.dcc_listen("raw")
-        msg_parts = map(str, (
-            'SEND',
-            name,
-            irc.client.ip_quad_to_numstr(dcc.localaddress),
-            dcc.localport,
-            size,
-        ))
+        msg_parts = map(str, ("SEND", name, irc.client.ip_quad_to_numstr(dcc.localaddress), dcc.localport, size))
         msg = subprocess.list2cmdline(msg_parts)
         self.connection.ctcp("DCC", identifier.nick, msg)
         stream = Stream(identifier, fsource, name, size, stream_type)
@@ -608,12 +605,16 @@ class IRCConnection(SingleServerIRCBot):
             dcc.disconnect()
             self.transfers.pop(dcc)
         elif acked == stream.transfered:
-            log.debug("Chunk for file %s successfully transfered to %s (%d/%d)  " %
-                      (stream.name, stream.identifier, stream.transfered, stream.size))
+            log.debug(
+                "Chunk for file %s successfully transfered to %s (%d/%d)  "
+                % (stream.name, stream.identifier, stream.transfered, stream.size)
+            )
             self.send_chunk(stream, dcc)
         else:
-            log.debug("Partial chunk for file %s successfully transfered to %s (%d/%d), wait for more" %
-                      (stream.name, stream.identifier, stream.transfered, stream.size))
+            log.debug(
+                "Partial chunk for file %s successfully transfered to %s (%d/%d), wait for more"
+                % (stream.name, stream.identifier, stream.transfered, stream.size)
+            )
 
     def away(self, message=""):
         """
@@ -625,48 +626,49 @@ class IRCConnection(SingleServerIRCBot):
 
 
 class IRCBackend(ErrBot):
-    aclpattern = '{nick}!{user}@{host}'
+    aclpattern = "{nick}!{user}@{host}"
 
     def __init__(self, config):
-        if hasattr(config, 'IRC_ACL_PATTERN'):
+        if hasattr(config, "IRC_ACL_PATTERN"):
             IRCBackend.aclpattern = config.IRC_ACL_PATTERN
 
         identity = config.BOT_IDENTITY
-        nickname = identity['nickname']
-        server = identity['server']
-        port = identity.get('port', 6667)
-        password = identity.get('password', None)
-        ssl = identity.get('ssl', False)
-        bind_address = identity.get('bind_address', None)
-        ipv6 = identity.get('ipv6', False)
-        username = identity.get('username', None)
-        nickserv_password = identity.get('nickserv_password', None)
+        nickname = identity["nickname"]
+        server = identity["server"]
+        port = identity.get("port", 6667)
+        password = identity.get("password", None)
+        ssl = identity.get("ssl", False)
+        bind_address = identity.get("bind_address", None)
+        ipv6 = identity.get("ipv6", False)
+        username = identity.get("username", None)
+        nickserv_password = identity.get("nickserv_password", None)
 
-        compact = config.COMPACT_OUTPUT if hasattr(config, 'COMPACT_OUTPUT') else True
-        enable_format('irc', IRC_CHRS, borders=not compact)
+        compact = config.COMPACT_OUTPUT if hasattr(config, "COMPACT_OUTPUT") else True
+        enable_format("irc", IRC_CHRS, borders=not compact)
 
-        private_rate = getattr(config, 'IRC_PRIVATE_RATE', 1)
-        channel_rate = getattr(config, 'IRC_CHANNEL_RATE', 1)
-        reconnect_on_kick = getattr(config, 'IRC_RECONNECT_ON_KICK', 5)
-        reconnect_on_disconnect = getattr(config, 'IRC_RECONNECT_ON_DISCONNECT', 5)
+        private_rate = getattr(config, "IRC_PRIVATE_RATE", 1)
+        channel_rate = getattr(config, "IRC_CHANNEL_RATE", 1)
+        reconnect_on_kick = getattr(config, "IRC_RECONNECT_ON_KICK", 5)
+        reconnect_on_disconnect = getattr(config, "IRC_RECONNECT_ON_DISCONNECT", 5)
 
-        self.bot_identifier = IRCPerson(nickname + '!' + nickname + '@' + server)
+        self.bot_identifier = IRCPerson(nickname + "!" + nickname + "@" + server)
         super().__init__(config)
-        self.conn = IRCConnection(bot=self,
-                                  nickname=nickname,
-                                  server=server,
-                                  port=port,
-                                  ssl=ssl,
-                                  bind_address=bind_address,
-                                  ipv6=ipv6,
-                                  password=password,
-                                  username=username,
-                                  nickserv_password=nickserv_password,
-                                  private_rate=private_rate,
-                                  channel_rate=channel_rate,
-                                  reconnect_on_kick=reconnect_on_kick,
-                                  reconnect_on_disconnect=reconnect_on_disconnect,
-                                  )
+        self.conn = IRCConnection(
+            bot=self,
+            nickname=nickname,
+            server=server,
+            port=port,
+            ssl=ssl,
+            bind_address=bind_address,
+            ipv6=ipv6,
+            password=password,
+            username=username,
+            nickserv_password=nickserv_password,
+            private_rate=private_rate,
+            channel_rate=channel_rate,
+            reconnect_on_kick=reconnect_on_kick,
+            reconnect_on_disconnect=reconnect_on_disconnect,
+        )
         self.md = irc_md()
         config.MESSAGE_SIZE_LIMIT = IRC_MESSAGE_SIZE_LIMIT
 
@@ -680,14 +682,14 @@ class IRCBackend(ErrBot):
             msg_to = msg.to.room
 
         body = self.md.convert(msg.body)
-        for line in body.split('\n'):
+        for line in body.split("\n"):
             msg_func(msg_to, line)
 
-    def change_presence(self, status: str = ONLINE, message: str = '') -> None:
+    def change_presence(self, status: str = ONLINE, message: str = "") -> None:
         if status == ONLINE:
             self.conn.away()  # cancels the away message
         else:
-            self.conn.away('[%s] %s' % (status, message))
+            self.conn.away("[%s] %s" % (status, message))
 
     def send_stream_request(self, identifier, fsource, name=None, size=None, stream_type=None):
         return self.conn.send_stream_request(identifier, fsource, name, size, stream_type)
@@ -722,19 +724,19 @@ class IRCBackend(ErrBot):
         return self.conn
 
     def build_message(self, text):
-        text = text.replace('', '*')  # there is a weird chr IRC is sending that we need to filter out
+        text = text.replace("", "*")  # there is a weird chr IRC is sending that we need to filter out
         return super().build_message(text)
 
     def build_identifier(self, txtrep):
         log.debug("Build identifier from [%s]" % txtrep)
         # A textual representation starting with # means that we are talking
         # about an IRC channel -- IRCRoom in internal err-speak.
-        if txtrep.startswith('#'):
+        if txtrep.startswith("#"):
             return IRCRoom(txtrep, self)
 
         # Occupants are represented as 2 lines, one is the IRC mask and the second is the Room.
-        if '\n' in txtrep:
-            m, r = txtrep.split('\n')
+        if "\n" in txtrep:
+            m, r = txtrep.split("\n")
             return IRCRoomOccupant(m, IRCRoom(r, self))
         return IRCPerson(txtrep)
 
@@ -757,7 +759,7 @@ class IRCBackend(ErrBot):
 
     @property
     def mode(self):
-        return 'irc'
+        return "irc"
 
     def rooms(self):
         """
@@ -771,4 +773,4 @@ class IRCBackend(ErrBot):
 
     def prefix_groupchat_reply(self, message, identifier):
         super().prefix_groupchat_reply(message, identifier)
-        message.body = '{0}: {1}'.format(identifier.nick, message.body)
+        message.body = "{0}: {1}".format(identifier.nick, message.body)

--- a/errbot/backends/null.py
+++ b/errbot/backends/null.py
@@ -1,16 +1,16 @@
 import logging
 from time import sleep
-from errbot.backends.base import ONLINE
 
+from errbot.backends.base import ONLINE
 from errbot.backends.test import TestPerson
 from errbot.core import ErrBot
 
-
 # Can't use __name__ because of Yapsy
-log = logging.getLogger('errbot.backends.null')
+log = logging.getLogger("errbot.backends.null")
 
 
 class ConnectionMock(object):
+
     def send(self, msg):
         pass
 
@@ -24,7 +24,7 @@ class NullBackend(ErrBot):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.bot_identifier = self.build_identifier('Err')  # whatever
+        self.bot_identifier = self.build_identifier("Err")  # whatever
 
     def serve_forever(self):
         self.connect()  # be sure we are "connected" before the first command
@@ -56,7 +56,7 @@ class NullBackend(ErrBot):
             self.running = False
             super().shutdown()  # only once (hackish)
 
-    def change_presence(self, status: str = ONLINE, message: str = '') -> None:
+    def change_presence(self, status: str = ONLINE, message: str = "") -> None:
         pass
 
     def build_reply(self, msg, text=None, private=False, threaded=False):
@@ -73,4 +73,4 @@ class NullBackend(ErrBot):
 
     @property
     def mode(self):
-        return 'null'
+        return "null"

--- a/errbot/backends/text.py
+++ b/errbot/backends/text.py
@@ -1,34 +1,33 @@
 # -*- coding: utf-8 -*-
 # vim: ts=4:sw=4
+import copyreg
 import logging
+import re
 import sys
 from time import sleep
-import re
 
-import copyreg
 from ansi.color import fg, fx
+from markdown import Markdown
+from markdown.extensions.extra import ExtraExtension
 from pygments import highlight
 from pygments.formatters import Terminal256Formatter
 from pygments.lexers import get_lexer_by_name
 
-from errbot import botcmd, BotPlugin
-from errbot.rendering import ansi, text, xhtml, imtext
-from errbot.rendering.ansiext import enable_format, ANSI_CHRS, AnsiExtension
-from errbot.backends.base import Message, Person, Presence, ONLINE, OFFLINE, Room, RoomOccupant
+from errbot import BotPlugin, botcmd
+from errbot.backends.base import OFFLINE, ONLINE, Message, Person, Presence, Room, RoomOccupant
 from errbot.core import ErrBot
 from errbot.logs import console_hdlr
-
-from markdown import Markdown
-from markdown.extensions.extra import ExtraExtension
+from errbot.rendering import ansi, imtext, text, xhtml
+from errbot.rendering.ansiext import ANSI_CHRS, AnsiExtension, enable_format
 
 # Can't use __name__ because of Yapsy
-log = logging.getLogger('errbot.backends.text')
+log = logging.getLogger("errbot.backends.text")
 
 ENCODING_INPUT = sys.stdin.encoding
-ANSI = hasattr(sys.stderr, 'isatty') and sys.stderr.isatty()
+ANSI = hasattr(sys.stderr, "isatty") and sys.stderr.isatty()
 
 
-enable_format('borderless', ANSI_CHRS, borders=False)
+enable_format("borderless", ANSI_CHRS, borders=False)
 
 
 def borderless_ansi():
@@ -39,7 +38,7 @@ def borderless_ansi():
 
     ansi_txt = md_converter.convert(md_txt)
     """
-    md = Markdown(output_format='borderless', extensions=[ExtraExtension(), AnsiExtension()])
+    md = Markdown(output_format="borderless", extensions=[ExtraExtension(), AnsiExtension()])
     md.stripTopLevelTags = False
     return md
 
@@ -76,7 +75,7 @@ class TextPerson(Person):
         return str(self)
 
     def __str__(self):
-        return '@' + self._person
+        return "@" + self._person
 
     def __eq__(self, other):
         if not isinstance(other, Person):
@@ -90,15 +89,17 @@ class TextPerson(Person):
 class TextRoom(Room):
 
     def __init__(self, name, bot):
-        self._topic = ''
+        self._topic = ""
         self._joined = False
         self.name = name
         self._bot = bot
 
         # fill up the room with a coherent set of identities.
-        self._occupants = [TextOccupant('somebody', self),
-                           TextOccupant(TextPerson(bot.bot_config.BOT_ADMINS[0]), self),
-                           TextOccupant(bot.bot_identifier, self)]
+        self._occupants = [
+            TextOccupant("somebody", self),
+            TextOccupant(TextPerson(bot.bot_config.BOT_ADMINS[0]), self),
+            TextOccupant(bot.bot_identifier, self),
+        ]
 
     def join(self, username=None, password=None):
         self._joined = True
@@ -136,7 +137,7 @@ class TextRoom(Room):
         pass
 
     def __str__(self):
-        return '#' + self.name
+        return "#" + self.name
 
     def __eq__(self, other):
         return self.name == other.name
@@ -156,7 +157,7 @@ class TextOccupant(TextPerson, RoomOccupant):
         return self._room
 
     def __str__(self):
-        return '#%s/%s' % (self._room.name, self._person.person)
+        return "#%s/%s" % (self._room.name, self._person.person)
 
     def __eq__(self, other):
         return self.person == other.person and self.room == other.room
@@ -185,22 +186,23 @@ You start as a **bot admin in a one-on-one conversation** with the bot.
 
 
 class TextBackend(ErrBot):
+
     def __init__(self, config):
         super().__init__(config)
         log.debug("Text Backend Init.")
 
-        if hasattr(self.bot_config, 'BOT_IDENTITY') and 'username' in self.bot_config.BOT_IDENTITY:
-            self.bot_identifier = self.build_identifier(self.bot_config.BOT_IDENTITY['username'])
+        if hasattr(self.bot_config, "BOT_IDENTITY") and "username" in self.bot_config.BOT_IDENTITY:
+            self.bot_identifier = self.build_identifier(self.bot_config.BOT_IDENTITY["username"])
         else:
             # Just a default identity for the bot if nothing has been specified.
-            self.bot_identifier = self.build_identifier('@errbot')
+            self.bot_identifier = self.build_identifier("@errbot")
 
-        log.debug('Bot username set at %s.', self.bot_identifier)
+        log.debug("Bot username set at %s.", self.bot_identifier)
         self._inroom = False
         self._rooms = []
         self._multiline = False
 
-        self.demo_mode = self.bot_config.TEXT_DEMO_MODE if hasattr(self.bot_config, 'TEXT_DEMO_MODE') else False
+        self.demo_mode = self.bot_config.TEXT_DEMO_MODE if hasattr(self.bot_config, "TEXT_DEMO_MODE") else False
         if not self.demo_mode:
             self.md_html = xhtml()  # for more debug feedback on md
             self.md_text = text()  # for more debug feedback on md
@@ -210,7 +212,7 @@ class TextBackend(ErrBot):
 
         self.md_ansi = ansi()
         self.html_lexer = get_lexer_by_name("html", stripall=True)
-        self.terminal_formatter = Terminal256Formatter(style='paraiso-dark')
+        self.terminal_formatter = Terminal256Formatter(style="paraiso-dark")
         self.user = self.build_identifier(self.bot_config.BOT_ADMINS[0])
         self._register_identifiers_pickling()
 
@@ -235,7 +237,7 @@ class TextBackend(ErrBot):
 
         if not self._rooms:
             # artificially join a room if None were specified.
-            self.query_room('#testroom').join()
+            self.query_room("#testroom").join()
 
         if self.demo_mode:
             # disable the console logging once it is serving in demo mode.
@@ -258,18 +260,14 @@ class TextBackend(ErrBot):
                     to = self.bot_identifier
 
                 print()
-                full_msg = ''
+                full_msg = ""
                 while True:
-                    prompt = '[␍] ' if full_msg else '>>> '
+                    prompt = "[␍] " if full_msg else ">>> "
                     if ANSI or self.demo_mode:
                         color = fg.red if self.user.person in self.bot_config.BOT_ADMINS[0] else fg.green
-                        entry = input(str(color) +
-                                      '[%s ➡ %s] ' % (frm, to) +
-                                      str(fg.cyan) +
-                                      prompt +
-                                      str(fx.reset))
+                        entry = input(str(color) + "[%s ➡ %s] " % (frm, to) + str(fg.cyan) + prompt + str(fx.reset))
                     else:
-                        entry = input('[%s ➡ %s] ' % (frm, to) + prompt)
+                        entry = input("[%s ➡ %s] " % (frm, to) + prompt)
 
                     if not self._multiline:
                         full_msg = entry
@@ -278,7 +276,7 @@ class TextBackend(ErrBot):
                     if not entry:
                         break
 
-                    full_msg += entry + '\n'
+                    full_msg += entry + "\n"
 
                 msg = Message(full_msg)
                 msg.frm = frm
@@ -286,7 +284,7 @@ class TextBackend(ErrBot):
 
                 self.callback_message(msg)
 
-                mentioned = [self.build_identifier(word) for word in re.findall(r'(?<=\s)@[\w]+', entry)]
+                mentioned = [self.build_identifier(word) for word in re.findall(r"(?<=\s)@[\w]+", entry)]
                 if mentioned:
                     self.callback_mention(msg, mentioned)
 
@@ -325,52 +323,52 @@ class TextBackend(ErrBot):
         if self.demo_mode:
             print(self.md_ansi.convert(msg.body))
         else:
-            bar = '\n╌╌[{mode}]' + ('╌' * 60)
+            bar = "\n╌╌[{mode}]" + ("╌" * 60)
             super().send_message(msg)
-            print(bar.format(mode='MD  '))
+            print(bar.format(mode="MD  "))
             if ANSI:
                 print(highlight(msg.body, self.md_lexer, self.terminal_formatter))
             else:
                 print(msg.body)
-            print(bar.format(mode='HTML'))
+            print(bar.format(mode="HTML"))
             html = self.md_html.convert(msg.body)
             if ANSI:
                 print(highlight(html, self.html_lexer, self.terminal_formatter))
             else:
                 print(html)
-            print(bar.format(mode='TEXT'))
+            print(bar.format(mode="TEXT"))
             print(self.md_text.convert(msg.body))
-            print(bar.format(mode='IM  '))
+            print(bar.format(mode="IM  "))
             print(self.md_im.convert(msg.body))
             if ANSI:
-                print(bar.format(mode='ANSI'))
+                print(bar.format(mode="ANSI"))
                 print(self.md_ansi.convert(msg.body))
-                print(bar.format(mode='BORDERLESS'))
+                print(bar.format(mode="BORDERLESS"))
                 print(self.md_borderless_ansi.convert(msg.body))
-            print('\n\n')
+            print("\n\n")
 
     def add_reaction(self, msg: Message, reaction: str) -> None:
         # this is like the Slack backend's add_reaction
-        self._react('+', msg, reaction)
+        self._react("+", msg, reaction)
 
     def remove_reaction(self, msg: Message, reaction: str) -> None:
-        self._react('-', msg, reaction)
+        self._react("-", msg, reaction)
 
     def _react(self, sign, msg, reaction):
-        self.send(msg.frm, 'reaction {}:{}:'.format(sign, reaction), in_reply_to=msg)
+        self.send(msg.frm, "reaction {}:{}:".format(sign, reaction), in_reply_to=msg)
 
-    def change_presence(self, status: str = ONLINE, message: str = '') -> None:
+    def change_presence(self, status: str = ONLINE, message: str = "") -> None:
         log.debug("*** Changed presence to [%s] %s", (status, message))
 
     def build_identifier(self, text_representation):
-        if text_representation.startswith('#'):
+        if text_representation.startswith("#"):
             rem = text_representation[1:]
-            if '/' in text_representation:
-                room, person = rem.split('/')
+            if "/" in text_representation:
+                room, person = rem.split("/")
                 return TextOccupant(TextPerson(person), TextRoom(room, self))
-            return self.query_room('#' + rem)
-        if not text_representation.startswith('@'):
-            raise ValueError('An identifier for the Text backend needs to start with # for a room or @ for a person.')
+            return self.query_room("#" + rem)
+        if not text_representation.startswith("@"):
+            raise ValueError("An identifier for the Text backend needs to start with # for a room or @ for a person.")
         return TextPerson(text_representation[1:])
 
     def build_reply(self, msg, text=None, private=False, threaded=False):
@@ -384,11 +382,11 @@ class TextBackend(ErrBot):
 
     @property
     def mode(self):
-        return 'text'
+        return "text"
 
     def query_room(self, room):
-        if not room.startswith('#'):
-            raise ValueError('A Room name must start by #.')
+        if not room.startswith("#"):
+            raise ValueError("A Room name must start by #.")
         text_room = TextRoom(room[1:], self)
         if text_room not in self._rooms:
             self._rooms.append(text_room)
@@ -399,4 +397,4 @@ class TextBackend(ErrBot):
         return self._rooms
 
     def prefix_groupchat_reply(self, message, identifier):
-        message.body = '{0} {1}'.format(identifier.person, message.body)
+        message.body = "{0} {1}".format(identifier.person, message.body)

--- a/errbot/bootstrap.py
+++ b/errbot/bootstrap.py
@@ -1,76 +1,76 @@
-from os import path, makedirs
+import ast
 import importlib
 import logging
 import sys
-import ast
+from os import makedirs, path
 
 from errbot.core import ErrBot
+from errbot.logs import format_logs
 from errbot.plugin_manager import BotPluginManager
 from errbot.repo_manager import BotRepoManager
 from errbot.specific_plugin_manager import SpecificPluginManager
 from errbot.storage.base import StoragePluginBase
 from errbot.utils import PLUGINS_SUBDIR
-from errbot.logs import format_logs
 
 log = logging.getLogger(__name__)
 
 HERE = path.dirname(path.abspath(__file__))
-CORE_BACKENDS = path.join(HERE, 'backends')
-CORE_STORAGE = path.join(HERE, 'storage')
+CORE_BACKENDS = path.join(HERE, "backends")
+CORE_STORAGE = path.join(HERE, "storage")
 
-PLUGIN_DEFAULT_INDEX = 'https://repos.errbot.io/repos.json'
+PLUGIN_DEFAULT_INDEX = "https://repos.errbot.io/repos.json"
 
 
 def bot_config_defaults(config):
-    if not hasattr(config, 'ACCESS_CONTROLS_DEFAULT'):
+    if not hasattr(config, "ACCESS_CONTROLS_DEFAULT"):
         config.ACCESS_CONTROLS_DEFAULT = {}
-    if not hasattr(config, 'ACCESS_CONTROLS'):
+    if not hasattr(config, "ACCESS_CONTROLS"):
         config.ACCESS_CONTROLS = {}
-    if not hasattr(config, 'HIDE_RESTRICTED_COMMANDS'):
+    if not hasattr(config, "HIDE_RESTRICTED_COMMANDS"):
         config.HIDE_RESTRICTED_COMMANDS = False
-    if not hasattr(config, 'HIDE_RESTRICTED_ACCESS'):
+    if not hasattr(config, "HIDE_RESTRICTED_ACCESS"):
         config.HIDE_RESTRICTED_ACCESS = False
-    if not hasattr(config, 'BOT_PREFIX_OPTIONAL_ON_CHAT'):
+    if not hasattr(config, "BOT_PREFIX_OPTIONAL_ON_CHAT"):
         config.BOT_PREFIX_OPTIONAL_ON_CHAT = False
-    if not hasattr(config, 'BOT_PREFIX'):
-        config.BOT_PREFIX = '!'
-    if not hasattr(config, 'BOT_ALT_PREFIXES'):
+    if not hasattr(config, "BOT_PREFIX"):
+        config.BOT_PREFIX = "!"
+    if not hasattr(config, "BOT_ALT_PREFIXES"):
         config.BOT_ALT_PREFIXES = ()
-    if not hasattr(config, 'BOT_ALT_PREFIX_SEPARATORS'):
+    if not hasattr(config, "BOT_ALT_PREFIX_SEPARATORS"):
         config.BOT_ALT_PREFIX_SEPARATORS = ()
-    if not hasattr(config, 'BOT_ALT_PREFIX_CASEINSENSITIVE'):
+    if not hasattr(config, "BOT_ALT_PREFIX_CASEINSENSITIVE"):
         config.BOT_ALT_PREFIX_CASEINSENSITIVE = False
-    if not hasattr(config, 'DIVERT_TO_PRIVATE'):
+    if not hasattr(config, "DIVERT_TO_PRIVATE"):
         config.DIVERT_TO_PRIVATE = ()
-    if not hasattr(config, 'DIVERT_TO_THREAD'):
+    if not hasattr(config, "DIVERT_TO_THREAD"):
         config.DIVERT_TO_THREAD = ()
-    if not hasattr(config, 'MESSAGE_SIZE_LIMIT'):
+    if not hasattr(config, "MESSAGE_SIZE_LIMIT"):
         config.MESSAGE_SIZE_LIMIT = 10000  # Corresponds with what HipChat accepts
-    if not hasattr(config, 'GROUPCHAT_NICK_PREFIXED'):
+    if not hasattr(config, "GROUPCHAT_NICK_PREFIXED"):
         config.GROUPCHAT_NICK_PREFIXED = False
-    if not hasattr(config, 'AUTOINSTALL_DEPS'):
+    if not hasattr(config, "AUTOINSTALL_DEPS"):
         config.AUTOINSTALL_DEPS = True
-    if not hasattr(config, 'SUPPRESS_CMD_NOT_FOUND'):
+    if not hasattr(config, "SUPPRESS_CMD_NOT_FOUND"):
         config.SUPPRESS_CMD_NOT_FOUND = False
-    if not hasattr(config, 'BOT_ASYNC'):
+    if not hasattr(config, "BOT_ASYNC"):
         config.BOT_ASYNC = True
-    if not hasattr(config, 'BOT_ASYNC_POOLSIZE'):
+    if not hasattr(config, "BOT_ASYNC_POOLSIZE"):
         config.BOT_ASYNC_POOLSIZE = 10
-    if not hasattr(config, 'CHATROOM_PRESENCE'):
+    if not hasattr(config, "CHATROOM_PRESENCE"):
         config.CHATROOM_PRESENCE = ()
-    if not hasattr(config, 'CHATROOM_RELAY'):
+    if not hasattr(config, "CHATROOM_RELAY"):
         config.CHATROOM_RELAY = ()
-    if not hasattr(config, 'REVERSE_CHATROOM_RELAY'):
+    if not hasattr(config, "REVERSE_CHATROOM_RELAY"):
         config.REVERSE_CHATROOM_RELAY = ()
-    if not hasattr(config, 'CHATROOM_FN'):
-        config.CHATROOM_FN = 'Errbot'
-    if not hasattr(config, 'TEXT_DEMO_MODE'):
+    if not hasattr(config, "CHATROOM_FN"):
+        config.CHATROOM_FN = "Errbot"
+    if not hasattr(config, "TEXT_DEMO_MODE"):
         config.TEXT_DEMO_MODE = True
-    if not hasattr(config, 'BOT_ADMINS'):
-        raise ValueError('BOT_ADMINS missing from config.py.')
-    if not hasattr(config, 'TEXT_COLOR_THEME'):
-        config.TEXT_COLOR_THEME = 'light'
-    if not hasattr(config, 'BOT_ADMINS_NOTIFICATIONS'):
+    if not hasattr(config, "BOT_ADMINS"):
+        raise ValueError("BOT_ADMINS missing from config.py.")
+    if not hasattr(config, "TEXT_COLOR_THEME"):
+        config.TEXT_COLOR_THEME = "light"
+    if not hasattr(config, "BOT_ADMINS_NOTIFICATIONS"):
         config.BOT_ADMINS_NOTIFICATIONS = config.BOT_ADMINS
 
 
@@ -80,7 +80,7 @@ def setup_bot(backend_name, logger, config, restore=None):
 
     bot_config_defaults(config)
 
-    if hasattr(config, 'BOT_LOG_FORMATTER'):
+    if hasattr(config, "BOT_LOG_FORMATTER"):
         format_logs(formatter=config.BOT_LOG_FORMATTER)
     else:
         format_logs(theme_color=config.TEXT_COLOR_THEME)
@@ -90,7 +90,7 @@ def setup_bot(backend_name, logger, config, restore=None):
             hdlr.setFormatter(logging.Formatter("%(asctime)s %(levelname)-8s %(name)-25s %(message)s"))
             logger.addHandler(hdlr)
 
-    if hasattr(config, 'BOT_LOG_SENTRY') and config.BOT_LOG_SENTRY:
+    if hasattr(config, "BOT_LOG_SENTRY") and config.BOT_LOG_SENTRY:
         try:
             from raven.handlers.logging import SentryHandler
         except ImportError:
@@ -102,7 +102,7 @@ def setup_bot(backend_name, logger, config, restore=None):
             )
             exit(-1)
 
-        if hasattr(config, 'SENTRY_TRANSPORT') and isinstance(config.SENTRY_TRANSPORT, tuple):
+        if hasattr(config, "SENTRY_TRANSPORT") and isinstance(config.SENTRY_TRANSPORT, tuple):
             try:
                 mod = importlib.import_module(config.SENTRY_TRANSPORT[1])
                 transport = getattr(mod, config.SENTRY_TRANSPORT[0])
@@ -112,9 +112,7 @@ def setup_bot(backend_name, logger, config, restore=None):
                 )
                 exit(-1)
 
-            sentryhandler = SentryHandler(config.SENTRY_DSN,
-                                          level=config.SENTRY_LOGLEVEL,
-                                          transport=transport)
+            sentryhandler = SentryHandler(config.SENTRY_DSN, level=config.SENTRY_LOGLEVEL, transport=transport)
         else:
             sentryhandler = SentryHandler(config.SENTRY_DSN, level=config.SENTRY_LOGLEVEL)
         logger.addHandler(sentryhandler)
@@ -128,19 +126,19 @@ def setup_bot(backend_name, logger, config, restore=None):
     if not path.exists(botplugins_dir):
         makedirs(botplugins_dir, mode=0o755)
 
-    plugin_indexes = getattr(config, 'BOT_PLUGIN_INDEXES', (PLUGIN_DEFAULT_INDEX,))
+    plugin_indexes = getattr(config, "BOT_PLUGIN_INDEXES", (PLUGIN_DEFAULT_INDEX,))
     if isinstance(plugin_indexes, str):
-        plugin_indexes = (plugin_indexes, )
+        plugin_indexes = (plugin_indexes,)
 
-    repo_manager = BotRepoManager(storage_plugin,
-                                  botplugins_dir,
-                                  plugin_indexes)
-    botpm = BotPluginManager(storage_plugin,
-                             repo_manager,
-                             config.BOT_EXTRA_PLUGIN_DIR,
-                             config.AUTOINSTALL_DEPS,
-                             getattr(config, 'CORE_PLUGINS', None),
-                             getattr(config, 'PLUGINS_CALLBACK_ORDER', (None, )))
+    repo_manager = BotRepoManager(storage_plugin, botplugins_dir, plugin_indexes)
+    botpm = BotPluginManager(
+        storage_plugin,
+        repo_manager,
+        config.BOT_EXTRA_PLUGIN_DIR,
+        config.AUTOINSTALL_DEPS,
+        getattr(config, "CORE_PLUGINS", None),
+        getattr(config, "PLUGINS_CALLBACK_ORDER", (None,)),
+    )
 
     # init the backend manager & the bot
     backendpm = bpm_from_config(config)
@@ -162,17 +160,17 @@ def setup_bot(backend_name, logger, config, restore=None):
     # restore the bot from the restore script
     if restore:
         # Prepare the context for the restore script
-        if 'repos' in bot:
-            log.fatal('You cannot restore onto a non empty bot.')
+        if "repos" in bot:
+            log.fatal("You cannot restore onto a non empty bot.")
             sys.exit(-1)
-        log.info('**** RESTORING the bot from %s' % restore)
+        log.info("**** RESTORING the bot from %s" % restore)
         restore_bot_from_backup(restore, bot=bot, log=log)
-        print('Restore complete. You can restart the bot normally')
+        print("Restore complete. You can restart the bot normally")
         sys.exit(0)
 
     errors = bot.plugin_manager.update_dynamic_plugins()
     if errors:
-        log.error('Some plugins failed to load:\n' + '\n'.join(errors.values()))
+        log.error("Some plugins failed to load:\n" + "\n".join(errors.values()))
         bot._plugin_errors_during_startup = "\n".join(errors.values())
     return bot
 
@@ -188,7 +186,7 @@ def restore_bot_from_backup(backup_filename, *, bot, log):
     :param log: logger to use during the restoration process
     """
     with open(backup_filename) as f:
-        exec(f.read(), {'log': log, 'bot': bot})
+        exec(f.read(), {"log": log, "bot": bot})
     bot.close_storage()
 
 
@@ -198,9 +196,9 @@ def get_storage_plugin(config):
     :param config: the bot configuration.
     :return: the storage plugin
     """
-    storage_name = getattr(config, 'STORAGE', 'Shelf')
-    extra_storage_plugins_dir = getattr(config, 'BOT_EXTRA_STORAGE_PLUGINS_DIR', None)
-    spm = SpecificPluginManager(config, 'storage', StoragePluginBase, CORE_STORAGE, extra_storage_plugins_dir)
+    storage_name = getattr(config, "STORAGE", "Shelf")
+    extra_storage_plugins_dir = getattr(config, "BOT_EXTRA_STORAGE_PLUGINS_DIR", None)
+    spm = SpecificPluginManager(config, "storage", StoragePluginBase, CORE_STORAGE, extra_storage_plugins_dir)
     storage_pluginfo = spm.get_candidate(storage_name)
     log.info("Found Storage plugin: '%s'\nDescription: %s" % (storage_pluginfo.name, storage_pluginfo.description))
     storage_plugin = spm.get_plugin_by_name(storage_name)
@@ -209,14 +207,8 @@ def get_storage_plugin(config):
 
 def bpm_from_config(config):
     """Creates a backend plugin manager from a given config."""
-    extra = getattr(config, 'BOT_EXTRA_BACKEND_DIR', [])
-    return SpecificPluginManager(
-        config,
-        'backends',
-        ErrBot,
-        CORE_BACKENDS,
-        extra_search_dirs=extra
-    )
+    extra = getattr(config, "BOT_EXTRA_BACKEND_DIR", [])
+    return SpecificPluginManager(config, "backends", ErrBot, CORE_BACKENDS, extra_search_dirs=extra)
 
 
 def enumerate_backends(config):
@@ -236,5 +228,5 @@ def bootstrap(bot_class, logger, config, restore=None):
     :param restore: Start Errbot in restore mode (from a backup).
     """
     bot = setup_bot(bot_class, logger, config, restore)
-    log.debug('Start serving commands from the %s backend' % bot.mode)
+    log.debug("Start serving commands from the %s backend" % bot.mode)
     bot.serve_forever()

--- a/errbot/cli.py
+++ b/errbot/cli.py
@@ -15,13 +15,13 @@
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 import argparse
+import ast
 import locale
 import logging
 import os
 import sys
-from os import path, sep, getcwd, access, W_OK
+from os import W_OK, access, getcwd, path, sep
 from platform import system
-import ast
 
 from errbot.logs import root_logger
 from errbot.plugin_wizard import new_plugin_wizard
@@ -29,27 +29,29 @@ from errbot.version import VERSION
 
 log = logging.getLogger(__name__)
 
-if locale.getpreferredencoding().lower() != 'utf-8':
-    log.warning('Starting errbot with a default system encoding other than \'utf-8\''
-                ' might cause you a heap of troubles.'
-                ' Your current encoding is set at \'%s\'' % locale.getpreferredencoding().lower())
+if locale.getpreferredencoding().lower() != "utf-8":
+    log.warning(
+        "Starting errbot with a default system encoding other than 'utf-8'"
+        " might cause you a heap of troubles."
+        " Your current encoding is set at '%s'" % locale.getpreferredencoding().lower()
+    )
 
 
 # noinspection PyUnusedLocal
 def debug(sig, frame):
     """Interrupt running process, and provide a python prompt for
     interactive debugging."""
-    d = {'_frame': frame}  # Allow access to frame object.
+    d = {"_frame": frame}  # Allow access to frame object.
     d.update(frame.f_globals)  # Unless shadowed by global
     d.update(frame.f_locals)
 
     i = code.InteractiveConsole(d)
     message = "Signal received : entering python shell.\nTraceback:\n"
-    message += ''.join(traceback.format_stack(frame))
+    message += "".join(traceback.format_stack(frame))
     i.interact(message)
 
 
-ON_WINDOWS = system() == 'Windows'
+ON_WINDOWS = system() == "Windows"
 
 if not ON_WINDOWS:
     from daemonize import Daemonize
@@ -64,30 +66,33 @@ def get_config(config_path):
     config_fullpath = config_path
     if not path.exists(config_fullpath):
         log.error(
-            'I cannot find the config file %s \n'
-            '(You can change this path with the -c parameter see --help)' % config_path
+            "I cannot find the config file %s \n"
+            "(You can change this path with the -c parameter see --help)" % config_path
         )
         log.info(
-            'You can use the template %s as a base and copy it to %s. \nYou can then customize it.' % (
-                os.path.realpath(os.path.join(__file__, os.pardir, 'config-template.py')), config_path)
+            "You can use the template %s as a base and copy it to %s. \nYou can then customize it."
+            % (os.path.realpath(os.path.join(__file__, os.pardir, "config-template.py")), config_path)
         )
         exit(-1)
 
     try:
         config = __import__(path.splitext(path.basename(config_fullpath))[0])
-        log.info('Config check passed...')
+        log.info("Config check passed...")
         return config
     except Exception:
-        log.exception('I could not import your config from %s, please check the error below...' % config_fullpath)
+        log.exception("I could not import your config from %s, please check the error below..." % config_fullpath)
         exit(-1)
 
 
 def _read_dict():
     import collections
+
     new_dict = ast.literal_eval(sys.stdin.read())
     if not isinstance(new_dict, collections.Mapping):
-        raise ValueError("A dictionary written in python is needed from stdin. Type=%s, Value = %s" % (type(new_dict),
-                                                                                                       repr(new_dict)))
+        raise ValueError(
+            "A dictionary written in python is needed from stdin. Type=%s, Value = %s"
+            % (type(new_dict), repr(new_dict))
+        )
     return new_dict
 
 
@@ -99,91 +104,124 @@ def main():
     # the source tree directly without installing it.
     sys.path.insert(0, execution_dir)
 
-    parser = argparse.ArgumentParser(description='The main entry point of the errbot.')
-    parser.add_argument('-c', '--config', default=None,
-                        help='Full path to your config.py (default: config.py in current working directory).')
+    parser = argparse.ArgumentParser(description="The main entry point of the errbot.")
+    parser.add_argument(
+        "-c",
+        "--config",
+        default=None,
+        help="Full path to your config.py (default: config.py in current working directory).",
+    )
 
     mode_selection = parser.add_mutually_exclusive_group()
-    mode_selection.add_argument('-v', '--version', action='version', version='Errbot version {}'.format(VERSION))
-    mode_selection.add_argument('-r', '--restore', nargs='?', default=None, const='default',
-                                help='restore a bot from backup.py (default: backup.py from the bot data directory)')
-    mode_selection.add_argument('-l', '--list', action='store_true', help='list all available backends')
-    mode_selection.add_argument('--new-plugin', nargs='?', default=None, const='current_dir',
-                                help='create a new plugin in the specified directory')
-    mode_selection.add_argument('-i', '--init',
-                                nargs='?',
-                                default=None,
-                                const='.',
-                                help='Initialize a simple bot minimal configuration in the optionally '
-                                     'given directory (otherwise it will be the working directory). '
-                                     'This will create a data subdirectory for the bot data dir and a plugins directory'
-                                     ' for your plugin development with an example in it to get you started.')
+    mode_selection.add_argument("-v", "--version", action="version", version="Errbot version {}".format(VERSION))
+    mode_selection.add_argument(
+        "-r",
+        "--restore",
+        nargs="?",
+        default=None,
+        const="default",
+        help="restore a bot from backup.py (default: backup.py from the bot data directory)",
+    )
+    mode_selection.add_argument("-l", "--list", action="store_true", help="list all available backends")
+    mode_selection.add_argument(
+        "--new-plugin",
+        nargs="?",
+        default=None,
+        const="current_dir",
+        help="create a new plugin in the specified directory",
+    )
+    mode_selection.add_argument(
+        "-i",
+        "--init",
+        nargs="?",
+        default=None,
+        const=".",
+        help="Initialize a simple bot minimal configuration in the optionally "
+        "given directory (otherwise it will be the working directory). "
+        "This will create a data subdirectory for the bot data dir and a plugins directory"
+        " for your plugin development with an example in it to get you started.",
+    )
     # storage manipulation
-    mode_selection.add_argument('--storage-set', nargs=1, help='DANGER: Delete the given storage namespace '
-                                                               'and set the python dictionary expression '
-                                                               'passed on stdin.')
-    mode_selection.add_argument('--storage-merge', nargs=1, help='DANGER: Merge in the python dictionary expression '
-                                                                 'passed on stdin into the given storage namespace.')
-    mode_selection.add_argument('--storage-get', nargs=1, help='Dump the given storage namespace in a '
-                                                               'format compatible for --storage-set and '
-                                                               '--storage-merge.')
+    mode_selection.add_argument(
+        "--storage-set",
+        nargs=1,
+        help="DANGER: Delete the given storage namespace "
+        "and set the python dictionary expression "
+        "passed on stdin.",
+    )
+    mode_selection.add_argument(
+        "--storage-merge",
+        nargs=1,
+        help="DANGER: Merge in the python dictionary expression " "passed on stdin into the given storage namespace.",
+    )
+    mode_selection.add_argument(
+        "--storage-get",
+        nargs=1,
+        help="Dump the given storage namespace in a " "format compatible for --storage-set and " "--storage-merge.",
+    )
 
-    mode_selection.add_argument('-T', '--text', dest="backend", action='store_const', const="Text",
-                                help='force local text backend')
-    mode_selection.add_argument('-G', '--graphic', dest="backend", action='store_const', const="Graphic",
-                                help='force local graphical backend')
+    mode_selection.add_argument(
+        "-T", "--text", dest="backend", action="store_const", const="Text", help="force local text backend"
+    )
+    mode_selection.add_argument(
+        "-G", "--graphic", dest="backend", action="store_const", const="Graphic", help="force local graphical backend"
+    )
 
     if not ON_WINDOWS:
-        option_group = parser.add_argument_group('optional daemonization arguments')
-        option_group.add_argument('-d', '--daemon', action='store_true', help='Detach the process from the console')
-        option_group.add_argument('-p', '--pidfile', default=None,
-                                  help='Specify the pid file for the daemon (default: current bot data directory)')
+        option_group = parser.add_argument_group("optional daemonization arguments")
+        option_group.add_argument("-d", "--daemon", action="store_true", help="Detach the process from the console")
+        option_group.add_argument(
+            "-p",
+            "--pidfile",
+            default=None,
+            help="Specify the pid file for the daemon (default: current bot data directory)",
+        )
 
     args = vars(parser.parse_args())  # create a dictionary of args
 
-    if args['init']:
+    if args["init"]:
         try:
             import jinja2
             import shutil
-            base_dir = os.getcwd() if args['init'] == '.' else args['init']
+
+            base_dir = os.getcwd() if args["init"] == "." else args["init"]
 
             if not os.path.isdir(base_dir):
-                print('Target directory %s must exist. Please create it.' % base_dir)
+                print("Target directory %s must exist. Please create it." % base_dir)
 
             base_dir = os.path.abspath(base_dir)
-            data_dir = os.path.join(base_dir, 'data')
-            extra_plugin_dir = os.path.join(base_dir, 'plugins')
-            example_plugin_dir = os.path.join(extra_plugin_dir, 'err-example')
-            log_path = os.path.join(base_dir, 'errbot.log')
-            templates_dir = os.path.join(os.path.dirname(__file__), 'templates', 'initdir')
+            data_dir = os.path.join(base_dir, "data")
+            extra_plugin_dir = os.path.join(base_dir, "plugins")
+            example_plugin_dir = os.path.join(extra_plugin_dir, "err-example")
+            log_path = os.path.join(base_dir, "errbot.log")
+            templates_dir = os.path.join(os.path.dirname(__file__), "templates", "initdir")
             env = jinja2.Environment(loader=jinja2.FileSystemLoader(templates_dir), autoescape=True)
-            config_template = env.get_template('config.py.tmpl')
+            config_template = env.get_template("config.py.tmpl")
 
             os.mkdir(data_dir)
             os.mkdir(extra_plugin_dir)
             os.mkdir(example_plugin_dir)
 
-            with open(os.path.join(base_dir, 'config.py'), 'w') as f:
-                f.write(config_template.render(data_dir=data_dir,
-                                               extra_plugin_dir=extra_plugin_dir,
-                                               log_path=log_path))
-            shutil.copyfile(os.path.join(templates_dir, 'example.plug'),
-                            os.path.join(example_plugin_dir, 'example.plug'))
-            shutil.copyfile(os.path.join(templates_dir, 'example.py'), os.path.join(example_plugin_dir, 'example.py'))
-            print('Your Errbot directory has been correctly initialized !')
+            with open(os.path.join(base_dir, "config.py"), "w") as f:
+                f.write(config_template.render(data_dir=data_dir, extra_plugin_dir=extra_plugin_dir, log_path=log_path))
+            shutil.copyfile(
+                os.path.join(templates_dir, "example.plug"), os.path.join(example_plugin_dir, "example.plug")
+            )
+            shutil.copyfile(os.path.join(templates_dir, "example.py"), os.path.join(example_plugin_dir, "example.py"))
+            print("Your Errbot directory has been correctly initialized !")
             if base_dir == os.getcwd():
                 print('Just do "errbot" and it should start in text/development mode.')
             else:
-                print('Just do "cd %s" then "errbot" and it should start in text/development mode.' % args['init'])
+                print('Just do "cd %s" then "errbot" and it should start in text/development mode.' % args["init"])
             sys.exit(0)
         except Exception as e:
-            print('The initialization of your errbot directory failed: %s' % e)
+            print("The initialization of your errbot directory failed: %s" % e)
             sys.exit(1)
 
     # This must come BEFORE the config is loaded below, to avoid printing
     # logs as a side effect of config loading.
-    if args['new_plugin']:
-        directory = os.getcwd() if args['new_plugin'] == "current_dir" else args['new_plugin']
+    if args["new_plugin"]:
+        directory = os.getcwd() if args["new_plugin"] == "current_dir" else args["new_plugin"]
         for handler in logging.getLogger().handlers:
             root_logger.removeHandler(handler)
         try:
@@ -196,26 +234,28 @@ def main():
         finally:
             sys.exit(0)
 
-    config_path = args['config']
+    config_path = args["config"]
     # setup the environment to be able to import the config.py
     if config_path:
         # appends the current config in order to find config.py
         sys.path.insert(0, path.dirname(path.abspath(config_path)))
     else:
-        config_path = execution_dir + sep + 'config.py'
+        config_path = execution_dir + sep + "config.py"
 
     config = get_config(config_path)  # will exit if load fails
-    if args['list']:
+    if args["list"]:
         from errbot.bootstrap import enumerate_backends
-        print('Available backends:')
+
+        print("Available backends:")
         for backend_name in enumerate_backends(config):
-            print('\t\t%s' % backend_name)
+            print("\t\t%s" % backend_name)
         sys.exit(0)
 
     def storage_action(namespace, fn):
         # Used to defer imports until it is really necessary during the loading time.
         from errbot.bootstrap import get_storage_plugin
         from errbot.storage import StoreMixin
+
         try:
             with StoreMixin() as sdm:
                 sdm.open_storage(get_storage_plugin(config), namespace)
@@ -225,36 +265,42 @@ def main():
             print(str(e), file=sys.stderr)
             return -3
 
-    if args['storage_get']:
+    if args["storage_get"]:
+
         def p(sdm):
             print(repr(dict(sdm)))
-        err_value = storage_action(args['storage_get'][0], p)
+
+        err_value = storage_action(args["storage_get"][0], p)
         sys.exit(err_value)
 
-    if args['storage_set']:
+    if args["storage_set"]:
+
         def replace(sdm):
             new_dict = _read_dict()  # fail early and don't erase the storage if the input is invalid.
             sdm.clear()
             sdm.update(new_dict)
-        err_value = storage_action(args['storage_set'][0], replace)
+
+        err_value = storage_action(args["storage_set"][0], replace)
         sys.exit(err_value)
 
-    if args['storage_merge']:
+    if args["storage_merge"]:
+
         def merge(sdm):
             new_dict = _read_dict()
             sdm.update(new_dict)
-        err_value = storage_action(args['storage_merge'][0], merge)
+
+        err_value = storage_action(args["storage_merge"][0], merge)
         sys.exit(err_value)
 
-    if args['restore']:
-        backend = 'Null'  # we don't want any backend when we restore
-    elif args['backend'] is None:
-        if not hasattr(config, 'BACKEND'):
+    if args["restore"]:
+        backend = "Null"  # we don't want any backend when we restore
+    elif args["backend"] is None:
+        if not hasattr(config, "BACKEND"):
             log.fatal("The BACKEND configuration option is missing in config.py")
             sys.exit(1)
         backend = config.BACKEND
     else:
-        backend = args['backend']
+        backend = args["backend"]
 
     log.info("Selected backend '%s'." % backend)
 
@@ -267,35 +313,38 @@ def main():
     if not access(config.BOT_DATA_DIR, W_OK):
         raise Exception("The data directory '%s' should be writable for the bot" % config.BOT_DATA_DIR)
 
-    if (not ON_WINDOWS) and args['daemon']:
-        if args['backend'] == "Text":
-            raise Exception('You cannot run in text and daemon mode at the same time')
-        if args['restore']:
-            raise Exception('You cannot restore a backup in daemon mode.')
-        if args['pidfile']:
-            pid = args['pidfile']
+    if (not ON_WINDOWS) and args["daemon"]:
+        if args["backend"] == "Text":
+            raise Exception("You cannot run in text and daemon mode at the same time")
+        if args["restore"]:
+            raise Exception("You cannot restore a backup in daemon mode.")
+        if args["pidfile"]:
+            pid = args["pidfile"]
         else:
-            pid = config.BOT_DATA_DIR + sep + 'err.pid'
+            pid = config.BOT_DATA_DIR + sep + "err.pid"
 
         # noinspection PyBroadException
         try:
+
             def action():
                 from errbot.bootstrap import bootstrap
+
                 bootstrap(backend, root_logger, config)
 
             daemon = Daemonize(app="err", pid=pid, action=action, chdir=os.getcwd())
             log.info("Daemonizing")
             daemon.start()
         except Exception:
-            log.exception('Failed to daemonize the process')
+            log.exception("Failed to daemonize the process")
         exit(0)
     from errbot.bootstrap import bootstrap
-    restore = args['restore']
-    if restore == 'default':  # restore with no argument, get the default location
-        restore = path.join(config.BOT_DATA_DIR, 'backup.py')
+
+    restore = args["restore"]
+    if restore == "default":  # restore with no argument, get the default location
+        restore = path.join(config.BOT_DATA_DIR, "backup.py")
 
     bootstrap(backend, root_logger, config, restore)
-    log.info('Process exiting')
+    log.info("Process exiting")
 
 
 if __name__ == "__main__":

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -63,7 +63,7 @@ import logging
 
 # The location where all of Err's data should be stored. Make sure to set
 # this to a directory that is writable by the user running the bot.
-BOT_DATA_DIR = '/var/lib/err'
+BOT_DATA_DIR = "/var/lib/err"
 
 ### Repos and plugins config.
 
@@ -97,7 +97,7 @@ BOT_EXTRA_PLUGIN_DIR = None
 # pre- or post-processing on messages.
 # The 'None' tuple entry represents all the plugins that aren't to be explicitly ordered. For example, if
 # you want 'A' to run first, then everything else but 'B', then 'B', you would use ('A', None, 'B').
-PLUGINS_CALLBACK_ORDER = (None, )
+PLUGINS_CALLBACK_ORDER = (None,)
 
 # Should plugin dependencies be installed automatically? If this is true
 # then Errbot will use pip to install any missing dependencies automatically.
@@ -117,7 +117,7 @@ PLUGINS_CALLBACK_ORDER = (None, )
 
 # The location of the log file. If you set this to None, then logging will
 # happen to console only.
-BOT_LOG_FILE = BOT_DATA_DIR + '/err.log'
+BOT_LOG_FILE = BOT_DATA_DIR + "/err.log"
 
 # The verbosity level of logging that is done to the above logfile, and to
 # the console. This takes the standard Python logging levels, DEBUG, INFO,
@@ -131,7 +131,7 @@ BOT_LOG_LEVEL = logging.INFO
 # Enable logging to sentry (find out more about sentry at www.getsentry.com).
 # This is optional and disabled by default.
 BOT_LOG_SENTRY = False
-SENTRY_DSN = ''
+SENTRY_DSN = ""
 SENTRY_LOGLEVEL = BOT_LOG_LEVEL
 
 # Set an optional Sentry transport other than the default Threaded.
@@ -197,7 +197,7 @@ BOT_IDENTITY = {
 #
 # Unix-style glob patterns are supported, so 'gbin@localhost'
 # would be considered an admin if setting '*@localhost'.
-BOT_ADMINS = ('gbin@localhost',)
+BOT_ADMINS = ("gbin@localhost",)
 
 # Set of admins that wish to receive administrative bot notifications.
 #BOT_ADMINS_NOTIFICATIONS = ()

--- a/errbot/core_plugins/acls.py
+++ b/errbot/core_plugins/acls.py
@@ -1,4 +1,5 @@
 import fnmatch
+
 from errbot import BotPlugin, cmdfilter
 from errbot.backends.base import RoomOccupant
 
@@ -7,7 +8,7 @@ BLOCK_COMMAND = (None, None, None)
 
 def get_acl_usr(msg):
     """Return the ACL attribute of the sender of the given message"""
-    if hasattr(msg.frm, 'aclattr'):  # if the identity requires a special field to be used for acl
+    if hasattr(msg.frm, "aclattr"):  # if the identity requires a special field to be used for acl
         return msg.frm.aclattr
     return msg.frm.person  # default
 
@@ -59,43 +60,38 @@ class ACLS(BotPlugin):
         """
         self.log.debug("Check %s for ACLs." % cmd)
         f = self._bot.all_commands[cmd]
-        cmd_str = "{plugin}:{command}".format(
-            plugin=f.__self__.name,
-            command=cmd,
-        )
+        cmd_str = "{plugin}:{command}".format(plugin=f.__self__.name, command=cmd)
 
         usr = get_acl_usr(msg)
         acl = self.bot_config.ACCESS_CONTROLS_DEFAULT.copy()
         for pattern, acls in self.bot_config.ACCESS_CONTROLS.items():
-            if ':' not in pattern:
-                pattern = '*:{command}'.format(command=pattern)
+            if ":" not in pattern:
+                pattern = "*:{command}".format(command=pattern)
             if ciglob(cmd_str, (pattern,)):
                 acl.update(acls)
                 break
 
         self.log.info("Matching ACL %s against username %s for command %s" % (acl, usr, cmd_str))
 
-        if 'allowusers' in acl and not glob(usr, acl['allowusers']):
+        if "allowusers" in acl and not glob(usr, acl["allowusers"]):
             return self.access_denied(msg, "You're not allowed to access this command from this user", dry_run)
-        if 'denyusers' in acl and glob(usr, acl['denyusers']):
+        if "denyusers" in acl and glob(usr, acl["denyusers"]):
             return self.access_denied(msg, "You're not allowed to access this command from this user", dry_run)
         if msg.is_group:
             if not isinstance(msg.frm, RoomOccupant):
-                raise Exception('msg.frm is not a RoomOccupant. Class of frm: %s' % msg.frm.__class__)
+                raise Exception("msg.frm is not a RoomOccupant. Class of frm: %s" % msg.frm.__class__)
             room = str(msg.frm.room)
-            if 'allowmuc' in acl and acl['allowmuc'] is False:
+            if "allowmuc" in acl and acl["allowmuc"] is False:
                 return self.access_denied(msg, "You're not allowed to access this command from a chatroom", dry_run)
 
-            if 'allowrooms' in acl and not glob(room, acl['allowrooms']):
+            if "allowrooms" in acl and not glob(room, acl["allowrooms"]):
                 return self.access_denied(msg, "You're not allowed to access this command from this room", dry_run)
 
-            if 'denyrooms' in acl and glob(room, acl['denyrooms']):
+            if "denyrooms" in acl and glob(room, acl["denyrooms"]):
                 return self.access_denied(msg, "You're not allowed to access this command from this room", dry_run)
-        elif 'allowprivate' in acl and acl['allowprivate'] is False:
+        elif "allowprivate" in acl and acl["allowprivate"] is False:
             return self.access_denied(
-                msg,
-                "You're not allowed to access this command via private message to me",
-                dry_run
+                msg, "You're not allowed to access this command via private message to me", dry_run
             )
 
         self.log.info("Check if %s is admin only command." % cmd)

--- a/errbot/core_plugins/backup.py
+++ b/errbot/core_plugins/backup.py
@@ -5,37 +5,40 @@ from errbot import BotPlugin, botcmd
 
 class Backup(BotPlugin):
     """ Backup related commands. """
+
     @botcmd(admin_only=True)
     def backup(self, msg, args):
         """Backup everything.
            Makes a backup script called backup.py in the data bot directory.
            You can restore the backup from the command line with errbot --restore
         """
-        filename = os.path.join(self.bot_config.BOT_DATA_DIR, 'backup.py')
-        with open(filename, 'w') as f:
-            f.write('## This file is not executable on its own. use errbot -r FILE to restore your bot.\n\n')
+        filename = os.path.join(self.bot_config.BOT_DATA_DIR, "backup.py")
+        with open(filename, "w") as f:
+            f.write("## This file is not executable on its own. use errbot -r FILE to restore your bot.\n\n")
             f.write('log.info("Restoring repo_manager.")\n')
             for key, value in self._bot.repo_manager.items():
-                f.write('bot.repo_manager["' + key + '"] = ' + repr(value) + '\n')
+                f.write('bot.repo_manager["' + key + '"] = ' + repr(value) + "\n")
             f.write('log.info("Restoring plugin_manager.")\n')
-            for key, value in self._bot.plugin_manager.items():  # don't mimic that in real plugins, this is core only.
-                f.write('bot.plugin_manager["' + key + '"] = ' + repr(value) + '\n')
+            for (
+                key, value
+            ) in self._bot.plugin_manager.items():  # don't mimic that in real plugins, this is core only.
+                f.write('bot.plugin_manager["' + key + '"] = ' + repr(value) + "\n")
 
             f.write('log.info("Installing plugins.")\n')
             f.write('if "installed_repos" in bot.repo_manager:\n')
             f.write('  for repo in bot.repo_manager["installed_repos"]:\n')
-            f.write('    log.error(bot.repo_manager.install_repo(repo))\n')
+            f.write("    log.error(bot.repo_manager.install_repo(repo))\n")
 
             f.write('log.info("Restoring plugins data.")\n')
-            f.write('bot.plugin_manager.update_dynamic_plugins()\n')
+            f.write("bot.plugin_manager.update_dynamic_plugins()\n")
             for plug in self._bot.plugin_manager.getAllPlugins():
                 pobj = plug.plugin_object
                 if pobj._store:
                     f.write('pobj = bot.plugin_manager.get_plugin_by_name("' + plug.name + '").plugin_object\n')
-                    f.write('pobj.init_storage()\n')
+                    f.write("pobj.init_storage()\n")
 
                     for key, value in pobj.items():
-                        f.write('pobj["' + key + '"] = ' + repr(value) + '\n')
-                    f.write('pobj.close_storage()\n')
+                        f.write('pobj["' + key + '"] = ' + repr(value) + "\n")
+                    f.write("pobj.close_storage()\n")
 
         return "The backup file has been written in '%s'" % filename

--- a/errbot/core_plugins/chatRoom.py
+++ b/errbot/core_plugins/chatRoom.py
@@ -1,6 +1,6 @@
 import logging
 
-from errbot import BotPlugin, botcmd, SeparatorArgParser, ShlexArgParser
+from errbot import BotPlugin, SeparatorArgParser, ShlexArgParser, botcmd
 from errbot.backends.base import RoomNotJoinedError
 
 log = logging.getLogger(__name__)
@@ -11,11 +11,11 @@ class ChatRoom(BotPlugin):
     connected = False
 
     def callback_connect(self):
-        self.log.info('Callback_connect')
+        self.log.info("Callback_connect")
         if not self.connected:
             self.connected = True
             for room in self.bot_config.CHATROOM_PRESENCE:
-                self.log.debug('Try to join room %s' % repr(room))
+                self.log.debug("Try to join room %s" % repr(room))
                 try:
                     self._join_room(room)
                 except Exception:
@@ -82,7 +82,7 @@ class ChatRoom(BotPlugin):
         room_name, password = (args[0], None) if arglen == 1 else (args[0], args[1])
         room = self.query_room(room_name)
         if room is None:
-            return 'Cannot find room {}.'.format(room_name)
+            return "Cannot find room {}.".format(room_name)
 
         room.join(username=self.bot_config.CHATROOM_FN, password=password)
         return "Joined the room {}".format(room_name)
@@ -226,7 +226,7 @@ class ChatRoom(BotPlugin):
             if msg.is_direct:
                 username = msg.frm.person
                 if username in self.bot_config.CHATROOM_RELAY:
-                    self.log.debug('Message to relay from %s.' % username)
+                    self.log.debug("Message to relay from %s." % username)
                     body = msg.body
                     rooms = self.bot_config.CHATROOM_RELAY[username]
                     for roomstr in rooms:
@@ -236,9 +236,9 @@ class ChatRoom(BotPlugin):
                 chat_room = str(fr.room)
                 if chat_room in self.bot_config.REVERSE_CHATROOM_RELAY:
                     users_to_relay_to = self.bot_config.REVERSE_CHATROOM_RELAY[chat_room]
-                    self.log.debug('Message to relay to %s.' % users_to_relay_to)
-                    body = '[%s] %s' % (fr.person, msg.body)
+                    self.log.debug("Message to relay to %s." % users_to_relay_to)
+                    body = "[%s] %s" % (fr.person, msg.body)
                     for user in users_to_relay_to:
                         self.send(user, body)
         except Exception as e:
-            self.log.exception('crashed in callback_message %s' % e)
+            self.log.exception("crashed in callback_message %s" % e)

--- a/errbot/core_plugins/cnf_filter.py
+++ b/errbot/core_plugins/cnf_filter.py
@@ -2,6 +2,7 @@ from errbot import BotPlugin, cmdfilter
 
 
 class CommandNotFoundFilter(BotPlugin):
+
     @cmdfilter(catch_unprocessed=True)
     def cnf_filter(self, msg, cmd, args, dry_run, emptycmd=False):
         """
@@ -21,19 +22,19 @@ class CommandNotFoundFilter(BotPlugin):
             return msg, cmd, args
 
         if self.bot_config.SUPPRESS_CMD_NOT_FOUND:
-            self.log.debug('Suppressing command not found feedback.')
+            self.log.debug("Suppressing command not found feedback.")
             return
 
         command = msg.body.strip()
 
         for prefix in self.bot_config.BOT_ALT_PREFIXES + (self.bot_config.BOT_PREFIX,):
             if command.startswith(prefix):
-                command = command.replace(prefix, '', 1)
+                command = command.replace(prefix, "", 1)
                 break
 
-        command_args = command.split(' ', 1)
+        command_args = command.split(" ", 1)
         command = command_args[0]
         if len(command_args) > 1:
-            args = ' '.join(command_args[1:])
+            args = " ".join(command_args[1:])
 
         return self._bot.unknown_command(msg, command, args)

--- a/errbot/core_plugins/health.py
+++ b/errbot/core_plugins/health.py
@@ -1,15 +1,16 @@
 import gc
 import os
 import signal
-
 from datetime import datetime
-from errbot import BotPlugin, botcmd, arg_botcmd
+
+from errbot import BotPlugin, arg_botcmd, botcmd
 from errbot.plugin_manager import global_restart
 from errbot.utils import format_timedelta
 
 
 class Health(BotPlugin):
-    @botcmd(template='status')
+
+    @botcmd(template="status")
     def status(self, msg, args):
         """ If I am alive I should be able to respond to this one
         """
@@ -17,29 +18,28 @@ class Health(BotPlugin):
         loads = self.status_load(msg, args)
         gc = self.status_gc(msg, args)
 
-        return {'plugins_statuses': plugins_statuses['plugins_statuses'],
-                'loads': loads['loads'],
-                'gc': gc['gc']}
+        return {"plugins_statuses": plugins_statuses["plugins_statuses"], "loads": loads["loads"], "gc": gc["gc"]}
 
-    @botcmd(template='status_load')
+    @botcmd(template="status_load")
     def status_load(self, _, args):
         """ shows the load status
         """
         try:
             from posix import getloadavg
+
             loads = getloadavg()
         except Exception:
             loads = None
 
-        return {'loads': loads}
+        return {"loads": loads}
 
-    @botcmd(template='status_gc')
+    @botcmd(template="status_gc")
     def status_gc(self, _, args):
         """ shows the garbage collection details
         """
-        return {'gc': gc.get_count()}
+        return {"gc": gc.get_count()}
 
-    @botcmd(template='status_plugins')
+    @botcmd(template="status_plugins")
     def status_plugins(self, _, args):
         """ shows the plugin status
         """
@@ -51,26 +51,31 @@ class Health(BotPlugin):
         for name in all_attempted:
             if name in all_blacklisted:
                 if name in all_loaded:
-                    plugins_statuses.append(('BA', name))
+                    plugins_statuses.append(("BA", name))
                 else:
-                    plugins_statuses.append(('BD', name))
+                    plugins_statuses.append(("BD", name))
             elif name in all_loaded:
-                plugins_statuses.append(('A', name))
-            elif pm.get_plugin_obj_by_name(name) is not None \
-                    and pm.get_plugin_obj_by_name(name).get_configuration_template() is not None \
-                    and pm.get_plugin_configuration(name) is None:
-                plugins_statuses.append(('C', name))
+                plugins_statuses.append(("A", name))
+            elif pm.get_plugin_obj_by_name(name) is not None and pm.get_plugin_obj_by_name(
+                name
+            ).get_configuration_template() is not None and pm.get_plugin_configuration(
+                name
+            ) is None:
+                plugins_statuses.append(("C", name))
             else:
-                plugins_statuses.append(('D', name))
+                plugins_statuses.append(("D", name))
 
-        return {'plugins_statuses': plugins_statuses}
+        return {"plugins_statuses": plugins_statuses}
 
     @botcmd
     def uptime(self, _, args):
         """ Return the uptime of the bot
         """
-        return "I've been up for %s %s (since %s)" % (args, format_timedelta(datetime.now() - self._bot.startup_time),
-                                                      self._bot.startup_time.strftime('%A, %b %d at %H:%M'))
+        return "I've been up for %s %s (since %s)" % (
+            args,
+            format_timedelta(datetime.now() - self._bot.startup_time),
+            self._bot.startup_time.strftime("%A, %b %d at %H:%M"),
+        )
 
     # noinspection PyUnusedLocal
     @botcmd(admin_only=True)
@@ -84,10 +89,16 @@ class Health(BotPlugin):
         return "I'm restarting..."
 
     # noinspection PyUnusedLocal
-    @arg_botcmd('--confirm', dest="confirmed", action="store_true",
-                help="confirm you want to shut down", admin_only=True)
-    @arg_botcmd('--kill', dest="kill", action="store_true",
-                help="kill the bot instantly, don't shut down gracefully", admin_only=True)
+    @arg_botcmd(
+        "--confirm", dest="confirmed", action="store_true", help="confirm you want to shut down", admin_only=True
+    )
+    @arg_botcmd(
+        "--kill",
+        dest="kill",
+        action="store_true",
+        help="kill the bot instantly, don't shut down gracefully",
+        admin_only=True,
+    )
     def shutdown(self, msg, confirmed, kill):
         """
         Shutdown the bot.

--- a/errbot/core_plugins/help.py
+++ b/errbot/core_plugins/help.py
@@ -1,19 +1,18 @@
-import textwrap
 import subprocess
+import textwrap
 
 from errbot import BotPlugin, botcmd
 from errbot.version import VERSION
 
 
 class Help(BotPlugin):
-    MSG_HELP_TAIL = 'Type help <command name> to get more info ' \
-                    'about that specific command.'
-    MSG_HELP_UNDEFINED_COMMAND = 'That command is not defined.'
+    MSG_HELP_TAIL = "Type help <command name> to get more info " "about that specific command."
+    MSG_HELP_UNDEFINED_COMMAND = "That command is not defined."
 
-    def is_git_directory(self, path='.'):
+    def is_git_directory(self, path="."):
         try:
             git_call = subprocess.Popen(["git", "tag"], stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
-        except:
+        except Exception:
             return None
         tags, _ = git_call.communicate()
         return_code = git_call.returncode
@@ -24,14 +23,14 @@ class Help(BotPlugin):
             return tags.split(b"\n").pop(-1)
 
     # noinspection PyUnusedLocal
-    @botcmd(template='about')
+    @botcmd(template="about")
     def about(self, msg, args):
         """Return information about this Errbot instance and version"""
         git_version = self.is_git_directory()
         if git_version:
-            return {'version': "{} GIT CHECKOUT".format(git_version.decode("utf-8"))}
+            return {"version": "{} GIT CHECKOUT".format(git_version.decode("utf-8"))}
         else:
-            return {'version': VERSION}
+            return {"version": VERSION}
 
     # noinspection PyUnusedLocal
     @botcmd
@@ -40,35 +39,40 @@ class Help(BotPlugin):
 
         Automatically assigned to the "help" command."""
         if not args:
-            return 'Usage: ' + self._bot.prefix + 'apropos search_term'
+            return "Usage: " + self._bot.prefix + "apropos search_term"
 
-        description = 'Available commands:\n'
+        description = "Available commands:\n"
 
         cls_commands = {}
         for (name, command) in self._bot.all_commands.items():
             cls = self._bot.get_plugin_class_from_method(command)
-            cls = str.__module__ + '.' + cls.__name__  # makes the fuul qualified name
+            cls = str.__module__ + "." + cls.__name__  # makes the fuul qualified name
             commands = cls_commands.get(cls, [])
             if not self.bot_config.HIDE_RESTRICTED_COMMANDS or self._bot.check_command_access(msg, name)[0]:
                 commands.append((name, command))
                 cls_commands[cls] = commands
 
-        usage = ''
+        usage = ""
         for cls in sorted(cls_commands):
-            usage += '\n'.join(sorted([
-                '\t' + self._bot.prefix + '%s: %s' % (
-                    name.replace('_', ' ', 1),
-                    (command.__doc__ or '(undocumented)').strip().split('\n', 1)[0]
+            usage += "\n".join(
+                sorted(
+                    [
+                        "\t"
+                        + self._bot.prefix
+                        + "%s: %s"
+                        % (name.replace("_", " ", 1), (command.__doc__ or "(undocumented)").strip().split("\n", 1)[0])
+                        for (name, command) in cls_commands[cls]
+                        if args is not None
+                        and command.__doc__ is not None
+                        and args.lower() in command.__doc__.lower()
+                        and name != "help"
+                        and not command._err_command_hidden
+                    ]
                 )
-                for (name, command) in cls_commands[cls]
-                if args is not None and
-                command.__doc__ is not None and
-                args.lower() in command.__doc__.lower() and
-                name != 'help' and not command._err_command_hidden
-            ]))
-        usage += '\n\n'
+            )
+        usage += "\n\n"
 
-        return ''.join(filter(None, [description, usage])).strip()
+        return "".join(filter(None, [description, usage])).strip()
 
     @botcmd
     def help(self, msg, args):
@@ -76,21 +80,16 @@ class Help(BotPlugin):
         Automatically assigned to the "help" command."""
 
         def may_access_command(m, cmd):
-            m, _, _ = self._bot._process_command_filters(
-                msg=m,
-                cmd=cmd,
-                args=None,
-                dry_run=True
-            )
+            m, _, _ = self._bot._process_command_filters(msg=m, cmd=cmd, args=None, dry_run=True)
             return m is not None
 
         def get_name(named):
             return named.__name__.lower()
 
         # Normalize args to lowercase for ease of use
-        args = args.lower() if args else ''
-        usage = ''
-        description = '### All commands\n'
+        args = args.lower() if args else ""
+        usage = ""
+        description = "### All commands\n"
 
         cls_obj_commands = {}
         for (name, command) in self._bot.all_commands.items():
@@ -107,17 +106,14 @@ class Help(BotPlugin):
                 obj, commands = cls_obj_commands[cls]
                 name = obj.name
                 # shows class and description
-                usage += '\n**{name}**\n\n*{doc}*\n\n'.format(
-                    name=name,
-                    doc=cls.__errdoc__.strip() or '',
-                )
+                usage += "\n**{name}**\n\n*{doc}*\n\n".format(name=name, doc=cls.__errdoc__.strip() or "")
 
                 for name, command in sorted(commands):
                     if command._err_command_hidden:
                         continue
                     # show individual commands
                     usage += self._cmd_help_line(name, command)
-            usage += '\n\n'  # end cls section
+            usage += "\n\n"  # end cls section
         elif args:
             for cls, (obj, cmds) in cls_obj_commands.items():
                 if obj.name.lower() == args:
@@ -127,54 +123,52 @@ class Help(BotPlugin):
 
             if cls is None:
                 # Plugin not found.
-                description = ''
+                description = ""
                 all_commands = dict(self._bot.all_commands)
-                all_commands.update(
-                    {k.replace('_', ' '): v for k, v in all_commands.items()})
+                all_commands.update({k.replace("_", " "): v for k, v in all_commands.items()})
                 if args in all_commands:
                     usage += self._cmd_help_line(args, all_commands[args], True)
                 else:
                     usage += self.MSG_HELP_UNDEFINED_COMMAND
             else:
                 # filter out the commands related to this class
-                description = '\n**{name}**\n\n*{doc}*\n\n'.format(
-                    name=obj.name,
-                    doc=cls.__errdoc__.strip() or '',
+                description = "\n**{name}**\n\n*{doc}*\n\n".format(name=obj.name, doc=cls.__errdoc__.strip() or "")
+                pairs = sorted(
+                    [
+                        (name, command)
+                        for (name, command) in cmds
+                        if not command._err_command_hidden
+                        and (not self.bot_config.HIDE_RESTRICTED_COMMANDS or may_access_command(msg, name))
+                    ]
                 )
-                pairs = sorted([
-                    (name, command)
-                    for (name, command) in cmds
-                    if not command._err_command_hidden and
-                    (not self.bot_config.HIDE_RESTRICTED_COMMANDS or may_access_command(msg, name))
-                ])
 
                 for (name, command) in pairs:
                     usage += self._cmd_help_line(name, command)
 
-        return ''.join(filter(None, [description, usage]))
+        return "".join(filter(None, [description, usage]))
 
     def _cmd_help_line(self, name, command, show_doc=False):
         """
         Returns:
             str. a single line indicating the help representation of a command.
         """
-        cmd_name = name.replace('_', ' ')
+        cmd_name = name.replace("_", " ")
         cmd_doc = textwrap.dedent(self._bot.get_doc(command)).strip()
-        prefix = self._bot.prefix if getattr(command, '_err_command_prefix_required', True) else ''
+        prefix = self._bot.prefix if getattr(command, "_err_command_prefix_required", True) else ""
 
         name = cmd_name
-        patt = getattr(command, '_err_command_re_pattern', None)
+        patt = getattr(command, "_err_command_re_pattern", None)
 
         if patt:
-            re_help_name = getattr(command, '_err_command_re_name_help', None)
+            re_help_name = getattr(command, "_err_command_re_name_help", None)
             name = re_help_name if re_help_name else patt.pattern
 
         if not show_doc:
-            cmd_doc = cmd_doc.split('\n')[0]
+            cmd_doc = cmd_doc.split("\n")[0]
 
             if len(cmd_doc) > 80:
-                cmd_doc = '{doc}...'.format(doc=cmd_doc[:77])
+                cmd_doc = "{doc}...".format(doc=cmd_doc[:77])
 
-        help_str = '- **{prefix}{name}** - {doc}\n'.format(prefix=prefix, name=name, doc=cmd_doc)
+        help_str = "- **{prefix}{name}** - {doc}\n".format(prefix=prefix, name=name, doc=cmd_doc)
 
         return help_str

--- a/errbot/core_plugins/plugins.py
+++ b/errbot/core_plugins/plugins.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-from ast import literal_eval
-from pprint import pformat
 import os
 import shutil
+from ast import literal_eval
+from pprint import pformat
 
 from errbot import BotPlugin, botcmd
-from errbot.plugin_manager import PluginConfigurationException, PluginActivationException
+from errbot.plugin_manager import PluginActivationException, PluginConfigurationException
 from errbot.repo_manager import RepoException
 
 
@@ -20,23 +20,27 @@ class Plugins(BotPlugin):
         """
         args = args.strip()
         if not args:
-            yield "Please specify a repository listed in '!repos' or " \
-                  "give me the URL to a git repository that I should clone for you."
+            yield (
+                "Please specify a repository listed in '!repos' or "
+                "give me the URL to a git repository that I should clone for you."
+            )
             return
         try:
             yield "Installing %s..." % args
             local_path = self._bot.repo_manager.install_repo(args)
             errors = self._bot.plugin_manager.update_dynamic_plugins()
             if errors:
-                yield 'Some plugins are generating errors:\n' + '\n'.join(errors.values())
+                yield "Some plugins are generating errors:\n" + "\n".join(errors.values())
                 # if the load of the plugin failed, uninstall cleanly teh repo
                 for path in errors.keys():
                     if path.startswith(local_path):
-                        yield 'Removing %s as it did not load correctly.' % local_path
+                        yield "Removing %s as it did not load correctly." % local_path
                         shutil.rmtree(local_path)
             else:
-                yield ("A new plugin repository has been installed correctly from "
-                       "%s. Refreshing the plugins commands..." % args)
+                yield (
+                    "A new plugin repository has been installed correctly from "
+                    "%s. Refreshing the plugins commands..." % args
+                )
             loading_errors = self._bot.plugin_manager.activate_non_started_plugins()
             if loading_errors:
                 yield loading_errors
@@ -61,9 +65,9 @@ class Plugins(BotPlugin):
         plugin_path = os.path.join(self._bot.repo_manager.plugin_dir, repo_name)
         self._bot.plugin_manager.remove_plugins_from_path(plugin_path)
         self._bot.repo_manager.uninstall_repo(repo_name)
-        yield 'Repo %s removed.' % repo_name
+        yield "Repo %s removed." % repo_name
 
-    @botcmd(template='repos')
+    @botcmd(template="repos")
     def repos(self, _, args):
         """ list the current active plugin repositories
         """
@@ -72,7 +76,7 @@ class Plugins(BotPlugin):
 
         all_names = [name for name in installed_repos]
 
-        repos = {'repos': []}
+        repos = {"repos": []}
 
         for repo_name in all_names:
 
@@ -84,26 +88,26 @@ class Plugins(BotPlugin):
             from_index = self._bot.repo_manager.get_repo_from_index(repo_name)
 
             if from_index is not None:
-                description = '\n'.join(('%s: %s' % (plug.name, plug.documentation) for plug in from_index))
+                description = "\n".join(("%s: %s" % (plug.name, plug.documentation) for plug in from_index))
             else:
-                description = 'No description.'
+                description = "No description."
 
             # installed, public, name, desc
-            repos['repos'].append((installed, from_index is not None, repo_name, description))
+            repos["repos"].append((installed, from_index is not None, repo_name, description))
 
         return repos
 
-    @botcmd(template='repos2')
+    @botcmd(template="repos2")
     def repos_search(self, _, args):
         """ Searches the repo index.
         for example: !repos search jenkins
         """
         if not args:
             # TODO(gbin): return all the repos.
-            return {'error': "Please specify a keyword."}
-        return {'repos': self._bot.repo_manager.search_repos(args)}
+            return {"error": "Please specify a keyword."}
+        return {"repos": self._bot.repo_manager.search_repos(args)}
 
-    @botcmd(split_args_with=' ', admin_only=True)
+    @botcmd(split_args_with=" ", admin_only=True)
     def repos_update(self, _, args):
         """ update the bot and/or plugins
         use : !repos update all
@@ -111,7 +115,7 @@ class Plugins(BotPlugin):
         or : !repos update repo_name repo_name ...
         to update selectively some repos
         """
-        if 'all' in args:
+        if "all" in args:
             results = self._bot.repo_manager.update_all_repos()
         else:
             results = self._bot.repo_manager.update_repos(args)
@@ -125,17 +129,17 @@ class Plugins(BotPlugin):
                 yield "Update of %s failed...\n\n%s" % (d, feedback)
 
             for plugin in self._bot.plugin_manager.getAllPlugins():
-                if plugin.path.startswith(d) and hasattr(plugin, 'is_activated') and plugin.is_activated:
+                if plugin.path.startswith(d) and hasattr(plugin, "is_activated") and plugin.is_activated:
                     name = plugin.name
-                    yield '/me is reloading plugin %s' % name
+                    yield "/me is reloading plugin %s" % name
                     try:
                         self._bot.plugin_manager.reload_plugin_by_name(plugin.name)
                         yield "Plugin %s reloaded." % plugin.name
                     except PluginActivationException as pae:
-                        yield 'Error reactivating plugin %s: %s' % (plugin.name, pae)
+                        yield "Error reactivating plugin %s: %s" % (plugin.name, pae)
         yield "Done."
 
-    @botcmd(split_args_with=' ', admin_only=True)
+    @botcmd(split_args_with=" ", admin_only=True)
     def plugin_config(self, _, args):
         """ configure or get the configuration / configuration template for a specific plugin
         ie.
@@ -152,53 +156,58 @@ class Plugins(BotPlugin):
         """
         plugin_name = args[0]
         if self._bot.plugin_manager.is_plugin_blacklisted(plugin_name):
-            return 'Load this plugin first with ' + self._bot.prefix + 'load %s' % plugin_name
+            return "Load this plugin first with " + self._bot.prefix + "load %s" % plugin_name
         obj = self._bot.plugin_manager.get_plugin_obj_by_name(plugin_name)
         if obj is None:
-            return 'Unknown plugin or the plugin could not load %s' % plugin_name
+            return "Unknown plugin or the plugin could not load %s" % plugin_name
         template_obj = obj.get_configuration_template()
         if template_obj is None:
-            return 'This plugin is not configurable.'
+            return "This plugin is not configurable."
 
         if len(args) == 1:
-            response = ("Default configuration for this plugin (you can copy and paste "
-                        "this directly as a command):\n\n"
-                        "```\n{prefix}plugin config {plugin_name} \n{config}\n```").format(
-                prefix=self._bot.prefix, plugin_name=plugin_name, config=pformat(template_obj))
+            response = (
+                "Default configuration for this plugin (you can copy and paste "
+                "this directly as a command):\n\n"
+                "```\n{prefix}plugin config {plugin_name} \n{config}\n```"
+            ).format(
+                prefix=self._bot.prefix, plugin_name=plugin_name, config=pformat(template_obj)
+            )
 
             current_config = self._bot.plugin_manager.get_plugin_configuration(plugin_name)
             if current_config:
-                response += ("\n\nCurrent configuration:\n\n"
-                             "```\n{prefix}plugin config {plugin_name} \n{config}\n```").format(
-                    prefix=self._bot.prefix, plugin_name=plugin_name, config=pformat(current_config))
+                response += (
+                    "\n\nCurrent configuration:\n\n" "```\n{prefix}plugin config {plugin_name} \n{config}\n```"
+                ).format(
+                    prefix=self._bot.prefix, plugin_name=plugin_name, config=pformat(current_config)
+                )
             return response
 
         # noinspection PyBroadException
         try:
-            real_config_obj = literal_eval(' '.join(args[1:]))
+            real_config_obj = literal_eval(" ".join(args[1:]))
         except Exception:
-            self.log.exception('Invalid expression for the configuration of the plugin')
-            return 'Syntax error in the given configuration'
+            self.log.exception("Invalid expression for the configuration of the plugin")
+            return "Syntax error in the given configuration"
         if type(real_config_obj) != type(template_obj):
-            return 'It looks fishy, your config type is not the same as the template !'
+            return "It looks fishy, your config type is not the same as the template !"
 
         self._bot.plugin_manager.set_plugin_configuration(plugin_name, real_config_obj)
 
         try:
             self._bot.plugin_manager.deactivate_plugin(plugin_name)
         except PluginActivationException as pae:
-            return 'Error deactivating %s: %s' % (plugin_name, pae)
+            return "Error deactivating %s: %s" % (plugin_name, pae)
 
         try:
             self._bot.plugin_manager.activate_plugin(plugin_name)
         except PluginConfigurationException as ce:
-            self.log.debug('Invalid configuration for the plugin, reverting the plugin to unconfigured.')
+            self.log.debug("Invalid configuration for the plugin, reverting the plugin to unconfigured.")
             self._bot.plugin_manager.set_plugin_configuration(plugin_name, None)
-            return 'Incorrect plugin configuration: %s' % ce
+            return "Incorrect plugin configuration: %s" % ce
         except PluginActivationException as pae:
-            return 'Error activating plugin: %s' % pae
+            return "Error activating plugin: %s" % pae
 
-        return 'Plugin configuration done.'
+        return "Plugin configuration done."
 
     def formatted_plugin_list(self, active_only=True):
         """
@@ -219,88 +228,106 @@ class Plugins(BotPlugin):
         """reload a plugin: reload the code of the plugin leaving the activation status intact."""
         name = args.strip()
         if not name:
-            yield ("Please tell me which of the following plugins to reload:\n"
-                   "{}".format(self.formatted_plugin_list(active_only=False)))
+            yield (
+                "Please tell me which of the following plugins to reload:\n"
+                "{}".format(self.formatted_plugin_list(active_only=False))
+            )
             return
         if name not in self._bot.plugin_manager.get_all_plugin_names():
-            yield ("{} isn't a valid plugin name. The current plugins are:\n"
-                   "{}".format(name, self.formatted_plugin_list(active_only=False)))
+            yield (
+                "{} isn't a valid plugin name. The current plugins are:\n"
+                "{}".format(name, self.formatted_plugin_list(active_only=False))
+            )
             return
 
         if name not in self._bot.plugin_manager.get_all_active_plugin_names():
-            yield (("Warning: plugin %s is currently not activated. " +
-                   "Use `%splugin activate %s` to activate it.") % (name, self._bot.prefix, name))
+            yield (
+                ("Warning: plugin %s is currently not activated. " + "Use `%splugin activate %s` to activate it.")
+                % (name, self._bot.prefix, name)
+            )
 
         try:
             self._bot.plugin_manager.reload_plugin_by_name(name)
             yield "Plugin %s reloaded." % name
         except PluginActivationException as pae:
-            yield 'Error activating plugin %s: %s' % (name, pae)
+            yield "Error activating plugin %s: %s" % (name, pae)
 
     @botcmd(admin_only=True)
     def plugin_activate(self, _, args):
         """activate a plugin. [calls .activate() on the plugin]"""
         args = args.strip()
         if not args:
-            return ("Please tell me which of the following plugins to activate:\n"
-                    "{}".format(self.formatted_plugin_list(active_only=False)))
+            return (
+                "Please tell me which of the following plugins to activate:\n"
+                "{}".format(self.formatted_plugin_list(active_only=False))
+            )
         if args not in self._bot.plugin_manager.get_all_plugin_names():
-            return ("{} isn't a valid plugin name. The current plugins are:\n"
-                    "{}".format(args, self.formatted_plugin_list(active_only=False)))
+            return (
+                "{} isn't a valid plugin name. The current plugins are:\n"
+                "{}".format(args, self.formatted_plugin_list(active_only=False))
+            )
         if args in self._bot.plugin_manager.get_all_active_plugin_names():
             return "{} is already activated.".format(args)
 
         try:
             self._bot.plugin_manager.activate_plugin(args)
         except PluginActivationException as pae:
-            return 'Error activating plugin: %s' % pae
-        return 'Plugin {} activated.'.format(args)
+            return "Error activating plugin: %s" % pae
+        return "Plugin {} activated.".format(args)
 
     @botcmd(admin_only=True)
     def plugin_deactivate(self, _, args):
         """deactivate a plugin. [calls .deactivate on the plugin]"""
         args = args.strip()
         if not args:
-            return ("Please tell me which of the following plugins to deactivate:\n"
-                    "{}".format(self.formatted_plugin_list(active_only=False)))
+            return (
+                "Please tell me which of the following plugins to deactivate:\n"
+                "{}".format(self.formatted_plugin_list(active_only=False))
+            )
         if args not in self._bot.plugin_manager.get_all_plugin_names():
-            return ("{} isn't a valid plugin name. The current plugins are:\n"
-                    "{}".format(args, self.formatted_plugin_list(active_only=False)))
+            return (
+                "{} isn't a valid plugin name. The current plugins are:\n"
+                "{}".format(args, self.formatted_plugin_list(active_only=False))
+            )
         if args not in self._bot.plugin_manager.get_all_active_plugin_names():
             return "{} is already deactivated.".format(args)
 
         try:
             self._bot.plugin_manager.deactivate_plugin(args)
         except PluginActivationException as pae:
-            return 'Error deactivating %s: %s' % (args, pae)
-        return 'Plugin {} deactivated.'.format(args)
+            return "Error deactivating %s: %s" % (args, pae)
+        return "Plugin {} deactivated.".format(args)
 
     @botcmd(admin_only=True)
     def plugin_blacklist(self, _, args):
         """Blacklist a plugin so that it will not be loaded automatically during bot startup.
         If the plugin is currently activated, it will deactiveate it first."""
         if args not in self._bot.plugin_manager.get_all_plugin_names():
-            return ("{} isn't a valid plugin name. The current plugins are:\n"
-                    "{}".format(args, self.formatted_plugin_list(active_only=False)))
+            return (
+                "{} isn't a valid plugin name. The current plugins are:\n"
+                "{}".format(args, self.formatted_plugin_list(active_only=False))
+            )
 
         if args in self._bot.plugin_manager.get_all_active_plugin_names():
             try:
                 self._bot.plugin_manager.deactivate_plugin(args)
             except PluginActivationException as pae:
-                return 'Error deactivating %s: %s' % (args, pae)
+                return "Error deactivating %s: %s" % (args, pae)
         return self._bot.plugin_manager.blacklist_plugin(args)
 
     @botcmd(admin_only=True)
     def plugin_unblacklist(self, _, args):
         """Remove a plugin from the blacklist"""
         if args not in self._bot.plugin_manager.get_all_plugin_names():
-            return ("{} isn't a valid plugin name. The current plugins are:\n"
-                    "{}".format(args, self.formatted_plugin_list(active_only=False)))
+            return (
+                "{} isn't a valid plugin name. The current plugins are:\n"
+                "{}".format(args, self.formatted_plugin_list(active_only=False))
+            )
 
         if args not in self._bot.plugin_manager.get_all_active_plugin_names():
             try:
                 self._bot.plugin_manager.activate_plugin(args)
             except PluginActivationException as pae:
-                return 'Error activating plugin: %s' % pae
+                return "Error activating plugin: %s" % pae
 
         return self._bot.plugin_manager.unblacklist_plugin(args)

--- a/errbot/core_plugins/textcmds.py
+++ b/errbot/core_plugins/textcmds.py
@@ -1,6 +1,6 @@
 from errbot import BotPlugin, botcmd
 
-INROOM, USER, MULTILINE = 'inroom', 'user', 'multiline'
+INROOM, USER, MULTILINE = "inroom", "user", "multiline"
 
 
 class TextModeCmds(BotPlugin):
@@ -13,7 +13,7 @@ class TextModeCmds(BotPlugin):
     def activate(self):
 
         # This won't activate the plugin in anything else than text mode.
-        if self.mode != 'text':
+        if self.mode != "text":
             return
 
         super().activate()
@@ -48,7 +48,7 @@ class TextModeCmds(BotPlugin):
            This puts you in a room with the bot.
         """
         self._bot._inroom = True
-        return 'Joined Room %s.' % self._bot._rooms[0]
+        return "Joined Room %s." % self._bot._rooms[0]
 
     @botcmd
     def inperson(self, msg, _):
@@ -56,7 +56,7 @@ class TextModeCmds(BotPlugin):
            This puts you in a 1-1 chat with the bot.
         """
         self._bot._inroom = False
-        return 'Now in one-on-one with the bot.'
+        return "Now in one-on-one with the bot."
 
     @botcmd
     def asuser(self, msg, args):
@@ -65,12 +65,12 @@ class TextModeCmds(BotPlugin):
         """
         if args:
             usr = args
-            if usr[0] != '@':
-                usr = '@' + usr
+            if usr[0] != "@":
+                usr = "@" + usr
             self._bot.user = self.build_identifier(usr)
         else:
-            self._bot.user = self.build_identifier('@luser')
-        return 'You are now: %s' % self._bot.user
+            self._bot.user = self.build_identifier("@luser")
+        return "You are now: %s" % self._bot.user
 
     @botcmd
     def asadmin(self, msg, _):
@@ -78,7 +78,7 @@ class TextModeCmds(BotPlugin):
            This puts you in a 1-1 chat with the bot.
         """
         self._bot.user = self.build_identifier(self.bot_config.BOT_ADMINS[0])
-        return 'You are now an admin: %s' % self._bot.user
+        return "You are now an admin: %s" % self._bot.user
 
     @botcmd
     def ml(self, msg, _):
@@ -87,4 +87,4 @@ class TextModeCmds(BotPlugin):
            commands spanning multiple lines. Note: in multiline, press enter twice to end and send the message.
         """
         self._bot._multiline = not self._bot._multiline
-        return 'Multiline mode, press enter twice to end messages' if self._bot._multiline else 'Normal one line mode.'
+        return "Multiline mode, press enter twice to end messages" if self._bot._multiline else "Normal one line mode."

--- a/errbot/core_plugins/utils.py
+++ b/errbot/core_plugins/utils.py
@@ -4,7 +4,7 @@ from errbot import BotPlugin, botcmd
 
 
 def tail(f, window=20):
-    return ''.join(f.readlines()[-window:])
+    return "".join(f.readlines()[-window:])
 
 
 class Utils(BotPlugin):
@@ -32,7 +32,7 @@ class Utils(BotPlugin):
         resp += "| client   | `%s`\n\n" % frm.client
 
         #  extra info if it is a MUC
-        if hasattr(frm, 'room'):
+        if hasattr(frm, "room"):
             resp += "\n`room` is %s\n" % frm.room
         resp += "\n\n- string representation is '%s'\n" % frm
         resp += "- class is '%s'\n" % frm.__class__.__name__
@@ -48,8 +48,8 @@ class Utils(BotPlugin):
         l = len(user_cmd_history)
         for i in range(0, l):
             c = user_cmd_history[i]
-            answer.append('%2i:%s%s %s' % (l - i, self._bot.prefix, c[0], c[1]))
-        return '\n'.join(answer)
+            answer.append("%2i:%s%s %s" % (l - i, self._bot.prefix, c[0], c[1]))
+        return "\n".join(answer)
 
     # noinspection PyUnusedLocal
     @botcmd(admin_only=True)
@@ -63,12 +63,12 @@ class Utils(BotPlugin):
 
         if self.bot_config.BOT_LOG_FILE:
             with open(self.bot_config.BOT_LOG_FILE) as f:
-                return '```\n' + tail(f, n) + '\n```'
-        return 'No log is configured, please define BOT_LOG_FILE in config.py'
+                return "```\n" + tail(f, n) + "\n```"
+        return "No log is configured, please define BOT_LOG_FILE in config.py"
 
     @botcmd
     def render_test(self, _, args):
         """ Tests / showcases the markdown rendering on your current backend
         """
-        with open(path.join(path.dirname(path.realpath(__file__)), 'test.md')) as f:
+        with open(path.join(path.dirname(path.realpath(__file__)), "test.md")) as f:
             return f.read()

--- a/errbot/core_plugins/vcheck.py
+++ b/errbot/core_plugins/vcheck.py
@@ -1,6 +1,6 @@
-from urllib.error import HTTPError, URLError
-import threading
 import sys
+import threading
+from urllib.error import HTTPError, URLError
 
 import requests
 
@@ -8,11 +8,11 @@ from errbot import BotPlugin
 from errbot.utils import version2array
 from errbot.version import VERSION
 
-HOME = 'http://version.errbot.io/'
+HOME = "http://version.errbot.io/"
 
 installed_version = version2array(VERSION)
 
-PY_VERSION = '.'.join(str(e) for e in sys.version_info[:3])
+PY_VERSION = ".".join(str(e) for e in sys.version_info[:3])
 
 
 class VersionChecker(BotPlugin):
@@ -21,13 +21,13 @@ class VersionChecker(BotPlugin):
     activated = False
 
     def activate(self):
-        if self.mode not in ('null', 'test', 'Dummy', 'text'):  # skip in all test confs.
+        if self.mode not in ("null", "test", "Dummy", "text"):  # skip in all test confs.
             self.activated = True
             self.version_check()  # once at startup anyway
             self.start_poller(3600 * 24, self.version_check)  # once every 24H
             super().activate()
         else:
-            self.log.info('Skip version checking under %s mode' % self.mode)
+            self.log.info("Skip version checking under %s mode" % self.mode)
 
     def deactivate(self):
         self.activated = False
@@ -36,24 +36,24 @@ class VersionChecker(BotPlugin):
     def _async_vcheck(self):
         # noinspection PyBroadException
         try:
-            current_version_txt = requests.get(HOME, params={'errbot': VERSION, 'python': PY_VERSION}).text.strip()
+            current_version_txt = requests.get(HOME, params={"errbot": VERSION, "python": PY_VERSION}).text.strip()
             self.log.debug("Tested current Errbot version and it is " + current_version_txt)
             current_version = version2array(current_version_txt)
             if installed_version < current_version:
-                self.log.debug('A new version %s has been found, notify the admins !' % current_version)
+                self.log.debug("A new version %s has been found, notify the admins !" % current_version)
                 self.warn_admins(
-                    'Version {0} of Errbot is available. http://pypi.python.org/pypi/errbot/{0}.'
-                    ' You can disable this check '
-                    'by doing {1}plugin blacklist VersionChecker'.format(current_version_txt, self._bot.prefix)
+                    "Version {0} of Errbot is available. http://pypi.python.org/pypi/errbot/{0}."
+                    " You can disable this check "
+                    "by doing {1}plugin blacklist VersionChecker".format(current_version_txt, self._bot.prefix)
                 )
         except (HTTPError, URLError):
-            self.log.info('Could not establish connection to retrieve latest version.')
+            self.log.info("Could not establish connection to retrieve latest version.")
 
     def version_check(self):
         if not self.activated:
-            self.log.debug('Version check disabled')
+            self.log.debug("Version check disabled")
             return
-        self.log.debug('Checking version in background.')
+        self.log.debug("Checking version in background.")
         threading.Thread(target=self._async_vcheck).start()
 
     def callback_connect(self):

--- a/errbot/logs.py
+++ b/errbot/logs.py
@@ -11,8 +11,8 @@ def ispydevd():
 
 
 root_logger = logging.getLogger()
-logging.getLogger('yapsy').setLevel(logging.INFO)  # this one is way too verbose in debug
-logging.getLogger('Rocket.Errors.ThreadPool').setLevel(logging.INFO)  # this one is way too verbose in debug
+logging.getLogger("yapsy").setLevel(logging.INFO)  # this one is way too verbose in debug
+logging.getLogger("Rocket.Errors.ThreadPool").setLevel(logging.INFO)  # this one is way too verbose in debug
 root_logger.setLevel(logging.INFO)
 
 pydev = ispydevd()
@@ -23,31 +23,19 @@ console_hdlr = logging.StreamHandler(stream)
 
 def get_log_colors(theme_color=None):
     """Return a tuple containing the log format string and a log color dict"""
-    if theme_color == 'light':
-        text_color_theme = 'white'
-    elif theme_color == 'dark':
-        text_color_theme = 'black'
+    if theme_color == "light":
+        text_color_theme = "white"
+    elif theme_color == "dark":
+        text_color_theme = "black"
     else:  # Anything else produces nocolor
         return (
             "%(name)-25.25s%(reset)s %(message)s%(reset)s",
-            {
-                'DEBUG': '',
-                'INFO': '',
-                'WARNING': '',
-                'ERROR': '',
-                'CRITICAL': '',
-            },
+            {"DEBUG": "", "INFO": "", "WARNING": "", "ERROR": "", "CRITICAL": ""},
         )
 
     return (
         "%(name)-25.25s%(reset)s %({})s%(message)s%(reset)s".format(text_color_theme),
-        {
-            'DEBUG': 'cyan',
-            'INFO': 'green',
-            'WARNING': 'yellow',
-            'ERROR': 'red',
-            'CRITICAL': 'red',
-        }
+        {"DEBUG": "cyan", "INFO": "green", "WARNING": "yellow", "ERROR": "red", "CRITICAL": "red"},
     )
 
 
@@ -62,10 +50,10 @@ def format_logs(formatter=None, theme_color=None):
     # if isatty and not True:
     elif isatty:
         from colorlog import ColoredFormatter  # noqa
+
         log_format, colors_dict = get_log_colors(theme_color)
         color_formatter = ColoredFormatter(
-            "%(asctime)s %(log_color)s%(levelname)-8s%(reset)s " +
-            log_format,
+            "%(asctime)s %(log_color)s%(levelname)-8s%(reset)s " + log_format,
             datefmt="%H:%M:%S",
             reset=True,
             log_colors=colors_dict,

--- a/errbot/plugin_wizard.py
+++ b/errbot/plugin_wizard.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 
 import errno
-import jinja2
 import os
 import re
 import sys
 from configparser import ConfigParser
+
+import jinja2
 
 from errbot.version import VERSION
 
@@ -24,17 +25,12 @@ def new_plugin_wizard(directory=None):
         print("Error: The path '%s' exists but it isn't a directory" % directory)
         sys.exit(1)
 
-    name = ask(
-        "What should the name of your new plugin be?",
-        validation_regex=r'^[a-zA-Z][a-zA-Z0-9 _-]*$'
-    ).strip()
-    module_name = name.lower().replace(' ', '_')
-    directory_name = name.lower().replace(' ', '-')
-    class_name = "".join([s.capitalize() for s in name.lower().split(' ')])
+    name = ask("What should the name of your new plugin be?", validation_regex=r"^[a-zA-Z][a-zA-Z0-9 _-]*$").strip()
+    module_name = name.lower().replace(" ", "_")
+    directory_name = name.lower().replace(" ", "-")
+    class_name = "".join([s.capitalize() for s in name.lower().split(" ")])
 
-    description = ask(
-        "What may I use as a short (one-line) description of your plugin?"
-    )
+    description = ask("What may I use as a short (one-line) description of your plugin?")
     python_version = "3"
     errbot_min_version = ask(
         "Which minimum version of errbot will your plugin work with? "
@@ -52,16 +48,9 @@ def new_plugin_wizard(directory=None):
         errbot_max_version = VERSION
 
     plug = ConfigParser()
-    plug["Core"] = {
-        "Name": name,
-        "Module": module_name,
-    }
-    plug["Documentation"] = {
-        "Description": description,
-    }
-    plug["Python"] = {
-        "Version": python_version,
-    }
+    plug["Core"] = {"Name": name, "Module": module_name}
+    plug["Documentation"] = {"Description": description}
+    plug["Python"] = {"Version": python_version}
 
     if errbot_max_version != "" or errbot_min_version != "":
         plug["Errbot"] = {}
@@ -85,16 +74,14 @@ def new_plugin_wizard(directory=None):
             "Warning: A plugin with this name was already found at {path}\n"
             "If you continue, these will be overwritten.\n"
             "Press Ctrl+C to abort now or type in 'overwrite' to confirm overwriting of these files."
-            "".format(
-                path=os.path.join(directory, module_name + ".{py,plug}")
-            ),
+            "".format(path=os.path.join(directory, module_name + ".{py,plug}")),
             valid_responses=["overwrite"],
         )
 
-    with open(plugfile_path, 'w') as f:
+    with open(plugfile_path, "w") as f:
         plug.write(f)
 
-    with open(pyfile_path, 'w') as f:
+    with open(pyfile_path, "w") as f:
         f.write(render_plugin(locals()))
 
     print("Success! You'll find your new plugin at '%s'" % plugfile_path)
@@ -132,10 +119,10 @@ def render_plugin(values):
     Render the Jinja template for the plugin with the given values.
     """
     env = jinja2.Environment(
-        loader=jinja2.FileSystemLoader(os.path.join(os.path.dirname(__file__), 'templates')),
+        loader=jinja2.FileSystemLoader(os.path.join(os.path.dirname(__file__), "templates")),
         auto_reload=False,
         keep_trailing_newline=True,
-        autoescape=True
+        autoescape=True,
     )
     template = env.get_template("new_plugin.py.tmpl")
     return template.render(**values)

--- a/errbot/rendering/__init__.py
+++ b/errbot/rendering/__init__.py
@@ -5,9 +5,10 @@ from markdown import Markdown
 from markdown.extensions.extra import ExtraExtension
 
 # Attribute regexp looks for extendend syntax: {: ... }
-ATTR_RE = re.compile(r'{:([^}]*)}')
-MD_ESCAPE_RE = re.compile('|'.join(re.escape(c) for c in ('\\', '`', '*', '_', '{', '}', '[', ']',
-                                                          '(', ')', '>', '#', '+', '-', '.', '!')))
+ATTR_RE = re.compile(r"{:([^}]*)}")
+MD_ESCAPE_RE = re.compile(
+    "|".join(re.escape(c) for c in ("\\", "`", "*", "_", "{", "}", "[", "]", "(", ")", ">", "#", "+", "-", ".", "!"))
+)
 
 # Here are few helpers to simplify the conversion from markdown to various
 # backend formats.
@@ -22,7 +23,8 @@ def ansi():
     ansi_txt = md_converter.convert(md_txt)
     """
     from .ansiext import AnsiExtension
-    md = Markdown(output_format='ansi', extensions=[ExtraExtension(), AnsiExtension()])
+
+    md = Markdown(output_format="ansi", extensions=[ExtraExtension(), AnsiExtension()])
     md.stripTopLevelTags = False
     return md
 
@@ -36,7 +38,8 @@ def text():
     pure_text = md_converter.convert(md_txt)
     """
     from .ansiext import AnsiExtension
-    md = Markdown(output_format='text', extensions=[ExtraExtension(), AnsiExtension()])
+
+    md = Markdown(output_format="text", extensions=[ExtraExtension(), AnsiExtension()])
     md.stripTopLevelTags = False
     return md
 
@@ -52,12 +55,14 @@ def imtext():
     im_text = md_converter.convert(md_txt)
     """
     from .ansiext import AnsiExtension
-    md = Markdown(output_format='imtext', extensions=[ExtraExtension(), AnsiExtension()])
+
+    md = Markdown(output_format="imtext", extensions=[ExtraExtension(), AnsiExtension()])
     md.stripTopLevelTags = False
     return md
 
 
 class Mde2mdConverter(object):
+
     def convert(self, mde):
         while True:
             m = ATTR_RE.search(mde)
@@ -82,11 +87,11 @@ def xhtml():
 
     html = md_converter.convert(md_txt)
     """
-    return Markdown(output_format='xhtml', extensions=[ExtraExtension()])
+    return Markdown(output_format="xhtml", extensions=[ExtraExtension()])
 
 
 def md_escape(txt):
     """ Call this if you want to be sure your text won't be interpreted as markdown
     :param txt: bare text to escape.
     """
-    return MD_ESCAPE_RE.sub(lambda match: '\\' + match.group(0), txt)
+    return MD_ESCAPE_RE.sub(lambda match: "\\" + match.group(0), txt)

--- a/errbot/rendering/ansiext.py
+++ b/errbot/rendering/ansiext.py
@@ -2,19 +2,18 @@
 # -*- coding: utf-8 -*-
 # vim: ts=4:sw=4
 
-from itertools import chain
-from collections import namedtuple
-from functools import partial
 import io
 import logging
+from collections import namedtuple
+from functools import partial
+from itertools import chain
 
+from ansi.color import bg, fg, fx
 from markdown import Markdown
 from markdown.extensions import Extension
-from markdown.postprocessors import Postprocessor
-from markdown.inlinepatterns import SubstituteTagPattern
 from markdown.extensions.fenced_code import FencedBlockPreprocessor
-
-from ansi.color import fg, bg, fx
+from markdown.inlinepatterns import SubstituteTagPattern
+from markdown.postprocessors import Postprocessor
 
 log = logging.getLogger(__name__)
 
@@ -22,11 +21,13 @@ try:
     from html import unescape  # py3.5
 except ImportError:
     from html.parser import HTMLParser  # py3.4
+
     unescape = HTMLParser().unescape
 
 
 # chr that should not count as a space
 class NSC(object):
+
     def __init__(self, s):
         self.s = s
 
@@ -35,131 +36,140 @@ class NSC(object):
 
 
 # The translation table for the special characters.
-CharacterTable = namedtuple('CharacterTable',
-                            ['fg_black',
-                             'fg_red',
-                             'fg_green',
-                             'fg_yellow',
-                             'fg_blue',
-                             'fg_magenta',
-                             'fg_cyan',
-                             'fg_white',
-                             'fg_default',
-                             'bg_black',
-                             'bg_red',
-                             'bg_green',
-                             'bg_yellow',
-                             'bg_blue',
-                             'bg_magenta',
-                             'bg_cyan',
-                             'bg_white',
-                             'bg_default',
-                             'fx_reset',
-                             'fx_bold',
-                             'fx_italic',
-                             'fx_underline',
-                             'fx_not_italic',
-                             'fx_not_underline',
-                             'fx_normal',
-                             'fixed_width',
-                             'end_fixed_width',
-                             'inline_code',
-                             'end_inline_code',
-                             ])
+CharacterTable = namedtuple(
+    "CharacterTable",
+    [
+        "fg_black",
+        "fg_red",
+        "fg_green",
+        "fg_yellow",
+        "fg_blue",
+        "fg_magenta",
+        "fg_cyan",
+        "fg_white",
+        "fg_default",
+        "bg_black",
+        "bg_red",
+        "bg_green",
+        "bg_yellow",
+        "bg_blue",
+        "bg_magenta",
+        "bg_cyan",
+        "bg_white",
+        "bg_default",
+        "fx_reset",
+        "fx_bold",
+        "fx_italic",
+        "fx_underline",
+        "fx_not_italic",
+        "fx_not_underline",
+        "fx_normal",
+        "fixed_width",
+        "end_fixed_width",
+        "inline_code",
+        "end_inline_code",
+    ],
+)
 
-ANSI_CHRS = CharacterTable(fg_black=fg.black,
-                           fg_red=fg.red,
-                           fg_green=fg.green,
-                           fg_yellow=fg.yellow,
-                           fg_blue=fg.blue,
-                           fg_magenta=fg.magenta,
-                           fg_cyan=fg.cyan,
-                           fg_white=fg.white,
-                           fg_default=fg.default,
-                           bg_black=bg.black,
-                           bg_red=bg.red,
-                           bg_green=bg.green,
-                           bg_yellow=bg.yellow,
-                           bg_blue=bg.blue,
-                           bg_magenta=bg.magenta,
-                           bg_cyan=bg.cyan,
-                           bg_white=bg.white,
-                           bg_default=bg.default,
-                           fx_reset=fx.reset,
-                           fx_bold=fx.bold,
-                           fx_italic=fx.italic,
-                           fx_underline=fx.underline,
-                           fx_not_italic=fx.not_italic,
-                           fx_not_underline=fx.not_underline,
-                           fx_normal=fx.normal,
-                           fixed_width='',
-                           end_fixed_width='',
-                           inline_code='',
-                           end_inline_code='')
+ANSI_CHRS = CharacterTable(
+    fg_black=fg.black,
+    fg_red=fg.red,
+    fg_green=fg.green,
+    fg_yellow=fg.yellow,
+    fg_blue=fg.blue,
+    fg_magenta=fg.magenta,
+    fg_cyan=fg.cyan,
+    fg_white=fg.white,
+    fg_default=fg.default,
+    bg_black=bg.black,
+    bg_red=bg.red,
+    bg_green=bg.green,
+    bg_yellow=bg.yellow,
+    bg_blue=bg.blue,
+    bg_magenta=bg.magenta,
+    bg_cyan=bg.cyan,
+    bg_white=bg.white,
+    bg_default=bg.default,
+    fx_reset=fx.reset,
+    fx_bold=fx.bold,
+    fx_italic=fx.italic,
+    fx_underline=fx.underline,
+    fx_not_italic=fx.not_italic,
+    fx_not_underline=fx.not_underline,
+    fx_normal=fx.normal,
+    fixed_width="",
+    end_fixed_width="",
+    inline_code="",
+    end_inline_code="",
+)
 
 
 # Pure Text doesn't have any graphical chrs.
-TEXT_CHRS = CharacterTable(fg_black='',
-                           fg_red='',
-                           fg_green='',
-                           fg_yellow='',
-                           fg_blue='',
-                           fg_magenta='',
-                           fg_cyan='',
-                           fg_white='',
-                           fg_default='',
-                           bg_black='',
-                           bg_red='',
-                           bg_green='',
-                           bg_yellow='',
-                           bg_blue='',
-                           bg_magenta='',
-                           bg_cyan='',
-                           bg_white='',
-                           bg_default='',
-                           fx_reset='',
-                           fx_bold='',
-                           fx_italic='',
-                           fx_underline='',
-                           fx_not_italic='',
-                           fx_not_underline='',
-                           fx_normal='',
-                           fixed_width='',
-                           end_fixed_width='',
-                           inline_code='',
-                           end_inline_code='')
+TEXT_CHRS = CharacterTable(
+    fg_black="",
+    fg_red="",
+    fg_green="",
+    fg_yellow="",
+    fg_blue="",
+    fg_magenta="",
+    fg_cyan="",
+    fg_white="",
+    fg_default="",
+    bg_black="",
+    bg_red="",
+    bg_green="",
+    bg_yellow="",
+    bg_blue="",
+    bg_magenta="",
+    bg_cyan="",
+    bg_white="",
+    bg_default="",
+    fx_reset="",
+    fx_bold="",
+    fx_italic="",
+    fx_underline="",
+    fx_not_italic="",
+    fx_not_underline="",
+    fx_normal="",
+    fixed_width="",
+    end_fixed_width="",
+    inline_code="",
+    end_inline_code="",
+)
 
 
 # IMText have some formatting available
-IMTEXT_CHRS = CharacterTable(fg_black='',
-                             fg_red='',
-                             fg_green='',
-                             fg_yellow='',
-                             fg_blue='',
-                             fg_magenta='',
-                             fg_cyan='',
-                             fg_white='',
-                             fg_default='',
-                             bg_black='',
-                             bg_red='',
-                             bg_green='',
-                             bg_yellow='',
-                             bg_blue='',
-                             bg_magenta='',
-                             bg_cyan='',
-                             bg_white='',
-                             bg_default='',
-                             fx_reset='',
-                             fx_bold=NSC('*'),
-                             fx_italic='',
-                             fx_underline=NSC('_'),
-                             fx_not_italic='',
-                             fx_not_underline=NSC('_'),
-                             fx_normal=NSC('*'),
-                             fixed_width='```\n',
-                             end_fixed_width='```\n',
-                             inline_code='`',
-                             end_inline_code='`')
+IMTEXT_CHRS = CharacterTable(
+    fg_black="",
+    fg_red="",
+    fg_green="",
+    fg_yellow="",
+    fg_blue="",
+    fg_magenta="",
+    fg_cyan="",
+    fg_white="",
+    fg_default="",
+    bg_black="",
+    bg_red="",
+    bg_green="",
+    bg_yellow="",
+    bg_blue="",
+    bg_magenta="",
+    bg_cyan="",
+    bg_white="",
+    bg_default="",
+    fx_reset="",
+    fx_bold=NSC("*"),
+    fx_italic="",
+    fx_underline=NSC("_"),
+    fx_not_italic="",
+    fx_not_underline=NSC("_"),
+    fx_normal=NSC("*"),
+    fixed_width="```\n",
+    end_fixed_width="```\n",
+    inline_code="`",
+    end_inline_code="`",
+)
 
 
 NEXT_ROW = "&NEXT_ROW;"
@@ -183,13 +193,13 @@ class Table(object):
         if not self.rows:
             self.rows = [[]]
         else:
-            self.rows[-1].append(('', 0))
+            self.rows[-1].append(("", 0))
 
     def add_header(self):
         if not self.headers:
             self.headers = [[]]
         else:
-            self.headers[-1].append(('', 0))
+            self.headers[-1].append(("", 0))
 
     def begin_headers(self):
         self.in_headers = True
@@ -210,7 +220,7 @@ class Table(object):
 
     def __str__(self):
         nbcols = max(len(row) for row in chain(self.headers, self.rows))
-        maxes = [0, ] * nbcols
+        maxes = [0] * nbcols
 
         for row in chain(self.headers, self.rows):
             for i, el in enumerate(row):
@@ -227,24 +237,24 @@ class Table(object):
 
         output = io.StringIO()
         if self.headers:
-            output.write('┏' + '┳'.join('━' * m for m in maxes) + '┓')
-            output.write('\n')
+            output.write("┏" + "┳".join("━" * m for m in maxes) + "┓")
+            output.write("\n")
             first = True
             for row in self.headers:
                 if not first:
-                    output.write('┣' + '╋'.join('━' * m for m in maxes) + '┫')
-                    output.write('\n')
+                    output.write("┣" + "╋".join("━" * m for m in maxes) + "┫")
+                    output.write("\n")
                 first = False
                 for i, header in enumerate(row):
                     text, l = header
-                    output.write('┃ ' + text + ' ' * (maxes[i] - 2 - l) + ' ')
-                output.write('┃')
-                output.write('\n')
-            output.write('┡' + '╇'.join('━' * m for m in maxes) + '┩')
-            output.write('\n')
+                    output.write("┃ " + text + " " * (maxes[i] - 2 - l) + " ")
+                output.write("┃")
+                output.write("\n")
+            output.write("┡" + "╇".join("━" * m for m in maxes) + "┩")
+            output.write("\n")
         else:
-            output.write('┌' + '┬'.join('─' * m for m in maxes) + '┐')
-            output.write('\n')
+            output.write("┌" + "┬".join("─" * m for m in maxes) + "┐")
+            output.write("\n")
         first = True
         for row in self.rows:
             max_row_height = 1
@@ -254,8 +264,8 @@ class Table(object):
                 if row_height > max_row_height:
                     max_row_height = row_height
             if not first:
-                output.write('├' + '┼'.join('─' * m for m in maxes) + '┤')
-                output.write('\n')
+                output.write("├" + "┼".join("─" * m for m in maxes) + "┤")
+                output.write("\n")
             first = False
             for j in range(max_row_height):
                 for i, item in enumerate(row):
@@ -266,12 +276,12 @@ class Table(object):
                         l = len(text)
                     else:
                         l = 1
-                        text = ' '
-                    output.write('│ ' + text + ' ' * (maxes[i] - 2 - l) + ' ')
-                output.write('│')
-                output.write('\n')
-        output.write('└' + '┴'.join('─' * m for m in maxes) + '┘')
-        output.write('\n')
+                        text = " "
+                    output.write("│ " + text + " " * (maxes[i] - 2 - l) + " ")
+                output.write("│")
+                output.write("\n")
+        output.write("└" + "┴".join("─" * m for m in maxes) + "┘")
+        output.write("\n")
         return str(self.ct.fixed_width) + output.getvalue() + str(self.ct.end_fixed_width)
 
 
@@ -293,13 +303,13 @@ class BorderlessTable(object):
         if not self.rows:
             self.rows = [[]]
         else:
-            self.rows[-1].append(('', 0))
+            self.rows[-1].append(("", 0))
 
     def add_header(self):
         if not self.headers:
             self.headers = [[]]
         else:
-            self.headers[-1].append(('', 0))
+            self.headers[-1].append(("", 0))
 
     def begin_headers(self):
         self.in_headers = True
@@ -320,7 +330,7 @@ class BorderlessTable(object):
 
     def __str__(self):
         nbcols = max(len(row) for row in chain(self.headers, self.rows))
-        maxes = [0, ] * nbcols
+        maxes = [0] * nbcols
 
         for row in chain(self.headers, self.rows):
             for i, el in enumerate(row):
@@ -340,8 +350,8 @@ class BorderlessTable(object):
             for row in self.headers:
                 for i, header in enumerate(row):
                     text, l = header
-                    output.write(text + ' ' * (maxes[i] - 2 - l) + ' ')
-                output.write('\n')
+                    output.write(text + " " * (maxes[i] - 2 - l) + " ")
+                output.write("\n")
         for row in self.rows:
             max_row_height = 1
             for i, item in enumerate(row):
@@ -358,9 +368,9 @@ class BorderlessTable(object):
                         l = len(text)
                     else:
                         l = 1
-                        text = ' '
-                    output.write(text + ' ' * (maxes[i] - 2 - l) + ' ')
-                output.write('\n')
+                        text = " "
+                    output.write(text + " " * (maxes[i] - 2 - l) + " ")
+                output.write("\n")
         return str(self.ct.fixed_width) + output.getvalue() + str(self.ct.end_fixed_width)
 
 
@@ -369,103 +379,103 @@ def recurse(write, chr_table, element, table=None, borders=True):
     if element.text:
         text = element.text
     else:
-        text = ''
+        text = ""
     items = element.items()
     for k, v in items:
-        if k == 'color':
-            color_attr = getattr(chr_table, 'fg_' + v, None)
+        if k == "color":
+            color_attr = getattr(chr_table, "fg_" + v, None)
             if color_attr is None:
                 log.warning("there is no '%s' color in ansi" % v)
                 continue
             write(color_attr)
             post_element.append(chr_table.fg_default)
-        elif k == 'bgcolor':
-            color_attr = getattr(chr_table, 'bg_' + v, None)
+        elif k == "bgcolor":
+            color_attr = getattr(chr_table, "bg_" + v, None)
             if color_attr is None:
                 log.warning("there is no '%s' bgcolor in ansi" % v)
                 continue
             write(color_attr)
             post_element.append(chr_table.bg_default)
-    if element.tag == 'img':
-        text = dict(items)['src']
-    elif element.tag == 'strong':
+    if element.tag == "img":
+        text = dict(items)["src"]
+    elif element.tag == "strong":
         write(chr_table.fx_bold)
         post_element.append(chr_table.fx_normal)
-    elif element.tag == 'code':
+    elif element.tag == "code":
         write(chr_table.inline_code)
         post_element.append(chr_table.end_inline_code)
-    elif element.tag == 'em':
+    elif element.tag == "em":
         write(chr_table.fx_underline)
         post_element.append(chr_table.fx_not_underline)
-    elif element.tag == 'p':
-        write(' ')
-        post_element.append('\n')
-    elif element.tag == 'br' and table:  # Treat <br/> differently in a table.
+    elif element.tag == "p":
+        write(" ")
+        post_element.append("\n")
+    elif element.tag == "br" and table:  # Treat <br/> differently in a table.
         write(NEXT_ROW)
-    elif element.tag == 'a':
-        post_element.append(' (' + element.get('href') + ')')
-    elif element.tag == 'li':
-        write('• ')
-        post_element.append('\n')
-    elif element.tag == 'hr':
-        write('─' * 80)
-        write('\n')
-    elif element.tag == 'ul':  # ignore the text part
+    elif element.tag == "a":
+        post_element.append(" (" + element.get("href") + ")")
+    elif element.tag == "li":
+        write("• ")
+        post_element.append("\n")
+    elif element.tag == "hr":
+        write("─" * 80)
+        write("\n")
+    elif element.tag == "ul":  # ignore the text part
         text = None
-    elif element.tag == 'h1':
+    elif element.tag == "h1":
         write(chr_table.fx_bold)
         text = text.upper()
         post_element.append(chr_table.fx_normal)
-        post_element.append('\n\n')
-    elif element.tag == 'h2':
-        write('\n')
-        write('  ')
+        post_element.append("\n\n")
+    elif element.tag == "h2":
+        write("\n")
+        write("  ")
         write(chr_table.fx_bold)
         post_element.append(chr_table.fx_normal)
-        post_element.append('\n\n')
-    elif element.tag == 'h3':
-        write('\n')
-        write('    ')
+        post_element.append("\n\n")
+    elif element.tag == "h3":
+        write("\n")
+        write("    ")
         write(chr_table.fx_underline)
         post_element.append(chr_table.fx_not_underline)
-        post_element.append('\n\n')
-    elif element.tag in ('h4', 'h5', 'h6'):
-        write('\n')
-        write('      ')
-        post_element.append('\n')
-    elif element.tag == 'table':
+        post_element.append("\n\n")
+    elif element.tag in ("h4", "h5", "h6"):
+        write("\n")
+        write("      ")
+        post_element.append("\n")
+    elif element.tag == "table":
         table = Table(chr_table) if borders else BorderlessTable(chr_table)
         orig_write = write
         write = table.write
         text = None
-    elif element.tag == 'tbody':
+    elif element.tag == "tbody":
         text = None
-    elif element.tag == 'thead':
+    elif element.tag == "thead":
         table.begin_headers()
         text = None
-    elif element.tag == 'tr':
+    elif element.tag == "tr":
         table.next_row()
         text = None
-    elif element.tag == 'td':
+    elif element.tag == "td":
         table.add_col()
-    elif element.tag == 'th':
+    elif element.tag == "th":
         table.add_header()
 
     if text:
         write(text)
     for e in element:
         recurse(write, chr_table, e, table, borders)
-    if element.tag == 'table':
+    if element.tag == "table":
         write = orig_write
         write(str(table))
 
-    if element.tag == 'thead':
+    if element.tag == "thead":
         table.end_headers()
 
     for restore in post_element:
         write(restore)
     if element.tail:
-        tail = element.tail.rstrip('\n')
+        tail = element.tail.rstrip("\n")
         if tail:
             write(tail)
 
@@ -475,8 +485,9 @@ def translate(element, chr_table=ANSI_CHRS, borders=True):
 
     def write(ansi_obj):
         return f.write(str(ansi_obj))
+
     recurse(write, chr_table, element, borders=borders)
-    result = f.getvalue().rstrip('\n')  # remove the useless final \n
+    result = f.getvalue().rstrip("\n")  # remove the useless final \n
     return result + str(chr_table.fx_reset)
 
 
@@ -485,7 +496,7 @@ def enable_format(name, chr_table, borders=True):
     Markdown.output_formats[name] = partial(translate, chr_table=chr_table, borders=borders)
 
 
-for n, ct in (('ansi', ANSI_CHRS), ('text', TEXT_CHRS), ('imtext', IMTEXT_CHRS)):
+for n, ct in (("ansi", ANSI_CHRS), ("text", TEXT_CHRS), ("imtext", IMTEXT_CHRS)):
     enable_format(n, ct)
 
 
@@ -498,28 +509,27 @@ class AnsiPostprocessor(Postprocessor):
 
 # This is an adapted FencedBlockPreprocessor that doesn't insert <code><pre>
 class AnsiPreprocessor(FencedBlockPreprocessor):
+
     def run(self, lines):
         """ Match and store Fenced Code Blocks in the HtmlStash. """
         text = "\n".join(lines)
         while 1:
             m = self.FENCED_BLOCK_RE.search(text)
             if m:
-                code = self._escape(m.group('code'))
+                code = self._escape(m.group("code"))
 
                 placeholder = self.markdown.htmlStash.store(code, safe=False)
-                text = '%s\n%s\n%s' % (text[:m.start()],
-                                       placeholder,
-                                       text[m.end():])
+                text = "%s\n%s\n%s" % (text[:m.start()], placeholder, text[m.end():])
             else:
                 break
         return text.split("\n")
 
     def _escape(self, txt):
         """ basic html escaping """
-        txt = txt.replace('&', '&amp;')
-        txt = txt.replace('<', '&lt;')
-        txt = txt.replace('>', '&gt;')
-        txt = txt.replace('"', '&quot;')
+        txt = txt.replace("&", "&amp;")
+        txt = txt.replace("<", "&lt;")
+        txt = txt.replace(">", "&gt;")
+        txt = txt.replace('"', "&quot;")
         return txt
 
 
@@ -528,15 +538,13 @@ class AnsiExtension(Extension):
 
     def extendMarkdown(self, md, md_globals):
         md.registerExtension(self)
-        md.postprocessors.add(
-            "unescape_html", AnsiPostprocessor(), ">unescape"
-        )
-        md.preprocessors.add(
-            "ansi_fenced_codeblock", AnsiPreprocessor(md), "<fenced_code_block"
-        )
+        md.postprocessors.add("unescape_html", AnsiPostprocessor(), ">unescape")
+        md.preprocessors.add("ansi_fenced_codeblock", AnsiPreprocessor(md), "<fenced_code_block")
         md.inlinePatterns.add(
             # Leave <br/> tags as is for proper table multiline cell processing
-            "br", SubstituteTagPattern(r'<br/>', "br"), "<html"
+            "br",
+            SubstituteTagPattern(r"<br/>", "br"),
+            "<html",
         )
-        del(md.preprocessors['fenced_code_block'])  # remove the old fenced block
-        del(md.treeprocessors['prettify'])  # remove prettify treeprocessor since it adds extra new lines
+        del (md.preprocessors["fenced_code_block"])  # remove the old fenced block
+        del (md.treeprocessors["prettify"])  # remove prettify treeprocessor since it adds extra new lines

--- a/errbot/rendering/xhtmlim.py
+++ b/errbot/rendering/xhtmlim.py
@@ -1,85 +1,196 @@
-from html.entities import entitydefs
 import re
+from html.entities import entitydefs
 
 # Helpers for xhtml-im
 
-SAFE_ENTITIES = {e: entitydefs[e] for e in entitydefs if e not in ('amp', 'quot', 'apos', 'gt', 'lt')}
+SAFE_ENTITIES = {e: entitydefs[e] for e in entitydefs if e not in ("amp", "quot", "apos", "gt", "lt")}
 
 _invalid_codepoints = {
     # 0x0001 to 0x0008
-    0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8,
+    0x1,
+    0x2,
+    0x3,
+    0x4,
+    0x5,
+    0x6,
+    0x7,
+    0x8,
     # 0x000E to 0x001F
-    0xe, 0xf, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19,
-    0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+    0xe,
+    0xf,
+    0x10,
+    0x11,
+    0x12,
+    0x13,
+    0x14,
+    0x15,
+    0x16,
+    0x17,
+    0x18,
+    0x19,
+    0x1a,
+    0x1b,
+    0x1c,
+    0x1d,
+    0x1e,
+    0x1f,
     # 0x007F to 0x009F
-    0x7f, 0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x8a,
-    0x8b, 0x8c, 0x8d, 0x8e, 0x8f, 0x90, 0x91, 0x92, 0x93, 0x94, 0x95, 0x96,
-    0x97, 0x98, 0x99, 0x9a, 0x9b, 0x9c, 0x9d, 0x9e, 0x9f,
+    0x7f,
+    0x80,
+    0x81,
+    0x82,
+    0x83,
+    0x84,
+    0x85,
+    0x86,
+    0x87,
+    0x88,
+    0x89,
+    0x8a,
+    0x8b,
+    0x8c,
+    0x8d,
+    0x8e,
+    0x8f,
+    0x90,
+    0x91,
+    0x92,
+    0x93,
+    0x94,
+    0x95,
+    0x96,
+    0x97,
+    0x98,
+    0x99,
+    0x9a,
+    0x9b,
+    0x9c,
+    0x9d,
+    0x9e,
+    0x9f,
     # 0xFDD0 to 0xFDEF
-    0xfdd0, 0xfdd1, 0xfdd2, 0xfdd3, 0xfdd4, 0xfdd5, 0xfdd6, 0xfdd7, 0xfdd8,
-    0xfdd9, 0xfdda, 0xfddb, 0xfddc, 0xfddd, 0xfdde, 0xfddf, 0xfde0, 0xfde1,
-    0xfde2, 0xfde3, 0xfde4, 0xfde5, 0xfde6, 0xfde7, 0xfde8, 0xfde9, 0xfdea,
-    0xfdeb, 0xfdec, 0xfded, 0xfdee, 0xfdef,
+    0xfdd0,
+    0xfdd1,
+    0xfdd2,
+    0xfdd3,
+    0xfdd4,
+    0xfdd5,
+    0xfdd6,
+    0xfdd7,
+    0xfdd8,
+    0xfdd9,
+    0xfdda,
+    0xfddb,
+    0xfddc,
+    0xfddd,
+    0xfdde,
+    0xfddf,
+    0xfde0,
+    0xfde1,
+    0xfde2,
+    0xfde3,
+    0xfde4,
+    0xfde5,
+    0xfde6,
+    0xfde7,
+    0xfde8,
+    0xfde9,
+    0xfdea,
+    0xfdeb,
+    0xfdec,
+    0xfded,
+    0xfdee,
+    0xfdef,
     # others
-    0xb, 0xfffe, 0xffff, 0x1fffe, 0x1ffff, 0x2fffe, 0x2ffff, 0x3fffe, 0x3ffff,
-    0x4fffe, 0x4ffff, 0x5fffe, 0x5ffff, 0x6fffe, 0x6ffff, 0x7fffe, 0x7ffff,
-    0x8fffe, 0x8ffff, 0x9fffe, 0x9ffff, 0xafffe, 0xaffff, 0xbfffe, 0xbffff,
-    0xcfffe, 0xcffff, 0xdfffe, 0xdffff, 0xefffe, 0xeffff, 0xffffe, 0xfffff,
-    0x10fffe, 0x10ffff
+    0xb,
+    0xfffe,
+    0xffff,
+    0x1fffe,
+    0x1ffff,
+    0x2fffe,
+    0x2ffff,
+    0x3fffe,
+    0x3ffff,
+    0x4fffe,
+    0x4ffff,
+    0x5fffe,
+    0x5ffff,
+    0x6fffe,
+    0x6ffff,
+    0x7fffe,
+    0x7ffff,
+    0x8fffe,
+    0x8ffff,
+    0x9fffe,
+    0x9ffff,
+    0xafffe,
+    0xaffff,
+    0xbfffe,
+    0xbffff,
+    0xcfffe,
+    0xcffff,
+    0xdfffe,
+    0xdffff,
+    0xefffe,
+    0xeffff,
+    0xffffe,
+    0xfffff,
+    0x10fffe,
+    0x10ffff,
 }
 
 _invalid_charrefs = {
-    0x00: '\ufffd',  # REPLACEMENT CHARACTER
-    0x0d: '\r',      # CARRIAGE RETURN
-    0x80: '\u20ac',  # EURO SIGN
-    0x81: '\x81',    # <control>
-    0x82: '\u201a',  # SINGLE LOW-9 QUOTATION MARK
-    0x83: '\u0192',  # LATIN SMALL LETTER F WITH HOOK
-    0x84: '\u201e',  # DOUBLE LOW-9 QUOTATION MARK
-    0x85: '\u2026',  # HORIZONTAL ELLIPSIS
-    0x86: '\u2020',  # DAGGER
-    0x87: '\u2021',  # DOUBLE DAGGER
-    0x88: '\u02c6',  # MODIFIER LETTER CIRCUMFLEX ACCENT
-    0x89: '\u2030',  # PER MILLE SIGN
-    0x8a: '\u0160',  # LATIN CAPITAL LETTER S WITH CARON
-    0x8b: '\u2039',  # SINGLE LEFT-POINTING ANGLE QUOTATION MARK
-    0x8c: '\u0152',  # LATIN CAPITAL LIGATURE OE
-    0x8d: '\x8d',    # <control>
-    0x8e: '\u017d',  # LATIN CAPITAL LETTER Z WITH CARON
-    0x8f: '\x8f',    # <control>
-    0x90: '\x90',    # <control>
-    0x91: '\u2018',  # LEFT SINGLE QUOTATION MARK
-    0x92: '\u2019',  # RIGHT SINGLE QUOTATION MARK
-    0x93: '\u201c',  # LEFT DOUBLE QUOTATION MARK
-    0x94: '\u201d',  # RIGHT DOUBLE QUOTATION MARK
-    0x95: '\u2022',  # BULLET
-    0x96: '\u2013',  # EN DASH
-    0x97: '\u2014',  # EM DASH
-    0x98: '\u02dc',  # SMALL TILDE
-    0x99: '\u2122',  # TRADE MARK SIGN
-    0x9a: '\u0161',  # LATIN SMALL LETTER S WITH CARON
-    0x9b: '\u203a',  # SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
-    0x9c: '\u0153',  # LATIN SMALL LIGATURE OE
-    0x9d: '\x9d',    # <control>
-    0x9e: '\u017e',  # LATIN SMALL LETTER Z WITH CARON
-    0x9f: '\u0178',  # LATIN CAPITAL LETTER Y WITH DIAERESIS
+    0x00: "\ufffd",  # REPLACEMENT CHARACTER
+    0x0d: "\r",  # CARRIAGE RETURN
+    0x80: "\u20ac",  # EURO SIGN
+    0x81: "\x81",  # <control>
+    0x82: "\u201a",  # SINGLE LOW-9 QUOTATION MARK
+    0x83: "\u0192",  # LATIN SMALL LETTER F WITH HOOK
+    0x84: "\u201e",  # DOUBLE LOW-9 QUOTATION MARK
+    0x85: "\u2026",  # HORIZONTAL ELLIPSIS
+    0x86: "\u2020",  # DAGGER
+    0x87: "\u2021",  # DOUBLE DAGGER
+    0x88: "\u02c6",  # MODIFIER LETTER CIRCUMFLEX ACCENT
+    0x89: "\u2030",  # PER MILLE SIGN
+    0x8a: "\u0160",  # LATIN CAPITAL LETTER S WITH CARON
+    0x8b: "\u2039",  # SINGLE LEFT-POINTING ANGLE QUOTATION MARK
+    0x8c: "\u0152",  # LATIN CAPITAL LIGATURE OE
+    0x8d: "\x8d",  # <control>
+    0x8e: "\u017d",  # LATIN CAPITAL LETTER Z WITH CARON
+    0x8f: "\x8f",  # <control>
+    0x90: "\x90",  # <control>
+    0x91: "\u2018",  # LEFT SINGLE QUOTATION MARK
+    0x92: "\u2019",  # RIGHT SINGLE QUOTATION MARK
+    0x93: "\u201c",  # LEFT DOUBLE QUOTATION MARK
+    0x94: "\u201d",  # RIGHT DOUBLE QUOTATION MARK
+    0x95: "\u2022",  # BULLET
+    0x96: "\u2013",  # EN DASH
+    0x97: "\u2014",  # EM DASH
+    0x98: "\u02dc",  # SMALL TILDE
+    0x99: "\u2122",  # TRADE MARK SIGN
+    0x9a: "\u0161",  # LATIN SMALL LETTER S WITH CARON
+    0x9b: "\u203a",  # SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
+    0x9c: "\u0153",  # LATIN SMALL LIGATURE OE
+    0x9d: "\x9d",  # <control>
+    0x9e: "\u017e",  # LATIN SMALL LETTER Z WITH CARON
+    0x9f: "\u0178",  # LATIN CAPITAL LETTER Y WITH DIAERESIS
 }
 
 
 def _replace_charref(s):
     s = s.group(1)
-    if s[0] == '#':
+    if s[0] == "#":
         # numeric charref
-        if s[1] in 'xX':
-            num = int(s[2:].rstrip(';'), 16)
+        if s[1] in "xX":
+            num = int(s[2:].rstrip(";"), 16)
         else:
-            num = int(s[1:].rstrip(';'))
+            num = int(s[1:].rstrip(";"))
         if num in _invalid_charrefs:
             return _invalid_charrefs[num]
         if 0xD800 <= num <= 0xDFFF or num > 0x10FFFF:
-            return '\uFFFD'
+            return "\uFFFD"
         if num in _invalid_codepoints:
-            return ''
+            return ""
         return chr(num)
     else:
         # named charref
@@ -90,15 +201,13 @@ def _replace_charref(s):
             if s[:x] in SAFE_ENTITIES:
                 return SAFE_ENTITIES[s[:x]] + s[x:]
         else:
-            return '&' + s
+            return "&" + s
 
 
-_charref = re.compile(r'&(#[0-9]+;?'
-                      r'|#[xX][0-9a-fA-F]+;?'
-                      r'|[^\t\n\f <&#;]{1,32};?)')
+_charref = re.compile(r"&(#[0-9]+;?" r"|#[xX][0-9a-fA-F]+;?" r"|[^\t\n\f <&#;]{1,32};?)")
 
 
 def unescape(s):
-    if '&' not in s:
+    if "&" not in s:
         return s
     return _charref.sub(_replace_charref, s)

--- a/errbot/specific_plugin_manager.py
+++ b/errbot/specific_plugin_manager.py
@@ -1,9 +1,9 @@
 import logging
 import sys
-
 import traceback
+
+from yapsy.PluginFileLocator import PluginFileAnalyzerWithInfoFile, PluginFileLocator
 from yapsy.PluginManager import PluginManager
-from yapsy.PluginFileLocator import PluginFileLocator, PluginFileAnalyzerWithInfoFile
 
 from .utils import collect_roots
 
@@ -16,13 +16,14 @@ class SpecificPluginLocator(PluginFileAnalyzerWithInfoFile):
     We have to go through hoops because yapsy is really aggressive at instanciating plugin.
     (this would instantiate several bots, we don't want to do that).
     """
+
     def __init__(self, name_to_find):
-        super().__init__('SpecificBackendLocator', 'plug')
+        super().__init__("SpecificBackendLocator", "plug")
         self._name_to_find = name_to_find
 
     def getInfosDictFromPlugin(self, dirpath, filename):
         plugin_info_dict, config_parser = super().getInfosDictFromPlugin(dirpath, filename)
-        if plugin_info_dict['name'] != self._name_to_find:
+        if plugin_info_dict["name"] != self._name_to_find:
             # reject
             return None, config_parser
         return plugin_info_dict, config_parser
@@ -32,24 +33,25 @@ class SpecificPluginManager(PluginManager):
     """ SpecificPluginManager is a customized plugin manager to enumerate plugins
         and load only a specific one.
     """
+
     def __init__(self, bot_config, category, base_class, base_search_dir, extra_search_dirs=()):
         self._config = bot_config
         # set a locator that gets every possible backends as a first discovery pass.
-        self._locator = PluginFileLocator(analyzers=[PluginFileAnalyzerWithInfoFile('SpecificLocator', 'plug')])
+        self._locator = PluginFileLocator(analyzers=[PluginFileAnalyzerWithInfoFile("SpecificLocator", "plug")])
         self._locator.disableRecursiveScan()  # This is done below correctly with find_roots_with_extra
         super().__init__(plugin_locator=self._locator)
         self.setCategoriesFilter({category: base_class})
 
         all_plugins_paths = collect_roots((base_search_dir, extra_search_dirs))
-        log.info('%s search paths %s', category, all_plugins_paths)
+        log.info("%s search paths %s", category, all_plugins_paths)
         self.setPluginPlaces(all_plugins_paths)
         for entry in all_plugins_paths:
             if entry not in sys.path:
                 sys.path.append(entry)  # so backends can relatively import their submodules
         self.locatePlugins()
-        log.info('Found those plugings available:')
+        log.info("Found those plugings available:")
         for (_, _, plug) in self.getPluginCandidates():
-            log.info('\t%10s  (%s)' % (plug.name, plug.path + '.py'))
+            log.info("\t%10s  (%s)" % (plug.name, plug.path + ".py"))
 
     def instanciateElement(self, element):
         """ Override the loading method to inject config
@@ -82,7 +84,7 @@ class SpecificPluginManager(PluginManager):
             raise Exception("There are 2 plugins with the name '%s'." % name)
         if plugins[0].error is not None:
             reason = plugins[0].error
-            formatted_error = "%s:\n%s" % (reason[0], ''.join(traceback.format_tb(plugins[0].error[2])))
-            raise Exception('Error loading plugin %s:\nError:\n%s\n' % (name, formatted_error))
+            formatted_error = "%s:\n%s" % (reason[0], "".join(traceback.format_tb(plugins[0].error[2])))
+            raise Exception("Error loading plugin %s:\nError:\n%s\n" % (name, formatted_error))
 
         return plugins[0].plugin_object

--- a/errbot/storage/__init__.py
+++ b/errbot/storage/__init__.py
@@ -2,6 +2,7 @@ import types
 from collections import MutableMapping
 from contextlib import contextmanager
 import logging
+
 log = logging.getLogger(__name__)
 
 
@@ -27,14 +28,14 @@ class StoreMixin(MutableMapping):
         self.namespace = None
 
     def open_storage(self, storage_plugin, namespace):
-        if hasattr(self, 'store') and self._store is not None:
+        if hasattr(self, "store") and self._store is not None:
             raise StoreAlreadyOpenError("Storage appears to be opened already")
         log.debug("Opening storage '%s'" % namespace)
         self._store = storage_plugin.open(namespace)
         self.namespace = namespace
 
     def close_storage(self):
-        if not hasattr(self, '_store') or self._store is None:
+        if not hasattr(self, "_store") or self._store is None:
             raise StoreNotOpenError("Storage does not appear to have been opened yet")
         self._store.close()
         self._store = None

--- a/errbot/storage/base.py
+++ b/errbot/storage/base.py
@@ -6,6 +6,7 @@ class StorageBase(object):
     """
     Contract to implemement a storage.
     """
+
     @abstractmethod
     def set(self, key: str, value: Any) -> None:
         """
@@ -68,8 +69,9 @@ class StoragePluginBase(object):
     Base to implement a storage plugin.
     This is a factory for the namespaces.
     """
+
     def __init__(self, bot_config):
-        self._storage_config = getattr(bot_config, 'STORAGE_CONFIG', {})
+        self._storage_config = getattr(bot_config, "STORAGE_CONFIG", {})
 
     @abstractmethod
     def open(self, namespace: str) -> StorageBase:

--- a/errbot/storage/shelf.py
+++ b/errbot/storage/shelf.py
@@ -1,18 +1,18 @@
 import logging
-from typing import Any
-import shelve
 import os
-
+import shelve
 import shutil
+from typing import Any
 
 from errbot.storage.base import StorageBase, StoragePluginBase
 
-log = logging.getLogger('errbot.storage.shelf')
+log = logging.getLogger("errbot.storage.shelf")
 
 
 class ShelfStorage(StorageBase):
+
     def __init__(self, path):
-        log.debug('Open shelf storage %s' % path)
+        log.debug("Open shelf storage %s" % path)
         self.shelf = shelve.DbfilenameShelf(path, protocol=2)
 
     def get(self, key: str) -> Any:
@@ -38,22 +38,23 @@ class ShelfStorage(StorageBase):
 
 
 class ShelfStoragePlugin(StoragePluginBase):
+
     def __init__(self, bot_config):
         super().__init__(bot_config)
-        if 'basedir' not in self._storage_config:
-            self._storage_config['basedir'] = bot_config.BOT_DATA_DIR
+        if "basedir" not in self._storage_config:
+            self._storage_config["basedir"] = bot_config.BOT_DATA_DIR
 
     def open(self, namespace: str) -> StorageBase:
         config = self._storage_config
         # Hack to port move old DBs to the new location.
-        new_spot = os.path.join(config['basedir'], namespace + '.db')
-        old_spot = os.path.join(config['basedir'], 'plugins', namespace + '.db')
+        new_spot = os.path.join(config["basedir"], namespace + ".db")
+        old_spot = os.path.join(config["basedir"], "plugins", namespace + ".db")
         if os.path.isfile(old_spot):
             if os.path.isfile(new_spot):
-                log.warning('You have an old v3 DB at %s and a duplicate new one at %s.' % (old_spot, new_spot))
-                log.warning('You need to either remove the old one or move it in place of the new one manually.')
+                log.warning("You have an old v3 DB at %s and a duplicate new one at %s." % (old_spot, new_spot))
+                log.warning("You need to either remove the old one or move it in place of the new one manually.")
             else:
-                log.info('Moving your old v3 DB from %s to %s.' % (old_spot, new_spot))
+                log.info("Moving your old v3 DB from %s to %s." % (old_spot, new_spot))
                 shutil.move(old_spot, new_spot)
 
         return ShelfStorage(new_spot)

--- a/errbot/streaming.py
+++ b/errbot/streaming.py
@@ -1,10 +1,11 @@
 
-import os
 import io
-from itertools import starmap, repeat
-from threading import Thread
-from .backends.base import STREAM_WAITING_TO_START, STREAM_TRANSFER_IN_PROGRESS
 import logging
+import os
+from itertools import repeat, starmap
+from threading import Thread
+
+from .backends.base import STREAM_TRANSFER_IN_PROGRESS, STREAM_WAITING_TO_START
 
 CHUNK_SIZE = 4096
 
@@ -27,6 +28,7 @@ def repeatfunc(func, times=None, *args):  # from the itertools receipes
 
 class Tee(object):
     """ Tee implements a multi reader / single writer """
+
     def __init__(self, incoming_stream, clients):
         """ clients is a list of objects implementing callback_stream """
         self.incoming_stream = incoming_stream
@@ -41,7 +43,7 @@ class Tee(object):
     def run(self):
         """ streams to all the clients synchronously """
         nb_clients = len(self.clients)
-        pipes = [(io.open(r, 'rb'), io.open(w, 'wb')) for r, w in repeatfunc(os.pipe, nb_clients)]
+        pipes = [(io.open(r, "rb"), io.open(w, "wb")) for r, w in repeatfunc(os.pipe, nb_clients)]
         streams = [self.incoming_stream.clone(pipe[0]) for pipe in pipes]
 
         def streamer(index):

--- a/errbot/templates/initdir/example.py
+++ b/errbot/templates/initdir/example.py
@@ -15,4 +15,4 @@ class Example(BotPlugin):
         Feel free to tweak me to experiment with Errbot.
         You can find me in your init directory in the subdirectory plugins.
         """
-        return 'It *works* !'  # This string format is markdown.
+        return "It *works* !"  # This string format is markdown.

--- a/errbot/templating.py
+++ b/errbot/templating.py
@@ -1,22 +1,23 @@
 import logging
 import os
+
 from jinja2 import Environment, FileSystemLoader
+
 from bottle import TEMPLATE_PATH
 
 log = logging.getLogger(__name__)
 
 
 def make_templates_path(root):
-    return os.path.join(root, 'templates')
+    return os.path.join(root, "templates")
 
 
 system_templates_path = make_templates_path(os.path.dirname(__file__))
 template_path = [system_templates_path]
 TEMPLATE_PATH.insert(0, system_templates_path)  # for views
-env = Environment(loader=FileSystemLoader(template_path),
-                  trim_blocks=True,
-                  keep_trailing_newline=False,
-                  autoescape=True)
+env = Environment(
+    loader=FileSystemLoader(template_path), trim_blocks=True, keep_trailing_newline=False, autoescape=True
+)
 
 
 def tenv():

--- a/errbot/version.py
+++ b/errbot/version.py
@@ -1,3 +1,3 @@
 # Just the current version of Errbot.
 # It is used for deployment on pypi AND for version checking at plugin load time.
-VERSION = '9.9.9'  # leave it at 9.9.9 on master until it is branched to a version.
+VERSION = "9.9.9"  # leave it at 9.9.9 on master until it is branched to a version.

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,5 +3,10 @@ max-line-length = 120
 
 [pycodestyle]
 max-line-length = 120
-ignore = E741,E722
-exclude = errbot/config-template.py, tests/config-travisci.py
+ignore = W503,W504,E741
+exclude = 
+	config.py,
+	errbot/config-template.py,
+	tests/config-travisci.py,
+	.tox,
+	docs/,

--- a/setup.py
+++ b/setup.py
@@ -23,35 +23,36 @@ from setuptools import setup, find_packages
 py_version = sys.version_info[:2]
 PY35_OR_GREATER = py_version >= (3, 5)
 
-ON_WINDOWS = system() == 'Windows'
+ON_WINDOWS = system() == "Windows"
 
 if py_version < (3, 4):
-    raise RuntimeError('Errbot requires Python 3.4 or later')
+    raise RuntimeError("Errbot requires Python 3.4 or later")
 
-VERSION_FILE = os.path.join('errbot', 'version.py')
+VERSION_FILE = os.path.join("errbot", "version.py")
 
-deps = ['webtest',
-        'setuptools',
-        'bottle',
-        'rocket-errbot',
-        'requests',
-        'jinja2',
-        'pyOpenSSL',
-        'colorlog',
-        'yapsy>=1.11',  # new contract for plugin instantiation
-        'markdown',  # rendering stuff
-        'ansi',
-        'Pygments>=2.0.2',
-        'pygments-markdown-lexer>=0.1.0.dev39',  # sytax coloring to debug md
-        'dnspython3',
-        ]
+deps = [
+    "webtest",
+    "setuptools",
+    "bottle",
+    "rocket-errbot",
+    "requests",
+    "jinja2",
+    "pyOpenSSL",
+    "colorlog",
+    "yapsy>=1.11",  # new contract for plugin instantiation
+    "markdown",  # rendering stuff
+    "ansi",
+    "Pygments>=2.0.2",
+    "pygments-markdown-lexer>=0.1.0.dev39",  # sytax coloring to debug md
+    "dnspython3",
+]
 
 if not PY35_OR_GREATER:
-    deps += ['typing', ]  # backward compatibility for 3.3 and 3.4
+    deps += ["typing"]  # backward compatibility for 3.3 and 3.4
 
 
 if not ON_WINDOWS:
-    deps += ['daemonize']
+    deps += ["daemonize"]
 
 src_root = os.curdir
 
@@ -64,12 +65,12 @@ def read_version():
 
     variables = {}
     with open(VERSION_FILE) as f:
-        exec(compile(f.read(), 'version.py', 'exec'), variables)
-    return variables['VERSION']
+        exec(compile(f.read(), "version.py", "exec"), variables)
+    return variables["VERSION"]
 
 
-def read(fname, encoding='ascii'):
-    return open(os.path.join(os.path.dirname(__file__), fname), 'r', encoding=encoding).read()
+def read(fname, encoding="ascii"):
+    return open(os.path.join(os.path.dirname(__file__), fname), "r", encoding=encoding).read()
 
 
 if __name__ == "__main__":
@@ -78,57 +79,52 @@ if __name__ == "__main__":
 
     args = set(sys.argv)
 
-    changes = read('CHANGES.rst', 'utf8')
+    changes = read("CHANGES.rst", "utf8")
 
     if changes.find(VERSION) == -1:
-        raise Exception('You forgot to put a release note in CHANGES.rst ?!')
+        raise Exception("You forgot to put a release note in CHANGES.rst ?!")
 
-    if args & {'bdist', 'bdist_dumb', 'bdist_rpm', 'bdist_wininst', 'bdist_msi'}:
+    if args & {"bdist", "bdist_dumb", "bdist_rpm", "bdist_wininst", "bdist_msi"}:
         raise Exception("err doesn't support binary distributions")
 
-    packages = find_packages(src_root, include=['errbot', 'errbot.*'])
+    packages = find_packages(src_root, include=["errbot", "errbot.*"])
 
     setup(
         name="errbot",
         version=VERSION,
         packages=packages,
-        entry_points={
-            'console_scripts': [
-                'errbot = errbot.cli:main',
+        entry_points={"console_scripts": ["errbot = errbot.cli:main"]},
+        install_requires=deps,
+        tests_require=["nose", "webtest", "requests"],
+        package_data={
+            "errbot": [
+                "backends/*.plug",
+                "backends/*.html",
+                "backends/styles/*.css",
+                "backends/images/*.svg",
+                "core_plugins/*.plug",
+                "core_plugins/*.md",
+                "core_plugins/templates/*.md",
+                "storage/*.plug",
+                "templates/initdir/example.py",
+                "templates/initdir/example.plug",
+                "templates/initdir/config.py.tmpl",
+                "templates/*.md",
+                "templates/new_plugin.py.tmpl",
             ]
         },
-
-        install_requires=deps,
-        tests_require=['nose', 'webtest', 'requests'],
-        package_data={
-            'errbot': ['backends/*.plug',
-                       'backends/*.html',
-                       'backends/styles/*.css',
-                       'backends/images/*.svg',
-                       'core_plugins/*.plug',
-                       'core_plugins/*.md',
-                       'core_plugins/templates/*.md',
-                       'storage/*.plug',
-                       'templates/initdir/example.py',
-                       'templates/initdir/example.plug',
-                       'templates/initdir/config.py.tmpl',
-                       'templates/*.md',
-                       'templates/new_plugin.py.tmpl',
-                       ],
-        },
         extras_require={
-            'graphic':  ['PySide', ],
-            'hipchat': ['hypchat', 'sleekxmpp', 'pyasn1', 'pyasn1-modules'],
-            'IRC': ['irc', ],
-            'slack': ['slackclient>=1.0.5', ],
-            'telegram': ['python-telegram-bot', ],
-            'XMPP': ['sleekxmpp', 'pyasn1', 'pyasn1-modules'],
+            "graphic": ["PySide"],
+            "hipchat": ["hypchat", "sleekxmpp", "pyasn1", "pyasn1-modules"],
+            "IRC": ["irc"],
+            "slack": ["slackclient>=1.0.5"],
+            "telegram": ["python-telegram-bot"],
+            "XMPP": ["sleekxmpp", "pyasn1", "pyasn1-modules"],
         },
-
         author="errbot.io",
         author_email="info@errbot.io",
         description="Errbot is a chatbot designed to be simple to extend with plugins written in Python.",
-        long_description=''.join([read('README.rst'), '\n\n', changes]),
+        long_description="".join([read("README.rst"), "\n\n", changes]),
         license="GPL",
         keywords="xmpp irc slack hipchat gitter tox chatbot bot plugin chatops",
         url="http://errbot.io/",
@@ -144,5 +140,5 @@ if __name__ == "__main__":
             "Programming Language :: Python :: 3.6",
         ],
         src_root=src_root,
-        platforms='any',
+        platforms="any",
     )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-logger = logging.getLogger('')
-logging.getLogger('yapsy').setLevel(logging.INFO)  # this one is way too verbose in debug
-logging.getLogger('Rocket.Errors').setLevel(logging.INFO)  # this one is way too verbose in debug
+logger = logging.getLogger("")
+logging.getLogger("yapsy").setLevel(logging.INFO)  # this one is way too verbose in debug
+logging.getLogger("Rocket.Errors").setLevel(logging.INFO)  # this one is way too verbose in debug
 logger.setLevel(logging.INFO)

--- a/tests/backend_manager_test.py
+++ b/tests/backend_manager_test.py
@@ -1,23 +1,17 @@
+import logging
 import unittest
 
-import logging
-
-from errbot.core import ErrBot
 from errbot.bootstrap import CORE_BACKENDS
+from errbot.core import ErrBot
 from errbot.specific_plugin_manager import SpecificPluginManager
 
 logging.basicConfig(level=logging.DEBUG)
 
 
 def test_builtins():
-    bpm = SpecificPluginManager(
-        {},
-        'backends',
-        ErrBot,
-        CORE_BACKENDS,
-        extra_search_dirs=())
+    bpm = SpecificPluginManager({}, "backends", ErrBot, CORE_BACKENDS, extra_search_dirs=())
     backend_plug = bpm.getPluginCandidates()
     names = [plug.name for (_, _, plug) in backend_plug]
-    assert 'Text' in names
-    assert 'Test' in names
-    assert 'Null' in names
+    assert "Text" in names
+    assert "Test" in names
+    assert "Null" in names

--- a/tests/backend_tests/slack_test.py
+++ b/tests/backend_tests/slack_test.py
@@ -1,8 +1,9 @@
-import sys
-import unittest
 import logging
 import os
+import sys
+import unittest
 from tempfile import mkdtemp
+
 from mock import MagicMock
 
 from errbot.bootstrap import bot_config_defaults
@@ -24,21 +25,22 @@ try:
 
         def username_to_userid(self, username, *args, **kwargs):
             """Have to mock because we don't have a slack server."""
-            return 'Utest'
+            return "Utest"
 
         def channelname_to_channelid(self, channelname):
-            return 'Ctest'
+            return "Ctest"
 
         def channelid_to_channelname(self, channelid):
-            return 'meh'
+            return "meh"
 
         def get_im_channel(self, id_):
-            return 'Cfoo'
+            return "Cfoo"
 
         def find_user(self, user):
             m = MagicMock()
             m.name = user
             return m
+
 
 except SystemExit:
     log.exception("Can't import backends.slack for testing")
@@ -51,64 +53,65 @@ class SlackTests(unittest.TestCase):
         # make up a config.
         tempdir = mkdtemp()
         # reset the config every time
-        sys.modules.pop('errbot.config-template', None)
-        __import__('errbot.config-template')
-        config = sys.modules['errbot.config-template']
+        sys.modules.pop("errbot.config-template", None)
+        __import__("errbot.config-template")
+        config = sys.modules["errbot.config-template"]
         bot_config_defaults(config)
         config.BOT_DATA_DIR = tempdir
-        config.BOT_LOG_FILE = os.path.join(tempdir, 'log.txt')
+        config.BOT_LOG_FILE = os.path.join(tempdir, "log.txt")
         config.BOT_EXTRA_PLUGIN_DIR = []
         config.BOT_LOG_LEVEL = logging.DEBUG
-        config.BOT_IDENTITY = {'username': 'err@localhost', 'token': '___'}
+        config.BOT_IDENTITY = {"username": "err@localhost", "token": "___"}
         config.BOT_ASYNC = False
-        config.BOT_PREFIX = '!'
-        config.CHATROOM_FN = 'blah'
+        config.BOT_PREFIX = "!"
+        config.CHATROOM_FN = "blah"
 
         self.slack = TestSlackBackend(config)
 
     def testBotMessageWithAttachments(self):
         attachment = {
-            'title': 'sometitle',
-            'id': 1,
-            'fallback': ' *Host:* host-01', 'color': 'daa038',
-            'fields': [{'title': 'Metric', 'value': '1', 'short': True}],
-            'title_link': 'https://xx.com'
+            "title": "sometitle",
+            "id": 1,
+            "fallback": " *Host:* host-01",
+            "color": "daa038",
+            "fields": [{"title": "Metric", "value": "1", "short": True}],
+            "title_link": "https://xx.com",
         }
-        bot_id = 'B04HMXXXX'
+        bot_id = "B04HMXXXX"
         bot_msg = {
-            'channel': 'C0XXXXY6P',
-            'icons': {'emoji': ':warning:', 'image_64': 'https://xx.com/26a0.png'},
-            'ts': '1444416645.000641',
-            'type': 'message',
-            'text': '',
-            'bot_id': bot_id,
-            'username': 'riemann',
-            'subtype': 'bot_message',
-            'attachments': [attachment]
+            "channel": "C0XXXXY6P",
+            "icons": {"emoji": ":warning:", "image_64": "https://xx.com/26a0.png"},
+            "ts": "1444416645.000641",
+            "type": "message",
+            "text": "",
+            "bot_id": bot_id,
+            "username": "riemann",
+            "subtype": "bot_message",
+            "attachments": [attachment],
         }
 
         self.slack._dispatch_slack_message(bot_msg)
         msg = self.slack.test_msgs.pop()
 
-        self.assertEqual(msg.extras['attachments'], [attachment])
+        self.assertEqual(msg.extras["attachments"], [attachment])
 
     def testSlackEventObjectAddedToExtras(self):
-        bot_id = 'B04HMXXXX'
+        bot_id = "B04HMXXXX"
         bot_msg = {
-            'channel': 'C0XXXXY6P',
-            'icons': {'emoji': ':warning:', 'image_64': 'https://xx.com/26a0.png'},
-            'ts': '1444416645.000641',
-            'type': 'message',
-            'text': '',
-            'bot_id': bot_id,
-            'username': 'riemann',
-            'subtype': 'bot_message',
+            "channel": "C0XXXXY6P",
+            "icons": {"emoji": ":warning:", "image_64": "https://xx.com/26a0.png"},
+            "ts": "1444416645.000641",
+            "type": "message",
+            "text": "",
+            "bot_id": bot_id,
+            "username": "riemann",
+            "subtype": "bot_message",
         }
 
         self.slack._dispatch_slack_message(bot_msg)
         msg = self.slack.test_msgs.pop()
 
-        self.assertEqual(msg.extras['slack_event'], bot_msg)
+        self.assertEqual(msg.extras["slack_event"], bot_msg)
 
     def testPrepareMessageBody(self):
         test_body = """
@@ -132,58 +135,31 @@ class SlackTests(unittest.TestCase):
         # ---------------------------------^ 21st char
         parts = self.slack.prepare_message_body(test_body, 21)
         assert len(parts) == 2
-        assert parts[0].count('```') == 2
-        assert parts[0].endswith('```')
-        assert parts[1].count('```') == 2
-        assert parts[1].endswith('```\n')
+        assert parts[0].count("```") == 2
+        assert parts[0].endswith("```")
+        assert parts[1].count("```") == 2
+        assert parts[1].endswith("```\n")
 
     def test_extract_identifiers(self):
         extract_from = self.slack.extract_identifiers_from_string
 
-        self.assertEqual(
-            extract_from("<@U12345>"),
-            (None, "U12345", None, None)
-        )
+        self.assertEqual(extract_from("<@U12345>"), (None, "U12345", None, None))
 
-        self.assertEqual(
-            extract_from("<@U12345|UName>"),
-            ("UName", "U12345", None, None)
-        )
+        self.assertEqual(extract_from("<@U12345|UName>"), ("UName", "U12345", None, None))
 
-        self.assertEqual(
-            extract_from("<@B12345>"),
-            (None, "B12345", None, None)
-        )
+        self.assertEqual(extract_from("<@B12345>"), (None, "B12345", None, None))
 
-        self.assertEqual(
-            extract_from("<#C12345>"),
-            (None, None, None, "C12345")
-        )
+        self.assertEqual(extract_from("<#C12345>"), (None, None, None, "C12345"))
 
-        self.assertEqual(
-            extract_from("<#G12345>"),
-            (None, None, None, "G12345")
-        )
+        self.assertEqual(extract_from("<#G12345>"), (None, None, None, "G12345"))
 
-        self.assertEqual(
-            extract_from("<#D12345>"),
-            (None, None, None, "D12345")
-        )
+        self.assertEqual(extract_from("<#D12345>"), (None, None, None, "D12345"))
 
-        self.assertEqual(
-            extract_from("@person"),
-            ("person", None, None, None)
-        )
+        self.assertEqual(extract_from("@person"), ("person", None, None, None))
 
-        self.assertEqual(
-            extract_from("#general/someuser"),
-            ("someuser", None, "general", None)
-        )
+        self.assertEqual(extract_from("#general/someuser"), ("someuser", None, "general", None))
 
-        self.assertEqual(
-            extract_from("#general"),
-            (None, None, "general", None)
-        )
+        self.assertEqual(extract_from("#general"), (None, None, "general", None))
 
         with self.assertRaises(ValueError):
             extract_from("")
@@ -205,40 +181,30 @@ class SlackTests(unittest.TestCase):
 
         def check_person(person, expected_uid, expected_cid):
             return person.userid == expected_uid and person.channelid == expected_cid
-        assert build_from("<#C12345>").name == 'meh'
+
+        assert build_from("<#C12345>").name == "meh"
         assert check_person(build_from("<@U12345>"), "U12345", "Cfoo")
         assert check_person(build_from("@user"), "Utest", "Cfoo")
-        assert build_from("#channel").name == 'meh'  # the mock always return meh ;)
+        assert build_from("#channel").name == "meh"  # the mock always return meh ;)
 
-        self.assertEqual(
-            build_from("#channel/user"),
-            slack.SlackRoomOccupant(None, "Utest", "Cfoo", self.slack)
-        )
+        self.assertEqual(build_from("#channel/user"), slack.SlackRoomOccupant(None, "Utest", "Cfoo", self.slack))
 
     def test_uri_sanitization(self):
         sanitize = self.slack.sanitize_uris
 
         self.assertEqual(
-            sanitize(
-                "The email is <mailto:test@example.org|test@example.org>."),
-            "The email is test@example.org."
+            sanitize("The email is <mailto:test@example.org|test@example.org>."), "The email is test@example.org."
         )
 
         self.assertEqual(
-            sanitize(
-                "Pretty URL Testing: <http://example.org|example.org> with "
-                "more text"),
-            "Pretty URL Testing: example.org with more text"
+            sanitize("Pretty URL Testing: <http://example.org|example.org> with " "more text"),
+            "Pretty URL Testing: example.org with more text",
         )
 
-        self.assertEqual(
-            sanitize("URL <http://example.org>"),
-            "URL http://example.org"
-        )
+        self.assertEqual(sanitize("URL <http://example.org>"), "URL http://example.org")
 
         self.assertEqual(
-            sanitize("Normal &lt;text&gt; that shouldn't be affected"),
-            "Normal &lt;text&gt; that shouldn't be affected"
+            sanitize("Normal &lt;text&gt; that shouldn't be affected"), "Normal &lt;text&gt; that shouldn't be affected"
         )
 
         self.assertEqual(
@@ -246,36 +212,30 @@ class SlackTests(unittest.TestCase):
                 "Multiple uris <mailto:test@example.org|test@example.org>, "
                 "<mailto:other@example.org|other@example.org> and "
                 "<http://www.example.org>, <https://example.com> and "
-                "<http://subdomain.example.org|subdomain.example.org>."),
+                "<http://subdomain.example.org|subdomain.example.org>."
+            ),
             "Multiple uris test@example.org, other@example.org and "
-            "http://www.example.org, https://example.com and subdomain.example.org."
+            "http://www.example.org, https://example.com and subdomain.example.org.",
         )
 
     def test_slack_markdown_link_preprocessor(self):
         convert = self.slack.md.convert
-        self.assertEqual(
-            "This is <http://example.com/|a link>.",
-            convert("This is [a link](http://example.com/).")
-        )
+        self.assertEqual("This is <http://example.com/|a link>.", convert("This is [a link](http://example.com/)."))
         self.assertEqual(
             "This is <https://example.com/|a link> and <mailto:me@comp.org|an email address>.",
-            convert("This is [a link](https://example.com/) and [an email address](mailto:me@comp.org).")
+            convert("This is [a link](https://example.com/) and [an email address](mailto:me@comp.org)."),
         )
         self.assertEqual(
             "This is <http://example.com/|a link> and a manual URL: https://example.com/.",
-            convert("This is [a link](http://example.com/) and a manual URL: https://example.com/.")
+            convert("This is [a link](http://example.com/) and a manual URL: https://example.com/."),
         )
+        self.assertEqual("<http://example.com/|This is a link>", convert("[This is a link](http://example.com/)"))
         self.assertEqual(
-            "<http://example.com/|This is a link>",
-            convert("[This is a link](http://example.com/)")
-        )
-        self.assertEqual(
-            "This is http://example.com/image.png.",
-            convert("This is ![an image](http://example.com/image.png).")
+            "This is http://example.com/image.png.", convert("This is ![an image](http://example.com/image.png).")
         )
         self.assertEqual(
             "This is [some text] then <http://example.com|a link>",
-            convert("This is [some text] then [a link](http://example.com)")
+            convert("This is [some text] then [a link](http://example.com)"),
         )
 
     def test_mention_processing(self):
@@ -284,36 +244,33 @@ class SlackTests(unittest.TestCase):
         mentions = self.slack.process_mentions
 
         self.assertEqual(
-            mentions(
-                "<@U1><@U2><@U3>"),
+            mentions("<@U1><@U2><@U3>"),
             (
                 "@U1@U2@U3",
-                [self.slack.build_identifier('<@U1>'),
-                 self.slack.build_identifier('<@U2>'),
-                 self.slack.build_identifier('<@U3>')])
+                [
+                    self.slack.build_identifier("<@U1>"),
+                    self.slack.build_identifier("<@U2>"),
+                    self.slack.build_identifier("<@U3>"),
+                ],
+            ),
         )
 
         self.assertEqual(
-            mentions(
-                "Is <@U12345>: here?"),
-            (
-                "Is @U12345: here?", [self.slack.build_identifier('<@U12345>')])
+            mentions("Is <@U12345>: here?"), ("Is @U12345: here?", [self.slack.build_identifier("<@U12345>")])
         )
 
         self.assertEqual(
-            mentions(
-                "<@U12345> told me about @a and <@U56789> told me about @b"),
+            mentions("<@U12345> told me about @a and <@U56789> told me about @b"),
             (
                 "@U12345 told me about @a and @U56789 told me about @b",
-                [self.slack.build_identifier('<@U12345>'),
-                 self.slack.build_identifier('<@U56789>')])
+                [self.slack.build_identifier("<@U12345>"), self.slack.build_identifier("<@U56789>")],
+            ),
         )
 
         self.assertEqual(
-            mentions(
-                "!these!<@UABCDE>!mentions! will !still!<@UFGHIJ>!work!"),
+            mentions("!these!<@UABCDE>!mentions! will !still!<@UFGHIJ>!work!"),
             (
                 "!these!@UABCDE!mentions! will !still!@UFGHIJ!work!",
-                [self.slack.build_identifier('<@UABCDE>'),
-                 self.slack.build_identifier('<@UFGHIJ>')])
+                [self.slack.build_identifier("<@UABCDE>"), self.slack.build_identifier("<@UFGHIJ>")],
+            ),
         )

--- a/tests/borken_plugin/broken.py
+++ b/tests/borken_plugin/broken.py
@@ -1,10 +1,10 @@
-from errbot import BotPlugin, botcmd
-
 import borken  # fails on purpose
+from errbot import BotPlugin, botcmd
 
 
 class Broken(BotPlugin):
+
     @botcmd
     def hello(self, msg, args):
         """ this command says hello """
-        return 'Hello World !'
+        return "Hello World !"

--- a/tests/commandnotfound_plugin/commandnotfound.py
+++ b/tests/commandnotfound_plugin/commandnotfound.py
@@ -2,6 +2,7 @@ from errbot import BotPlugin, cmdfilter
 
 
 class TestCommandNotFoundFilter(BotPlugin):
+
     @cmdfilter(catch_unprocessed=True)
     def command_not_found(self, msg, cmd, args, dry_run, emptycmd=False):
         if not emptycmd:

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -1,357 +1,352 @@
 # coding=utf-8
+import logging
 import os
 import re
-import logging
-from os import path, mkdir
+import tarfile
+from os import mkdir, path
 from queue import Empty
 from shutil import rmtree
 from tempfile import mkdtemp
 
 import pytest
-import tarfile
 
-extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), 'dummy_plugin')
+extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), "dummy_plugin")
 
 
 def test_root_help(testbot):
-    assert 'All commands' in testbot.exec_command('!help')
+    assert "All commands" in testbot.exec_command("!help")
 
 
 def test_help(testbot):
-    assert '!about' in testbot.exec_command('!help Help')
-    assert 'That command is not defined.' in testbot.exec_command('!help beurk')
+    assert "!about" in testbot.exec_command("!help Help")
+    assert "That command is not defined." in testbot.exec_command("!help beurk")
 
     # Ensure that help reports on re_commands.
-    assert 'runs foo' in testbot.exec_command('!help foo')  # Part of Dummy
-    assert 'runs re_foo' in testbot.exec_command('!help re_foo')  # Part of Dummy
-    assert 'runs re_foo' in testbot.exec_command('!help re foo')  # Part of Dummy
+    assert "runs foo" in testbot.exec_command("!help foo")  # Part of Dummy
+    assert "runs re_foo" in testbot.exec_command("!help re_foo")  # Part of Dummy
+    assert "runs re_foo" in testbot.exec_command("!help re foo")  # Part of Dummy
 
 
 def test_about(testbot):
-    assert 'Errbot version' in testbot.exec_command('!about')
+    assert "Errbot version" in testbot.exec_command("!about")
 
 
 def test_uptime(testbot):
-    assert 'I\'ve been up for' in testbot.exec_command('!uptime')
+    assert "I've been up for" in testbot.exec_command("!uptime")
 
 
 def test_status(testbot):
-    assert 'Yes I am alive' in testbot.exec_command('!status')
+    assert "Yes I am alive" in testbot.exec_command("!status")
 
 
 def test_status_plugins(testbot):
-    assert 'A = Activated, D = Deactivated' in testbot.exec_command('!status plugins')
+    assert "A = Activated, D = Deactivated" in testbot.exec_command("!status plugins")
 
 
 def test_status_load(testbot):
-    assert 'Load ' in testbot.exec_command('!status load')
+    assert "Load " in testbot.exec_command("!status load")
 
 
 def test_whoami(testbot):
-    assert 'person' in testbot.exec_command('!whoami')
-    assert 'gbin@localhost' in testbot.exec_command('!whoami')
+    assert "person" in testbot.exec_command("!whoami")
+    assert "gbin@localhost" in testbot.exec_command("!whoami")
 
 
 def test_echo(testbot):
-    assert 'foo' in testbot.exec_command('!echo foo')
+    assert "foo" in testbot.exec_command("!echo foo")
 
 
 def test_status_gc(testbot):
-    assert 'GC 0->' in testbot.exec_command('!status gc')
+    assert "GC 0->" in testbot.exec_command("!status gc")
 
 
 def test_config_cycle(testbot):
-    testbot.push_message('!plugin config Webserver')
+    testbot.push_message("!plugin config Webserver")
     m = testbot.pop_message()
-    assert 'Default configuration for this plugin (you can copy and paste this directly as a command)' in m
-    assert 'Current configuration' not in m
+    assert "Default configuration for this plugin (you can copy and paste this directly as a command)" in m
+    assert "Current configuration" not in m
 
-    testbot.assertCommand("!plugin config Webserver {'HOST': 'localhost', 'PORT': 3141, 'SSL':  None}",
-                          'Plugin configuration done.')
+    testbot.assertCommand(
+        "!plugin config Webserver {'HOST': 'localhost', 'PORT': 3141, 'SSL':  None}", "Plugin configuration done."
+    )
 
-    assert 'Current configuration' in testbot.exec_command('!plugin config Webserver')
-    assert 'localhost' in testbot.exec_command('!plugin config Webserver')
+    assert "Current configuration" in testbot.exec_command("!plugin config Webserver")
+    assert "localhost" in testbot.exec_command("!plugin config Webserver")
 
 
 def test_apropos(testbot):
-    assert '!about: Return information about' in testbot.exec_command('!apropos about')
+    assert "!about: Return information about" in testbot.exec_command("!apropos about")
 
 
 def test_logtail(testbot):
-    assert 'DEBUG' in testbot.exec_command('!log tail')
+    assert "DEBUG" in testbot.exec_command("!log tail")
 
 
 def test_history(testbot):
-    assert 'up' in testbot.exec_command('!uptime')
-    assert 'uptime' in testbot.exec_command('!history')
+    assert "up" in testbot.exec_command("!uptime")
+    assert "uptime" in testbot.exec_command("!history")
 
     orig_sender = testbot.bot.sender
     # Pretend to be someone else. History should be empty
-    testbot.bot.sender = testbot.bot.build_identifier('non_default_person')
-    testbot.push_message('!history')
+    testbot.bot.sender = testbot.bot.build_identifier("non_default_person")
+    testbot.push_message("!history")
     with pytest.raises(Empty):
         testbot.pop_message(timeout=1)
-    assert 'should be a separate history' in testbot.exec_command('!echo should be a separate history')
-    assert 'should be a separate history' in testbot.exec_command('!history')
+    assert "should be a separate history" in testbot.exec_command("!echo should be a separate history")
+    assert "should be a separate history" in testbot.exec_command("!history")
     testbot.bot.sender = orig_sender
     # Pretend to be the original person again. History should still contain uptime
-    assert 'uptime' in testbot.exec_command('!history')
+    assert "uptime" in testbot.exec_command("!history")
 
 
 def test_plugin_cycle(testbot):
 
-    plugins = [
-        'errbotio/err-helloworld',
-    ]
+    plugins = ["errbotio/err-helloworld"]
 
     for plugin in plugins:
-        testbot.assertCommand(
-            '!repos install {0}'.format(plugin),
-            'Installing {0}...'.format(plugin)
-        ),
-        assert 'A new plugin repository has been installed correctly from errbotio/err-helloworld' in \
-               testbot.pop_message(timeout=60)
-        assert 'Plugins reloaded' in testbot.pop_message()
+        testbot.assertCommand("!repos install {0}".format(plugin), "Installing {0}...".format(plugin)),
+        expected_response = "A new plugin repository has been installed correctly from errbotio/err-helloworld"
+        assert expected_response in testbot.pop_message(timeout=60)
+        assert "Plugins reloaded" in testbot.pop_message()
 
-        assert 'this command says hello' in testbot.exec_command('!help hello')
-        assert 'Hello World !' in testbot.exec_command('!hello')
+        assert "this command says hello" in testbot.exec_command("!help hello")
+        assert "Hello World !" in testbot.exec_command("!hello")
 
-        testbot.push_message('!plugin reload HelloWorld')
-        assert 'Plugin HelloWorld reloaded.' == testbot.pop_message()
+        testbot.push_message("!plugin reload HelloWorld")
+        assert "Plugin HelloWorld reloaded." == testbot.pop_message()
 
-        testbot.push_message('!hello')  # should still respond
-        assert 'Hello World !' == testbot.pop_message()
+        testbot.push_message("!hello")  # should still respond
+        assert "Hello World !" == testbot.pop_message()
 
-        testbot.push_message('!plugin blacklist HelloWorld')
-        assert 'Plugin HelloWorld is now blacklisted' == testbot.pop_message()
-        testbot.push_message('!plugin deactivate HelloWorld')
-        assert 'HelloWorld is already deactivated.' == testbot.pop_message()
+        testbot.push_message("!plugin blacklist HelloWorld")
+        assert "Plugin HelloWorld is now blacklisted" == testbot.pop_message()
+        testbot.push_message("!plugin deactivate HelloWorld")
+        assert "HelloWorld is already deactivated." == testbot.pop_message()
 
-        testbot.push_message('!hello')  # should not respond
+        testbot.push_message("!hello")  # should not respond
         assert 'Command "hello" not found' in testbot.pop_message()
 
-        testbot.push_message('!plugin unblacklist HelloWorld')
-        assert 'Plugin HelloWorld removed from blacklist' == testbot.pop_message()
-        testbot.push_message('!plugin activate HelloWorld')
-        assert 'HelloWorld is already activated.' == testbot.pop_message()
+        testbot.push_message("!plugin unblacklist HelloWorld")
+        assert "Plugin HelloWorld removed from blacklist" == testbot.pop_message()
+        testbot.push_message("!plugin activate HelloWorld")
+        assert "HelloWorld is already activated." == testbot.pop_message()
 
-        testbot.push_message('!hello')  # should respond back
-        assert 'Hello World !' == testbot.pop_message()
+        testbot.push_message("!hello")  # should respond back
+        assert "Hello World !" == testbot.pop_message()
 
-        testbot.push_message('!repos uninstall errbotio/err-helloworld')
-        assert 'Repo errbotio/err-helloworld removed.' == testbot.pop_message()
+        testbot.push_message("!repos uninstall errbotio/err-helloworld")
+        assert "Repo errbotio/err-helloworld removed." == testbot.pop_message()
 
-        testbot.push_message('!hello')  # should not respond
+        testbot.push_message("!hello")  # should not respond
         assert 'Command "hello" not found' in testbot.pop_message()
 
 
 def test_broken_plugin(testbot):
 
-    borken_plugin_dir = path.join(path.dirname(path.realpath(__file__)), 'borken_plugin')
+    borken_plugin_dir = path.join(path.dirname(path.realpath(__file__)), "borken_plugin")
     try:
         tempd = mkdtemp()
         tgz = os.path.join(tempd, "borken.tar.gz")
         with tarfile.open(tgz, "w:gz") as tar:
-            tar.add(borken_plugin_dir, arcname='borken')
-        assert 'Installing' in testbot.exec_command('!repos install file://' + tgz,
-                                                    timeout=120)
-        assert 'import borken  # fails' in testbot.pop_message()
-        assert 'as it did not load correctly.' in testbot.pop_message()
-        assert 'Plugins reloaded.' in testbot.pop_message()
+            tar.add(borken_plugin_dir, arcname="borken")
+        assert "Installing" in testbot.exec_command("!repos install file://" + tgz, timeout=120)
+        assert "import borken  # fails" in testbot.pop_message()
+        assert "as it did not load correctly." in testbot.pop_message()
+        assert "Plugins reloaded." in testbot.pop_message()
     finally:
         rmtree(tempd)
 
 
 def test_backup(testbot):
     bot = testbot.bot  # used while restoring
-    bot.push_message('!repos install https://github.com/errbotio/err-helloworld.git')
-    assert 'Installing' in testbot.pop_message()
-    assert 'err-helloworld' in testbot.pop_message(timeout=60)
-    assert 'reload' in testbot.pop_message()
-    bot.push_message('!backup')
+    bot.push_message("!repos install https://github.com/errbotio/err-helloworld.git")
+    assert "Installing" in testbot.pop_message()
+    assert "err-helloworld" in testbot.pop_message(timeout=60)
+    assert "reload" in testbot.pop_message()
+    bot.push_message("!backup")
     msg = testbot.pop_message()
-    assert 'has been written in' in msg
+    assert "has been written in" in msg
     filename = re.search(r"'([:A-Za-z0-9_./\\-]*)'", msg).group(1)
 
     # At least the backup should mention the installed plugin
-    assert 'errbotio/err-helloworld' in open(filename).read()
+    assert "errbotio/err-helloworld" in open(filename).read()
 
     # Now try to clean the bot and restore
     for p in testbot.bot.plugin_manager.get_all_active_plugin_objects():
         p.close_storage()
 
-    assert 'Plugin HelloWorld deactivated.' in testbot.exec_command('!plugin deactivate HelloWorld')
+    assert "Plugin HelloWorld deactivated." in testbot.exec_command("!plugin deactivate HelloWorld")
 
-    plugins_dir = path.join(testbot.bot_config.BOT_DATA_DIR, 'plugins')
-    bot.repo_manager['installed_repos'] = {}
-    bot.plugin_manager['configs'] = {}
+    plugins_dir = path.join(testbot.bot_config.BOT_DATA_DIR, "plugins")
+    bot.repo_manager["installed_repos"] = {}
+    bot.plugin_manager["configs"] = {}
     rmtree(plugins_dir)
     mkdir(plugins_dir)
 
     from errbot.bootstrap import restore_bot_from_backup
+
     log = logging.getLogger(__name__)  # noqa
     restore_bot_from_backup(filename, bot=bot, log=log)
 
-    assert 'Plugin HelloWorld activated.' in testbot.exec_command('!plugin activate HelloWorld')
-    assert 'Hello World !' in testbot.exec_command('!hello')
-    testbot.push_message('!repos uninstall errbotio/err-helloworld')
+    assert "Plugin HelloWorld activated." in testbot.exec_command("!plugin activate HelloWorld")
+    assert "Hello World !" in testbot.exec_command("!hello")
+    testbot.push_message("!repos uninstall errbotio/err-helloworld")
 
 
 def test_encoding_preservation(testbot):
-    testbot.push_message('!echo へようこそ')
-    assert 'へようこそ' == testbot.pop_message()
+    testbot.push_message("!echo へようこそ")
+    assert "へようこそ" == testbot.pop_message()
 
 
 def test_webserver_webhook_test(testbot):
     testbot.push_message("!plugin config Webserver {'HOST': 'localhost', 'PORT': 3141, 'SSL':  None}")
-    assert 'Plugin configuration done.' in testbot.pop_message()
-    testbot.assertCommand("!webhook test /echo toto", 'Status code : 200')
+    assert "Plugin configuration done." in testbot.pop_message()
+    testbot.assertCommand("!webhook test /echo toto", "Status code : 200")
 
 
 def test_activate_reload_and_deactivate(testbot):
-    for command in ('activate', 'reload', 'deactivate'):
+    for command in ("activate", "reload", "deactivate"):
         testbot.push_message("!plugin {}".format(command))
         m = testbot.pop_message()
-        assert 'Please tell me which of the following plugins to' in m
-        assert 'ChatRoom' in m
+        assert "Please tell me which of the following plugins to" in m
+        assert "ChatRoom" in m
 
-        testbot.push_message('!plugin {} nosuchplugin'.format(command))
+        testbot.push_message("!plugin {} nosuchplugin".format(command))
         m = testbot.pop_message()
-        assert 'nosuchplugin isn\'t a valid plugin name. The current plugins are' in m
-        assert 'ChatRoom' in m
+        assert "nosuchplugin isn't a valid plugin name. The current plugins are" in m
+        assert "ChatRoom" in m
 
-    testbot.push_message('!plugin reload ChatRoom')
-    assert 'Plugin ChatRoom reloaded.' == testbot.pop_message()
-
-    testbot.push_message('!status plugins')
-    assert 'A      │ ChatRoom' in testbot.pop_message()
-
-    testbot.push_message('!plugin deactivate ChatRoom')
-    assert 'Plugin ChatRoom deactivated.' == testbot.pop_message()
+    testbot.push_message("!plugin reload ChatRoom")
+    assert "Plugin ChatRoom reloaded." == testbot.pop_message()
 
     testbot.push_message("!status plugins")
-    assert 'D      │ ChatRoom' in testbot.pop_message()
+    assert "A      │ ChatRoom" in testbot.pop_message()
 
-    testbot.push_message('!plugin deactivate ChatRoom')
-    assert 'ChatRoom is already deactivated.' in testbot.pop_message()
+    testbot.push_message("!plugin deactivate ChatRoom")
+    assert "Plugin ChatRoom deactivated." == testbot.pop_message()
 
-    testbot.push_message('!plugin activate ChatRoom')
-    assert 'Plugin ChatRoom activated.' in testbot.pop_message()
+    testbot.push_message("!status plugins")
+    assert "D      │ ChatRoom" in testbot.pop_message()
 
-    testbot.push_message('!status plugins')
-    assert 'A      │ ChatRoom' in testbot.pop_message()
+    testbot.push_message("!plugin deactivate ChatRoom")
+    assert "ChatRoom is already deactivated." in testbot.pop_message()
 
-    testbot.push_message('!plugin activate ChatRoom')
-    assert 'ChatRoom is already activated.' == testbot.pop_message()
+    testbot.push_message("!plugin activate ChatRoom")
+    assert "Plugin ChatRoom activated." in testbot.pop_message()
 
-    testbot.push_message('!plugin deactivate ChatRoom')
-    assert 'Plugin ChatRoom deactivated.' == testbot.pop_message()
-    testbot.push_message('!plugin reload ChatRoom')
-    assert 'Warning: plugin ChatRoom is currently not activated. Use !plugin activate ChatRoom to activate it.' == \
-           testbot.pop_message()
-    assert 'Plugin ChatRoom reloaded.' == testbot.pop_message()
+    testbot.push_message("!status plugins")
+    assert "A      │ ChatRoom" in testbot.pop_message()
 
-    testbot.push_message('!plugin blacklist ChatRoom')
-    assert 'Plugin ChatRoom is now blacklisted' == testbot.pop_message()
+    testbot.push_message("!plugin activate ChatRoom")
+    assert "ChatRoom is already activated." == testbot.pop_message()
 
-    testbot.push_message('!status plugins')
-    assert 'B,D    │ ChatRoom' in testbot.pop_message()
+    testbot.push_message("!plugin deactivate ChatRoom")
+    assert "Plugin ChatRoom deactivated." == testbot.pop_message()
+    testbot.push_message("!plugin reload ChatRoom")
+    assert (
+        "Warning: plugin ChatRoom is currently not activated. Use !plugin activate ChatRoom to activate it."
+        == testbot.pop_message()
+    )
+    assert "Plugin ChatRoom reloaded." == testbot.pop_message()
+
+    testbot.push_message("!plugin blacklist ChatRoom")
+    assert "Plugin ChatRoom is now blacklisted" == testbot.pop_message()
+
+    testbot.push_message("!status plugins")
+    assert "B,D    │ ChatRoom" in testbot.pop_message()
 
     # Needed else configuration for this plugin gets saved which screws up
     # other tests
-    testbot.push_message('!plugin unblacklist ChatRoom')
+    testbot.push_message("!plugin unblacklist ChatRoom")
     testbot.pop_message()
 
 
 def test_unblacklist_and_blacklist(testbot):
-    testbot.push_message('!plugin unblacklist nosuchplugin')
+    testbot.push_message("!plugin unblacklist nosuchplugin")
     m = testbot.pop_message()
     assert "nosuchplugin isn't a valid plugin name. The current plugins are" in m
-    assert 'ChatRoom' in m
+    assert "ChatRoom" in m
 
-    testbot.push_message('!plugin blacklist nosuchplugin')
+    testbot.push_message("!plugin blacklist nosuchplugin")
     m = testbot.pop_message()
     assert "nosuchplugin isn't a valid plugin name. The current plugins are" in m
-    assert 'ChatRoom' in m
+    assert "ChatRoom" in m
 
-    testbot.push_message('!plugin blacklist ChatRoom')
-    assert 'Plugin ChatRoom is now blacklisted' in testbot.pop_message()
+    testbot.push_message("!plugin blacklist ChatRoom")
+    assert "Plugin ChatRoom is now blacklisted" in testbot.pop_message()
 
-    testbot.push_message('!plugin blacklist ChatRoom')
-    assert 'Plugin ChatRoom is already blacklisted' == testbot.pop_message()
+    testbot.push_message("!plugin blacklist ChatRoom")
+    assert "Plugin ChatRoom is already blacklisted" == testbot.pop_message()
 
-    testbot.push_message('!status plugins')
-    assert 'B,D    │ ChatRoom' in testbot.pop_message()
+    testbot.push_message("!status plugins")
+    assert "B,D    │ ChatRoom" in testbot.pop_message()
 
-    testbot.push_message('!plugin unblacklist ChatRoom')
-    assert 'Plugin ChatRoom removed from blacklist' == testbot.pop_message()
+    testbot.push_message("!plugin unblacklist ChatRoom")
+    assert "Plugin ChatRoom removed from blacklist" == testbot.pop_message()
 
-    testbot.push_message('!plugin unblacklist ChatRoom')
-    assert 'Plugin ChatRoom is not blacklisted' == testbot.pop_message()
+    testbot.push_message("!plugin unblacklist ChatRoom")
+    assert "Plugin ChatRoom is not blacklisted" == testbot.pop_message()
 
-    testbot.push_message('!status plugins')
-    assert 'A      │ ChatRoom' in testbot.pop_message()
+    testbot.push_message("!status plugins")
+    assert "A      │ ChatRoom" in testbot.pop_message()
 
 
 def test_optional_prefix(testbot):
     testbot.bot_config.BOT_PREFIX_OPTIONAL_ON_CHAT = False
-    assert 'Yes I am alive' in testbot.exec_command('!status')
+    assert "Yes I am alive" in testbot.exec_command("!status")
 
     testbot.bot_config.BOT_PREFIX_OPTIONAL_ON_CHAT = True
-    assert 'Yes I am alive' in testbot.exec_command('!status')
-    assert 'Yes I am alive' in testbot.exec_command('status')
+    assert "Yes I am alive" in testbot.exec_command("!status")
+    assert "Yes I am alive" in testbot.exec_command("status")
 
 
 def test_optional_prefix_re_cmd(testbot):
     testbot.bot_config.BOT_PREFIX_OPTIONAL_ON_CHAT = False
-    assert 'bar' in testbot.exec_command('!plz dont match this')
+    assert "bar" in testbot.exec_command("!plz dont match this")
 
     testbot.bot_config.BOT_PREFIX_OPTIONAL_ON_CHAT = True
-    assert 'bar' in testbot.exec_command('!plz dont match this')
-    assert 'bar' in testbot.exec_command('plz dont match this')
+    assert "bar" in testbot.exec_command("!plz dont match this")
+    assert "bar" in testbot.exec_command("plz dont match this")
 
 
 def test_simple_match(testbot):
-    assert 'bar' in testbot.exec_command('match this')
+    assert "bar" in testbot.exec_command("match this")
 
 
 def test_no_suggest_on_re_commands(testbot):
-    testbot.push_message('!re_ba')
+    testbot.push_message("!re_ba")
     # Don't suggest a regexp command.
-    assert '!re bar' not in testbot.pop_message()
+    assert "!re bar" not in testbot.pop_message()
 
 
 def test_callback_no_command(testbot):
-    extra_plugin_dir = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)),
-        'commandnotfound_plugin'
-    )
+    extra_plugin_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "commandnotfound_plugin")
 
-    cmd = '!this_is_not_a_real_command_at_all'
+    cmd = "!this_is_not_a_real_command_at_all"
     expected_str = "Command fell through: {}".format(cmd)
 
-    testbot.exec_command('!plugin deactivate CommandNotFoundFilter')
+    testbot.exec_command("!plugin deactivate CommandNotFoundFilter")
     testbot.bot.plugin_manager.update_plugin_places([], extra_plugin_dir)
-    testbot.exec_command('!plugin activate TestCommandNotFoundFilter')
+    testbot.exec_command("!plugin activate TestCommandNotFoundFilter")
     assert expected_str == testbot.exec_command(cmd)
 
 
 def test_subcommands(testbot):
     # test single subcommand (method is run_subcommands())
-    cmd = '!run subcommands with these args'
-    cmd_underscore = '!run_subcommands with these args'
-    expected_args = 'with these args'
+    cmd = "!run subcommands with these args"
+    cmd_underscore = "!run_subcommands with these args"
+    expected_args = "with these args"
     assert expected_args == testbot.exec_command(cmd)
     assert expected_args == testbot.exec_command(cmd_underscore)
 
     # test multiple subcmomands (method is run_lots_of_subcommands())
-    cmd = '!run lots of subcommands with these args'
-    cmd_underscore = '!run_lots_of_subcommands with these args'
+    cmd = "!run lots of subcommands with these args"
+    cmd_underscore = "!run_lots_of_subcommands with these args"
     assert expected_args == testbot.exec_command(cmd)
     assert expected_args == testbot.exec_command(cmd_underscore)
 
 
 def test_command_not_found_with_space_in_bot_prefix(testbot):
-    testbot.bot_config.BOT_PREFIX = '! '
-    assert 'Command "blah" not found.' in testbot.exec_command('! blah')
-    assert 'Command "blah" / "blah toto" not found.' in testbot.exec_command('! blah toto')
+    testbot.bot_config.BOT_PREFIX = "! "
+    assert 'Command "blah" not found.' in testbot.exec_command("! blah")
+    assert 'Command "blah" / "blah toto" not found.' in testbot.exec_command("! blah toto")

--- a/tests/config-travisci.py
+++ b/tests/config-travisci.py
@@ -1,24 +1,22 @@
 # config for travisci
 # Don't use this for sensible defaults
 import logging
-BOT_DATA_DIR = '/tmp'
+
+BOT_DATA_DIR = "/tmp"
 BOT_EXTRA_PLUGIN_DIR = None
 AUTOINSTALL_DEPS = True
-BOT_LOG_FILE = '/tmp/err.log'
+BOT_LOG_FILE = "/tmp/err.log"
 BOT_LOG_LEVEL = logging.DEBUG
 BOT_LOG_SENTRY = False
-SENTRY_DSN = ''
+SENTRY_DSN = ""
 SENTRY_LOGLEVEL = BOT_LOG_LEVEL
 BOT_ASYNC = True
-BOT_IDENTITY = {
-    'username': 'err@localhost',
-    'password': 'changeme',
-}
+BOT_IDENTITY = {"username": "err@localhost", "password": "changeme"}
 
-BOT_ADMINS = ('gbin@localhost',)
+BOT_ADMINS = ("gbin@localhost",)
 CHATROOM_PRESENCE = ()
-CHATROOM_FN = 'Err'
-BOT_PREFIX = '!'
+CHATROOM_FN = "Err"
+BOT_PREFIX = "!"
 DIVERT_TO_PRIVATE = ()
 CHATROOM_RELAY = {}
 REVERSE_CHATROOM_RELAY = {}

--- a/tests/config_plugin/config.py
+++ b/tests/config_plugin/config.py
@@ -5,5 +5,6 @@ class Config(BotPlugin):
     """
     Just a plugin with a simple string config.
     """
+
     def get_configuration_template(self):
-        return {'One': 'one'}
+        return {"One": "one"}

--- a/tests/core_plugins_test.py
+++ b/tests/core_plugins_test.py
@@ -1,26 +1,26 @@
 import os
 
-extra_plugin_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'room_plugin')
-extra_config = {'CORE_PLUGINS': ('Help', 'Utils', 'CommandNotFoundFilter'),
-                'BOT_ALT_PREFIXES': ('!',),
-                'BOT_PREFIX': '$'}
+extra_plugin_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "room_plugin")
+extra_config = {
+    "CORE_PLUGINS": ("Help", "Utils", "CommandNotFoundFilter"), "BOT_ALT_PREFIXES": ("!",), "BOT_PREFIX": "$"
+}
 
 
 def test_help_is_still_here(testbot):
-    assert 'All commands' in testbot.exec_command('!help')
+    assert "All commands" in testbot.exec_command("!help")
 
 
 def test_backup_help_not_here(testbot):
-    assert 'That command is not defined.' in testbot.exec_command('!help backup')
+    assert "That command is not defined." in testbot.exec_command("!help backup")
 
 
 def test_backup_should_not_be_there(testbot):
-    assert 'Command "backup" not found.' in testbot.exec_command('!backup')
+    assert 'Command "backup" not found.' in testbot.exec_command("!backup")
 
 
 def test_echo_still_here(testbot):
-    assert 'toto' in testbot.exec_command('!echo toto')
+    assert "toto" in testbot.exec_command("!echo toto")
 
 
 def test_bot_prefix_replaced(testbot):
-    assert '$help - Returns a help string' in testbot.exec_command('$help')
+    assert "$help - Returns a help string" in testbot.exec_command("$help")

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -1,17 +1,16 @@
 """Test _admins_to_notify wrapper functionality"""
 import pytest
 
-
-extra_config = {'BOT_ADMINS_NOTIFICATIONS': 'zoni@localdomain'}
+extra_config = {"BOT_ADMINS_NOTIFICATIONS": "zoni@localdomain"}
 
 
 def test_admins_to_notify(testbot):
     """Test which admins will be notified"""
     notified_admins = testbot._bot._admins_to_notify()
-    assert 'zoni@localdomain' in notified_admins
+    assert "zoni@localdomain" in notified_admins
 
 
 def test_admins_not_notified(testbot):
     """Test which admins will not be notified"""
     notified_admins = testbot._bot._admins_to_notify()
-    assert 'gbin@local' not in notified_admins
+    assert "gbin@local" not in notified_admins

--- a/tests/dependencies_test.py
+++ b/tests/dependencies_test.py
@@ -1,58 +1,58 @@
 import os
 
-extra_plugin_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'dependent_plugins')
+extra_plugin_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "dependent_plugins")
 
 
 def test_if_all_loaded_by_default(testbot):
     plug_names = testbot.bot.plugin_manager.get_all_active_plugin_names()
-    assert 'Single' in plug_names
-    assert 'Parent1' in plug_names
-    assert 'Parent2' in plug_names
+    assert "Single" in plug_names
+    assert "Parent1" in plug_names
+    assert "Parent2" in plug_names
 
 
 def test_single_dependency(testbot):
     pm = testbot.bot.plugin_manager
-    for p in ('Single', 'Parent1', 'Parent2'):
+    for p in ("Single", "Parent1", "Parent2"):
         pm.deactivate_plugin_by_name(p)
 
     # everything should be gone
     plug_names = pm.get_all_active_plugin_names()
-    assert 'Single' not in plug_names
-    assert 'Parent1' not in plug_names
-    assert 'Parent2' not in plug_names
+    assert "Single" not in plug_names
+    assert "Parent1" not in plug_names
+    assert "Parent2" not in plug_names
 
-    pm.activate_plugin('Single')
+    pm.activate_plugin("Single")
 
     # it should have activated the dependent plugin 'Parent1' only
     plug_names = pm.get_all_active_plugin_names()
-    assert 'Single' in plug_names
-    assert 'Parent1' in plug_names
-    assert 'Parent2' not in plug_names
+    assert "Single" in plug_names
+    assert "Parent1" in plug_names
+    assert "Parent2" not in plug_names
 
 
 def test_double_dependency(testbot):
     pm = testbot.bot.plugin_manager
-    all = ('Double', 'Parent1', 'Parent2')
+    all = ("Double", "Parent1", "Parent2")
     for p in all:
         pm.deactivate_plugin_by_name(p)
 
-    pm.activate_plugin('Double')
+    pm.activate_plugin("Double")
     plug_names = pm.get_all_active_plugin_names()
     for p in all:
         assert p in plug_names
 
 
 def test_dependency_retrieval(testbot):
-    assert 'youpi' in testbot.exec_command('!depfunc')
+    assert "youpi" in testbot.exec_command("!depfunc")
 
 
 def test_direct_cicular_dependency(testbot):
     plug_names = testbot.bot.plugin_manager.get_all_active_plugin_names()
-    assert 'Circular1' not in plug_names
+    assert "Circular1" not in plug_names
 
 
 def test_indirect_cicular_dependency(testbot):
     plug_names = testbot.bot.plugin_manager.get_all_active_plugin_names()
-    assert 'Circular2' not in plug_names
-    assert 'Circular3' not in plug_names
-    assert 'Circular4' not in plug_names
+    assert "Circular2" not in plug_names
+    assert "Circular3" not in plug_names
+    assert "Circular4" not in plug_names

--- a/tests/dependent_plugins/parent1.py
+++ b/tests/dependent_plugins/parent1.py
@@ -2,5 +2,6 @@ from errbot import BotPlugin
 
 
 class Parent1(BotPlugin):
+
     def shared_function(self):
-        return 'youpi'
+        return "youpi"

--- a/tests/dependent_plugins/single.py
+++ b/tests/dependent_plugins/single.py
@@ -5,4 +5,4 @@ class Single(BotPlugin):
 
     @botcmd
     def depfunc(self, msg, args):
-        return self.get_plugin('Parent1').shared_function()
+        return self.get_plugin("Parent1").shared_function()

--- a/tests/dummy_plugin/dummy.py
+++ b/tests/dummy_plugin/dummy.py
@@ -1,24 +1,26 @@
 from __future__ import absolute_import
-from errbot import BotPlugin, botcmd, re_botcmd, botmatch
+
+from errbot import BotPlugin, botcmd, botmatch, re_botcmd
 
 
 class DummyTest(BotPlugin):
     """Just a test plugin to see if it is picked up.
     """
+
     @botcmd
     def foo(self, msg, args):
         """This runs foo."""
-        return 'bar'
+        return "bar"
 
     @re_botcmd(pattern=r"plz dont match this")
     def re_foo(self, msg, match):
         """This runs re_foo."""
-        return 'bar'
+        return "bar"
 
     @botmatch(r"match this")
     def re_bar(self, msg, match):
         """This runs re_foo."""
-        return 'bar'
+        return "bar"
 
     @botcmd
     def run_subcommands(self, msg, args):

--- a/tests/dyna_plugin/dyna.py
+++ b/tests/dyna_plugin/dyna.py
@@ -1,67 +1,70 @@
 from __future__ import absolute_import
-from errbot import BotPlugin, botcmd, Command, botmatch
+
+from errbot import BotPlugin, Command, botcmd, botmatch
 
 
 def say_foo(plugin, msg, args):
-    return 'foo %s' % type(plugin)
+    return "foo %s" % type(plugin)
 
 
 class Dyna(BotPlugin):
     """Just a test plugin to see if synamic plugin API works.
     """
+
     @botcmd
     def add_simple(self, _, _1):
-        simple1 = Command(lambda plugin, msg, args: 'yep %s' % type(plugin), name='say_yep')
+        simple1 = Command(lambda plugin, msg, args: "yep %s" % type(plugin), name="say_yep")
         simple2 = Command(say_foo)
 
-        self.create_dynamic_plugin('simple with special#', (simple1, simple2), doc='documented')
+        self.create_dynamic_plugin("simple with special#", (simple1, simple2), doc="documented")
 
-        return 'added'
+        return "added"
 
     @botcmd
     def remove_simple(self, msg, args):
-        self.destroy_dynamic_plugin('simple with special#')
-        return 'removed'
+        self.destroy_dynamic_plugin("simple with special#")
+        return "removed"
 
     @botcmd
     def add_re(self, _, _1):
-        re1 = Command(lambda plugin, msg, match: 'fffound',
-                      name='ffound',
-                      cmd_type=botmatch,
-                      cmd_args=(r'^.*cheese.*$',))
-        self.create_dynamic_plugin('re', (re1, ))
-        return 'added'
+        re1 = Command(
+            lambda plugin, msg, match: "fffound", name="ffound", cmd_type=botmatch, cmd_args=(r"^.*cheese.*$",)
+        )
+        self.create_dynamic_plugin("re", (re1,))
+        return "added"
 
     @botcmd
     def remove_re(self, msg, args):
-        self.destroy_dynamic_plugin('re')
-        return 'removed'
+        self.destroy_dynamic_plugin("re")
+        return "removed"
 
     @botcmd
     def add_saw(self, _, _1):
-        re1 = Command(lambda plugin, msg, args: '+'.join(args),
-                      name='splitme',
-                      cmd_type=botcmd,
-                      cmd_kwargs={'split_args_with': ','})
-        self.create_dynamic_plugin('saw', (re1, ))
-        return 'added'
+        re1 = Command(
+            lambda plugin, msg, args: "+".join(args),
+            name="splitme",
+            cmd_type=botcmd,
+            cmd_kwargs={"split_args_with": ","},
+        )
+        self.create_dynamic_plugin("saw", (re1,))
+        return "added"
 
     @botcmd
     def remove_saw(self, msg, args):
-        self.destroy_dynamic_plugin('saw')
-        return 'removed'
+        self.destroy_dynamic_plugin("saw")
+        return "removed"
 
     @botcmd
     def clash(self, msg, args):
-        return 'original'
+        return "original"
 
     @botcmd
     def add_clashing(self, _, _1):
-        simple1 = Command(lambda plugin, msg, args: 'dynamic', name='clash')
-        self.create_dynamic_plugin('clashing', (simple1, ))
-        return 'added'
+        simple1 = Command(lambda plugin, msg, args: "dynamic", name="clash")
+        self.create_dynamic_plugin("clashing", (simple1,))
+        return "added"
 
     @botcmd
     def remove_clashing(self, _, _1):
-        self.destroy_dynamic_plugin('clashing')
-        return 'removed'
+        self.destroy_dynamic_plugin("clashing")
+        return "removed"

--- a/tests/dynaplug_test.py
+++ b/tests/dynaplug_test.py
@@ -1,36 +1,37 @@
 from os import path
 
-extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), 'dyna_plugin')
+extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), "dyna_plugin")
 
 
 def test_simple(testbot):
-    assert 'added' in testbot.exec_command('!add_simple')
-    assert 'yep' in testbot.exec_command('!say_yep')
-    assert 'foo' in testbot.exec_command('!say_foo')
-    assert 'documented' in testbot.exec_command('!help')
-    assert 'removed' in testbot.exec_command('!remove_simple')
-    assert 'Command "say_foo" not found' in testbot.exec_command('!say_foo')
+    assert "added" in testbot.exec_command("!add_simple")
+    assert "yep" in testbot.exec_command("!say_yep")
+    assert "foo" in testbot.exec_command("!say_foo")
+    assert "documented" in testbot.exec_command("!help")
+    assert "removed" in testbot.exec_command("!remove_simple")
+    assert 'Command "say_foo" not found' in testbot.exec_command("!say_foo")
 
 
 def test_re(testbot):
-    assert 'added' in testbot.exec_command('!add_re')
-    assert 'fffound' in testbot.exec_command('I said cheese')
-    assert 'removed' in testbot.exec_command('!remove_re')
+    assert "added" in testbot.exec_command("!add_re")
+    assert "fffound" in testbot.exec_command("I said cheese")
+    assert "removed" in testbot.exec_command("!remove_re")
 
 
 def test_saw(testbot):
-    assert 'added' in testbot.exec_command('!add_saw')
-    assert 'foo+bar+baz' in testbot.exec_command('!splitme foo,bar,baz')
-    assert 'removed' in testbot.exec_command('!remove_saw')
+    assert "added" in testbot.exec_command("!add_saw")
+    assert "foo+bar+baz" in testbot.exec_command("!splitme foo,bar,baz")
+    assert "removed" in testbot.exec_command("!remove_saw")
 
 
 def test_clashing(testbot):
-    assert 'original' in testbot.exec_command('!clash')
-    assert 'clashing.clash clashes with Dyna.clash so it has been renamed clashing-clash' in \
-           testbot.exec_command('!add_clashing')
-    assert 'added' in testbot.pop_message()
-    assert 'original' in testbot.exec_command('!clash')
-    assert 'dynamic' in testbot.exec_command('!clashing-clash')
-    assert 'removed' in testbot.exec_command('!remove_clashing')
-    assert 'original' in testbot.exec_command('!clash')
-    assert 'not found' in testbot.exec_command('!clashing-clash')
+    assert "original" in testbot.exec_command("!clash")
+    assert "clashing.clash clashes with Dyna.clash so it has been renamed clashing-clash" in testbot.exec_command(
+        "!add_clashing"
+    )
+    assert "added" in testbot.pop_message()
+    assert "original" in testbot.exec_command("!clash")
+    assert "dynamic" in testbot.exec_command("!clashing-clash")
+    assert "removed" in testbot.exec_command("!remove_clashing")
+    assert "original" in testbot.exec_command("!clash")
+    assert "not found" in testbot.exec_command("!clashing-clash")

--- a/tests/fail_config_plugin/failp.py
+++ b/tests/fail_config_plugin/failp.py
@@ -5,8 +5,9 @@ class FailP(BotPlugin):
     """
     Just a plugin failing at config time.
     """
+
     def get_configuration_template(self):
-        return {'One': 1, 'Two': 2}
+        return {"One": 1, "Two": 2}
 
     def check_configuration(self, configuration):
-        raise ValidationException('Message explaining why it failed.')
+        raise ValidationException("Message explaining why it failed.")

--- a/tests/flow_e2e_test.py
+++ b/tests/flow_e2e_test.py
@@ -3,128 +3,128 @@ from queue import Empty
 
 import pytest
 
-extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), 'flow_plugin')
+extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), "flow_plugin")
 
 
 def test_list_flows(testbot):
     assert len(testbot.bot.flow_executor.flow_roots) == 4
-    testbot.bot.push_message('!flows list')
+    testbot.bot.push_message("!flows list")
     result = testbot.pop_message()
-    assert 'documentation of W1' in result
-    assert 'documentation of W2' in result
-    assert 'documentation of W3' in result
-    assert 'documentation of W4' in result
-    assert 'w1' in result
-    assert 'w2' in result
-    assert 'w3' in result
-    assert 'w4' in result
+    assert "documentation of W1" in result
+    assert "documentation of W2" in result
+    assert "documentation of W3" in result
+    assert "documentation of W4" in result
+    assert "w1" in result
+    assert "w2" in result
+    assert "w3" in result
+    assert "w4" in result
 
 
 def test_no_autotrigger(testbot):
-    assert 'a' in testbot.exec_command('!a')
+    assert "a" in testbot.exec_command("!a")
     assert len(testbot.bot.flow_executor.in_flight) == 0
 
 
 def test_autotrigger(testbot):
-    assert 'c' in testbot.exec_command('!c')
+    assert "c" in testbot.exec_command("!c")
     flow_message = testbot.pop_message()
-    assert 'You are in the flow w2, you can continue with' in flow_message
-    assert '!b' in flow_message
+    assert "You are in the flow w2, you can continue with" in flow_message
+    assert "!b" in flow_message
     assert len(testbot.bot.flow_executor.in_flight) == 1
-    assert testbot.bot.flow_executor.in_flight[0].name == 'w2'
+    assert testbot.bot.flow_executor.in_flight[0].name == "w2"
 
 
 def test_no_duplicate_autotrigger(testbot):
-    assert 'c' in testbot.exec_command('!c')
+    assert "c" in testbot.exec_command("!c")
     flow_message = testbot.pop_message()
-    assert 'You are in the flow w2, you can continue with' in flow_message
-    assert 'c' in testbot.exec_command('!c')
+    assert "You are in the flow w2, you can continue with" in flow_message
+    assert "c" in testbot.exec_command("!c")
     assert len(testbot.bot.flow_executor.in_flight) == 1
-    assert testbot.bot.flow_executor.in_flight[0].name == 'w2'
+    assert testbot.bot.flow_executor.in_flight[0].name == "w2"
 
 
 def test_secondary_autotrigger(testbot):
-    assert 'e' in testbot.exec_command('!e')
+    assert "e" in testbot.exec_command("!e")
     second_message = testbot.pop_message()
-    assert 'You are in the flow w2, you can continue with' in second_message
-    assert '!d' in second_message
+    assert "You are in the flow w2, you can continue with" in second_message
+    assert "!d" in second_message
     assert len(testbot.bot.flow_executor.in_flight) == 1
-    assert testbot.bot.flow_executor.in_flight[0].name == 'w2'
+    assert testbot.bot.flow_executor.in_flight[0].name == "w2"
 
 
 def test_manual_flow(testbot):
-    assert 'Flow w1 started' in testbot.exec_command('!flows start w1')
+    assert "Flow w1 started" in testbot.exec_command("!flows start w1")
     flow_message = testbot.pop_message()
-    assert 'You are in the flow w1, you can continue with' in flow_message
-    assert '!a' in flow_message
-    assert 'a' in testbot.exec_command('!a')
+    assert "You are in the flow w1, you can continue with" in flow_message
+    assert "!a" in flow_message
+    assert "a" in testbot.exec_command("!a")
     flow_message = testbot.pop_message()
-    assert 'You are in the flow w1, you can continue with' in flow_message
-    assert '!b' in flow_message
-    assert '!c' in flow_message
+    assert "You are in the flow w1, you can continue with" in flow_message
+    assert "!b" in flow_message
+    assert "!c" in flow_message
 
 
 def test_manual_flow_with_or_without_hinting(testbot):
-    assert 'Flow w4 started' in testbot.exec_command('!flows start w4')
-    assert 'a' in testbot.exec_command('!a')
-    assert 'b' in testbot.exec_command('!b')
+    assert "Flow w4 started" in testbot.exec_command("!flows start w4")
+    assert "a" in testbot.exec_command("!a")
+    assert "b" in testbot.exec_command("!b")
     flow_message = testbot.pop_message()
-    assert 'You are in the flow w4, you can continue with' in flow_message
-    assert '!c' in flow_message
+    assert "You are in the flow w4, you can continue with" in flow_message
+    assert "!c" in flow_message
 
 
 def test_no_flyby_trigger_flow(testbot):
-    testbot.bot.push_message('!flows start w1')
+    testbot.bot.push_message("!flows start w1")
     # One message or the other can arrive first.
     flow_message = testbot.pop_message()
-    assert 'Flow w1 started' in flow_message or 'You are in the flow w1' in flow_message
+    assert "Flow w1 started" in flow_message or "You are in the flow w1" in flow_message
     flow_message = testbot.pop_message()
-    assert 'Flow w1 started' in flow_message or 'You are in the flow w1' in flow_message
-    assert 'a' in testbot.exec_command('!a')
+    assert "Flow w1 started" in flow_message or "You are in the flow w1" in flow_message
+    assert "a" in testbot.exec_command("!a")
     flow_message = testbot.pop_message()
-    assert 'You are in the flow w1' in flow_message
+    assert "You are in the flow w1" in flow_message
 
-    assert 'c' in testbot.exec_command('!c')  # c is a trigger for w2 but it should not trigger now.
+    assert "c" in testbot.exec_command("!c")  # c is a trigger for w2 but it should not trigger now.
     flow_message = testbot.pop_message()
-    assert 'You are in the flow w1' in flow_message
+    assert "You are in the flow w1" in flow_message
     assert len(testbot.bot.flow_executor.in_flight) == 1
 
 
 def test_flow_only(testbot):
-    assert 'a' in testbot.exec_command('!a')  # non flow_only should respond.
-    testbot.push_message('!d')
+    assert "a" in testbot.exec_command("!a")  # non flow_only should respond.
+    testbot.push_message("!d")
     with pytest.raises(Empty):
         testbot.pop_message(timeout=1)
 
 
 def test_flow_only_help(testbot):
-    testbot.push_message('!help')
+    testbot.push_message("!help")
     msg = testbot.bot.pop_message()
-    assert '!a' in msg  # non flow_only should be in help by default
-    assert '!d' not in msg  # flow_only should not be in help by default
+    assert "!a" in msg  # non flow_only should be in help by default
+    assert "!d" not in msg  # flow_only should not be in help by default
 
 
 def test_flows_stop(testbot):
-    assert 'c' in testbot.exec_command('!c')
+    assert "c" in testbot.exec_command("!c")
     flow_message = testbot.bot.pop_message()
-    assert 'You are in the flow w2' in flow_message
-    assert 'w2 stopped' in testbot.exec_command('!flows stop w2')
+    assert "You are in the flow w2" in flow_message
+    assert "w2 stopped" in testbot.exec_command("!flows stop w2")
     assert len(testbot.bot.flow_executor.in_flight) == 0
 
 
 def test_flows_kill(testbot):
-    assert 'c' in testbot.exec_command('!c')
+    assert "c" in testbot.exec_command("!c")
     flow_message = testbot.bot.pop_message()
-    assert 'You are in the flow w2' in flow_message
-    assert 'w2 killed' in testbot.exec_command('!flows kill gbin@localhost w2')
+    assert "You are in the flow w2" in flow_message
+    assert "w2 killed" in testbot.exec_command("!flows kill gbin@localhost w2")
 
 
 def test_room_flow(testbot):
-    assert 'Flow w3 started' in testbot.exec_command('!flows start w3')
+    assert "Flow w3 started" in testbot.exec_command("!flows start w3")
     flow_message = testbot.pop_message()
-    assert 'You are in the flow w3, you can continue with' in flow_message
-    assert '!a' in flow_message
-    assert 'a' in testbot.exec_command('!a')
+    assert "You are in the flow w3, you can continue with" in flow_message
+    assert "!a" in flow_message
+    assert "a" in testbot.exec_command("!a")
     flow_message = testbot.pop_message()
-    assert 'You are in the flow w3, you can continue with' in flow_message
-    assert '!b' in flow_message
+    assert "You are in the flow w3, you can continue with" in flow_message
+    assert "!b" in flow_message

--- a/tests/flow_plugin/flowtest.py
+++ b/tests/flow_plugin/flowtest.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 from errbot import BotPlugin, botcmd
 
 
@@ -6,22 +7,23 @@ class FlowTest(BotPlugin):
     """A plugin to test the flows
     see flowtest.png for the structure.
     """
+
     @botcmd
     def a(self, msg, args):
-        return 'a'
+        return "a"
 
     @botcmd
     def b(self, msg, args):
-        return 'b'
+        return "b"
 
     @botcmd
     def c(self, msg, args):
-        return 'c'
+        return "c"
 
     @botcmd(flow_only=True)
     def d(self, msg, args):
-        return 'd'
+        return "d"
 
     @botcmd
     def e(self, msg, args):
-        return 'e'
+        return "e"

--- a/tests/flow_plugin/flowtest_flows.py
+++ b/tests/flow_plugin/flowtest_flows.py
@@ -1,18 +1,20 @@
 from __future__ import absolute_import
-from errbot import botflow, FlowRoot, BotFlow
+
+from errbot import BotFlow, FlowRoot, botflow
 
 
 class FlowDefinitions(BotFlow):
     """A plugin to test the flows
     see flowtest.png for the structure.
     """
+
     @botflow
     def w1(self, flow: FlowRoot):
         "documentation of W1"
-        a_node = flow.connect('a')   # no autotrigger
-        b_node = a_node.connect('b')
-        c_node = a_node.connect('c')  # crosses the autotrigger of w2
-        d_node = c_node.connect('d')
+        a_node = flow.connect("a")  # no autotrigger
+        b_node = a_node.connect("b")
+        c_node = a_node.connect("c")  # crosses the autotrigger of w2
+        d_node = c_node.connect("d")
 
         assert a_node.hints
         assert b_node.hints
@@ -22,24 +24,24 @@ class FlowDefinitions(BotFlow):
     @botflow
     def w2(self, flow: FlowRoot):
         """documentation of W2"""
-        c_node = flow.connect('c', auto_trigger=True)
-        b_node = c_node.connect('b')
-        e_node = flow.connect('e', auto_trigger=True)  # 2 autotriggers for the same workflow
-        d_node = e_node.connect('d')
+        c_node = flow.connect("c", auto_trigger=True)
+        b_node = c_node.connect("b")
+        e_node = flow.connect("e", auto_trigger=True)  # 2 autotriggers for the same workflow
+        d_node = e_node.connect("d")
 
     @botflow
     def w3(self, flow: FlowRoot):
         """documentation of W3"""
-        c_node = flow.connect('a', room_flow=True)
-        b_node = c_node.connect('b')
+        c_node = flow.connect("a", room_flow=True)
+        b_node = c_node.connect("b")
 
     @botflow
     def w4(self, flow: FlowRoot):
         """documentation of W4"""
-        a_node = flow.connect('a')
-        b_node = a_node.connect('b')
-        c_node = b_node.connect('c')
-        c_node.connect('d')
+        a_node = flow.connect("a")
+        b_node = a_node.connect("b")
+        c_node = b_node.connect("c")
+        c_node.connect("d")
 
         # set some hinting.
         flow.hints = False

--- a/tests/flow_test.py
+++ b/tests/flow_test.py
@@ -10,16 +10,16 @@ log = logging.getLogger(__name__)
 
 def test_node():
     root = FlowRoot("test", "This is my flowroot")
-    node = root.connect("a", lambda ctx: ctx['toto'] == 'titui')
+    node = root.connect("a", lambda ctx: ctx["toto"] == "titui")
 
-    assert root.predicate_for_node(node)({'toto': 'titui'})
-    assert not root.predicate_for_node(node)({'toto': 'blah'})
+    assert root.predicate_for_node(node)({"toto": "titui"})
+    assert not root.predicate_for_node(node)({"toto": "blah"})
 
 
 def test_flow_predicate():
     root = FlowRoot("test", "This is my flowroot")
-    node = root.connect("a", lambda ctx: 'toto' in ctx and ctx['toto'] == 'titui')
-    somebody = TestPerson('me')
+    node = root.connect("a", lambda ctx: "toto" in ctx and ctx["toto"] == "titui")
+    somebody = TestPerson("me")
 
     # Non-matching predicate
     flow = Flow(root, somebody, {})
@@ -32,7 +32,7 @@ def test_flow_predicate():
     assert flow._current_step == node
 
     # Matching predicate
-    flow = Flow(root, somebody, {'toto': 'titui'})
+    flow = Flow(root, somebody, {"toto": "titui"})
     assert node in flow.next_steps()
     assert node in flow.next_autosteps()
     flow.advance(node)
@@ -41,5 +41,5 @@ def test_flow_predicate():
 
 def test_autotrigger():
     root = FlowRoot("test", "This is my flowroot")
-    node = root.connect("a", lambda ctx: 'toto' in ctx and ctx['toto'] == 'titui', auto_trigger=True)
+    node = root.connect("a", lambda ctx: "toto" in ctx and ctx["toto"] == "titui", auto_trigger=True)
     assert node.command in root.auto_triggers

--- a/tests/i18n_plugin/i18n.py
+++ b/tests/i18n_plugin/i18n.py
@@ -5,18 +5,19 @@ from errbot import BotPlugin, botcmd
 class I18nTest(BotPlugin):
     """A Just a test plugin to see if it is picked up.
     """
+
     @botcmd
     def i18n_1(self, msg, args):
-        return 'язы́к'
+        return "язы́к"
 
-    @botcmd(name='ру́сский')
+    @botcmd(name="ру́сский")
     def i18n_2(self, msg, args):
-        return 'OK'
+        return "OK"
 
-    @botcmd(name='prefix_ру́сский')
+    @botcmd(name="prefix_ру́сский")
     def i18n_3(self, msg, args):
-        return 'OK'
+        return "OK"
 
-    @botcmd(name='ру́сский_suffix')
+    @botcmd(name="ру́сский_suffix")
     def i18n_4(self, msg, args):
-        return 'OK'
+        return "OK"

--- a/tests/i18n_test.py
+++ b/tests/i18n_test.py
@@ -1,23 +1,24 @@
 # -*- coding=utf-8 -*-
 from os import path
+
 # This is to test end2end i18n behavior.
 
-extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), 'i18n_plugin')
+extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), "i18n_plugin")
 
 
 def test_i18n_return(testbot):
-    assert 'язы́к' in testbot.exec_command('!i18n 1')
+    assert "язы́к" in testbot.exec_command("!i18n 1")
 
 
 def test_i18n_simple_name(testbot):
-    assert 'OK' in testbot.exec_command('!ру́сский')
+    assert "OK" in testbot.exec_command("!ру́сский")
 
 
 def test_i18n_prefix(testbot):
-    assert 'OK' in testbot.exec_command('!prefix_ру́сский')
-    assert 'OK' in testbot.exec_command('!prefix ру́сский')
+    assert "OK" in testbot.exec_command("!prefix_ру́сский")
+    assert "OK" in testbot.exec_command("!prefix ру́сский")
 
 
 def test_i18n_suffix(testbot):
-    assert 'OK' in testbot.exec_command('!ру́сский_suffix')
-    assert 'OK' in testbot.exec_command('!ру́сский suffix')
+    assert "OK" in testbot.exec_command("!ру́сский_suffix")
+    assert "OK" in testbot.exec_command("!ру́сский suffix")

--- a/tests/link_test.py
+++ b/tests/link_test.py
@@ -3,9 +3,9 @@ from os import path
 
 import pytest
 
-extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), 'test_link')
+extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), "test_link")
 
 
 def test_linked_plugin_here(testbot):
-    testbot.push_message('!status plugins')
-    assert 'Dummy' in testbot.pop_message()
+    testbot.push_message("!status plugins")
+    assert "Dummy" in testbot.pop_message()

--- a/tests/matchall_plugin/matchall.py
+++ b/tests/matchall_plugin/matchall.py
@@ -2,6 +2,7 @@ from errbot import BotPlugin, botmatch
 
 
 class MatchAll(BotPlugin):
+
     @botmatch(r".*")
     def all(self, msg, match):
-        return 'Works!'
+        return "Works!"

--- a/tests/matchall_test.py
+++ b/tests/matchall_test.py
@@ -3,12 +3,12 @@ from os import path
 
 import pytest
 
-extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), 'matchall_plugin')
+extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), "matchall_plugin")
 
 
 def test_botmatch_correct(testbot):
-    assert 'Works!' in testbot.exec_command('hi hi hi')
+    assert "Works!" in testbot.exec_command("hi hi hi")
 
 
 def test_botmatch(testbot):
-    assert 'Works!' in testbot.exec_command('123123')
+    assert "Works!" in testbot.exec_command("123123")

--- a/tests/md_rendering_test.py
+++ b/tests/md_rendering_test.py
@@ -1,5 +1,6 @@
 # vim: ts=4:sw=4
 import logging
+
 from errbot import rendering
 
 log = logging.getLogger(__name__)
@@ -24,6 +25,6 @@ def test_mde2md():
 
 def test_escaping():
     mdc = rendering.text()
-    original = '#not a title\n*not italic*\n`not code`\ntoto{not annotation}'
+    original = "#not a title\n*not italic*\n`not code`\ntoto{not annotation}"
     escaped = rendering.md_escape(original)
     assert original == mdc.convert(escaped)

--- a/tests/mention_plugin/mention.py
+++ b/tests/mention_plugin/mention.py
@@ -2,8 +2,9 @@ from errbot import BotPlugin
 
 
 class MentionTestPlugin(BotPlugin):
+
     def callback_mention(self, msg, people):
         if self.bot_identifier in people:
             self.send(msg.frm, "Somebody mentioned me!", msg)
             return
-        self.send(msg.frm, "Somebody mentioned %s!" % ','.join(p.person for p in people), msg)
+        self.send(msg.frm, "Somebody mentioned %s!" % ",".join(p.person for p in people), msg)

--- a/tests/mention_test.py
+++ b/tests/mention_test.py
@@ -1,15 +1,15 @@
 from os import path
 
-extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), 'mention_plugin')
+extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), "mention_plugin")
 
 
 def test_foreign_mention(testbot):
-    assert 'Somebody mentioned toto!' in testbot.exec_command('I am telling you something @toto')
+    assert "Somebody mentioned toto!" in testbot.exec_command("I am telling you something @toto")
 
 
 def test_testbot_mention(testbot):
-    assert 'Somebody mentioned me!' in testbot.exec_command('I am telling you something @Err')
+    assert "Somebody mentioned me!" in testbot.exec_command("I am telling you something @Err")
 
 
 def test_multiple_mentions(testbot):
-    assert 'Somebody mentioned toto,titi!' in testbot.exec_command('I am telling you something @toto and @titi')
+    assert "Somebody mentioned toto,titi!" in testbot.exec_command("I am telling you something @toto and @titi")

--- a/tests/muc_test.py
+++ b/tests/muc_test.py
@@ -1,18 +1,20 @@
+import logging
 import os
+
 import errbot.backends.base
 from errbot.backends.test import TestOccupant
-import logging
+
 log = logging.getLogger(__name__)
 
-extra_plugin_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'room_plugin')
+extra_plugin_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "room_plugin")
 
 
 def test_plugin_methods(testbot):
-    p = testbot.bot.plugin_manager.get_plugin_obj_by_name('ChatRoom')
+    p = testbot.bot.plugin_manager.get_plugin_obj_by_name("ChatRoom")
     assert p is not None
 
-    assert hasattr(p, 'rooms')
-    assert hasattr(p, 'query_room')
+    assert hasattr(p, "rooms")
+    assert hasattr(p, "query_room")
 
 
 def test_create_join_leave_destroy_lifecycle(testbot):  # noqa
@@ -23,7 +25,7 @@ def test_create_join_leave_destroy_lifecycle(testbot):  # noqa
     assert str(r1) == "testroom"
     assert issubclass(r1.__class__, errbot.backends.base.Room)
 
-    r2 = testbot.bot.query_room('testroom2')
+    r2 = testbot.bot.query_room("testroom2")
     assert not r2.exists
 
     r2.create()
@@ -42,7 +44,7 @@ def test_create_join_leave_destroy_lifecycle(testbot):  # noqa
     rooms = testbot.bot.rooms()
     assert r2 in rooms
 
-    r2 = testbot.bot.query_room('testroom2')
+    r2 = testbot.bot.query_room("testroom2")
     assert r2.joined
 
     r2.leave()
@@ -55,7 +57,7 @@ def test_create_join_leave_destroy_lifecycle(testbot):  # noqa
 def test_occupants(testbot):  # noqa
     room = testbot.bot.rooms()[0]
     assert len(room.occupants) == 1
-    assert TestOccupant('err', 'testroom') in room.occupants
+    assert TestOccupant("err", "testroom") in room.occupants
 
 
 def test_topic(testbot):  # noqa
@@ -68,30 +70,30 @@ def test_topic(testbot):  # noqa
 
 
 def test_plugin_callbacks(testbot):  # noqa
-    p = testbot.bot.plugin_manager.get_plugin_obj_by_name('RoomTest')
+    p = testbot.bot.plugin_manager.get_plugin_obj_by_name("RoomTest")
     assert p is not None
     p.purge()
 
     log.debug("query and join")
-    p.query_room('newroom').join()
+    p.query_room("newroom").join()
     assert p.events.get(timeout=5) == "callback_room_joined newroom"
 
-    p.query_room('newroom').topic = "Errbot rocks!"
+    p.query_room("newroom").topic = "Errbot rocks!"
     assert p.events.get(timeout=5) == "callback_room_topic Errbot rocks!"
 
-    p.query_room('newroom').leave()
+    p.query_room("newroom").leave()
     assert p.events.get(timeout=5) == "callback_room_left newroom"
 
 
 def test_botcommands(testbot):  # noqa
     rooms = testbot.bot.rooms()
-    room = testbot.bot.query_room('testroom')
+    room = testbot.bot.query_room("testroom")
     assert len(rooms) == 1
     assert rooms[0] == room
 
     assert room.joined
     assert "Left the room testroom" in testbot.exec_command("!room leave testroom")
-    room = testbot.bot.query_room('testroom')
+    room = testbot.bot.query_room("testroom")
     assert not room.joined
 
     assert "I'm not currently in any rooms." in testbot.exec_command("!room list")
@@ -99,20 +101,20 @@ def test_botcommands(testbot):  # noqa
     assert "Destroyed the room testroom" in testbot.exec_command("!room destroy testroom")
 
     rooms = testbot.bot.rooms()
-    room = testbot.bot.query_room('testroom')
+    room = testbot.bot.query_room("testroom")
     assert not room.exists
     assert room not in rooms
 
     assert "Created the room testroom" in testbot.exec_command("!room create testroom")
     rooms = testbot.bot.rooms()
-    room = testbot.bot.query_room('testroom')
+    room = testbot.bot.query_room("testroom")
     assert room.exists
     assert room not in rooms
     assert not room.joined
 
     assert "Joined the room testroom" in testbot.exec_command("!room join testroom")
     rooms = testbot.bot.rooms()
-    room = testbot.bot.query_room('testroom')
+    room = testbot.bot.query_room("testroom")
     assert room.exists
     assert room.joined
     assert room in rooms

--- a/tests/multi_plugin/mp.py
+++ b/tests/multi_plugin/mp.py
@@ -4,6 +4,7 @@ from errbot import BotPlugin, botcmd
 class WhateverName(BotPlugin):
     """Test plugin to verify that now class names don't matter.
     """
+
     @botcmd
     def myname(self, msg, args):
         return self.name

--- a/tests/multi_plugin_test.py
+++ b/tests/multi_plugin_test.py
@@ -1,14 +1,14 @@
 from os import path
 
-extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), 'multi_plugin')
+extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), "multi_plugin")
 
 # This tests the decorellation between plugin class names and real names
 # by making 2 instances of the same plugin collide on purpose.
 
 
 def test_first(testbot):
-    assert 'Multi1' == testbot.exec_command('!myname')
+    assert "Multi1" == testbot.exec_command("!myname")
 
 
 def test_first(testbot):
-    assert 'Multi2' == testbot.exec_command('!multi2-myname')
+    assert "Multi2" == testbot.exec_command("!multi2-myname")

--- a/tests/persistence_test.py
+++ b/tests/persistence_test.py
@@ -4,17 +4,17 @@ from errbot.storage.memory import MemoryStoragePlugin
 
 def test_simple_store_retreive():
     sm = StoreMixin()
-    sm.open_storage(MemoryStoragePlugin(None), 'ns')
-    sm['toto'] = 'titui'
-    assert sm['toto'] == 'titui'
+    sm.open_storage(MemoryStoragePlugin(None), "ns")
+    sm["toto"] = "titui"
+    assert sm["toto"] == "titui"
 
 
 def test_mutable():
     sm = StoreMixin()
-    sm.open_storage(MemoryStoragePlugin(None), 'ns')
-    sm['toto'] = [1, 3]
+    sm.open_storage(MemoryStoragePlugin(None), "ns")
+    sm["toto"] = [1, 3]
 
-    with sm.mutable('toto') as titi:
+    with sm.mutable("toto") as titi:
         titi[1] = 5
 
-    assert sm['toto'] == [1, 5]
+    assert sm["toto"] == [1, 5]

--- a/tests/plugin_config_fail_test.py
+++ b/tests/plugin_config_fail_test.py
@@ -1,8 +1,9 @@
 from os import path
 
-extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), 'fail_config_plugin')
+extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), "fail_config_plugin")
 
 
 def test_failed_config(testbot):
-    assert 'Incorrect plugin configuration: Message explaining why it failed.' \
-           in testbot.exec_command('!plugin config Failp {}')
+    assert "Incorrect plugin configuration: Message explaining why it failed." in testbot.exec_command(
+        "!plugin config Failp {}"
+    )

--- a/tests/plugin_config_test.py
+++ b/tests/plugin_config_test.py
@@ -1,59 +1,66 @@
 from os import path
-from errbot.botplugin import recurse_check_structure, ValidationException
+
 import pytest
 
-extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), 'config_plugin')
+from errbot.botplugin import ValidationException, recurse_check_structure
+
+extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), "config_plugin")
 
 
 def test_recurse_check_structure_valid():
-    sample = dict(string="Foobar", list=["Foo", "Bar"], dict={'foo': "Bar"}, none=None, true=True, false=False)
-    to_check = dict(string="Foobar", list=["Foo", "Bar", "Bas"], dict={'foo': "Bar"}, none=None, true=True,
-                    false=False)
+    sample = dict(string="Foobar", list=["Foo", "Bar"], dict={"foo": "Bar"}, none=None, true=True, false=False)
+    to_check = dict(string="Foobar", list=["Foo", "Bar", "Bas"], dict={"foo": "Bar"}, none=None, true=True, false=False)
     recurse_check_structure(sample, to_check)
 
 
 def test_recurse_check_structure_missingitem():
-    sample = dict(string="Foobar", list=["Foo", "Bar"], dict={'foo': "Bar"}, none=None, true=True, false=False)
-    to_check = dict(string="Foobar", list=["Foo", "Bar"], dict={'foo': "Bar"}, none=None, true=True)
+    sample = dict(string="Foobar", list=["Foo", "Bar"], dict={"foo": "Bar"}, none=None, true=True, false=False)
+    to_check = dict(string="Foobar", list=["Foo", "Bar"], dict={"foo": "Bar"}, none=None, true=True)
     with pytest.raises(ValidationException):
         recurse_check_structure(sample, to_check)
 
 
 def test_recurse_check_structure_extrasubitem():
-    sample = dict(string="Foobar", list=["Foo", "Bar"], dict={'foo': "Bar"}, none=None, true=True, false=False)
-    to_check = dict(string="Foobar", list=["Foo", "Bar", "Bas"], dict={'foo': "Bar", 'Bar': "Foo"}, none=None,
-                    true=True, false=False)
+    sample = dict(string="Foobar", list=["Foo", "Bar"], dict={"foo": "Bar"}, none=None, true=True, false=False)
+    to_check = dict(
+        string="Foobar",
+        list=["Foo", "Bar", "Bas"],
+        dict={"foo": "Bar", "Bar": "Foo"},
+        none=None,
+        true=True,
+        false=False,
+    )
     with pytest.raises(ValidationException):
         recurse_check_structure(sample, to_check)
 
 
 def test_recurse_check_structure_missingsubitem():
-    sample = dict(string="Foobar", list=["Foo", "Bar"], dict={'foo': "Bar"}, none=None, true=True, false=False)
+    sample = dict(string="Foobar", list=["Foo", "Bar"], dict={"foo": "Bar"}, none=None, true=True, false=False)
     to_check = dict(string="Foobar", list=["Foo", "Bar", "Bas"], dict={}, none=None, true=True, false=False)
     with pytest.raises(ValidationException):
         recurse_check_structure(sample, to_check)
 
 
 def test_recurse_check_structure_wrongtype_1():
-    sample = dict(string="Foobar", list=["Foo", "Bar"], dict={'foo': "Bar"}, none=None, true=True, false=False)
-    to_check = dict(string=None, list=["Foo", "Bar"], dict={'foo': "Bar"}, none=None, true=True, false=False)
+    sample = dict(string="Foobar", list=["Foo", "Bar"], dict={"foo": "Bar"}, none=None, true=True, false=False)
+    to_check = dict(string=None, list=["Foo", "Bar"], dict={"foo": "Bar"}, none=None, true=True, false=False)
     with pytest.raises(ValidationException):
         recurse_check_structure(sample, to_check)
 
 
 def test_recurse_check_structure_wrongtype_2():
-    sample = dict(string="Foobar", list=["Foo", "Bar"], dict={'foo': "Bar"}, none=None, true=True, false=False)
-    to_check = dict(string="Foobar", list={'foo': "Bar"}, dict={'foo': "Bar"}, none=None, true=True, false=False)
+    sample = dict(string="Foobar", list=["Foo", "Bar"], dict={"foo": "Bar"}, none=None, true=True, false=False)
+    to_check = dict(string="Foobar", list={"foo": "Bar"}, dict={"foo": "Bar"}, none=None, true=True, false=False)
     with pytest.raises(ValidationException):
         recurse_check_structure(sample, to_check)
 
 
 def test_recurse_check_structure_wrongtype_3():
-    sample = dict(string="Foobar", list=["Foo", "Bar"], dict={'foo': "Bar"}, none=None, true=True, false=False)
+    sample = dict(string="Foobar", list=["Foo", "Bar"], dict={"foo": "Bar"}, none=None, true=True, false=False)
     to_check = dict(string="Foobar", list=["Foo", "Bar"], dict=["Foo", "Bar"], none=None, true=True, false=False)
     with pytest.raises(ValidationException):
         recurse_check_structure(sample, to_check)
 
 
 def test_failed_config(testbot):
-    assert 'Plugin configuration done.' in testbot.exec_command('!plugin config Config {"One": "two"}')
+    assert "Plugin configuration done." in testbot.exec_command('!plugin config Config {"One": "two"}')

--- a/tests/plugin_management_test.py
+++ b/tests/plugin_management_test.py
@@ -3,50 +3,50 @@ import tempfile
 from configparser import ConfigParser
 
 from errbot import plugin_manager
-from errbot.utils import find_roots, collect_roots
+from errbot.utils import collect_roots, find_roots
 
 CORE_PLUGINS = plugin_manager.CORE_PLUGINS
 
 
 def touch(name):
-    with open(name, 'a'):
+    with open(name, "a"):
         os.utime(name, None)
 
 
 def test_check_dependencies():
-    response, deps = plugin_manager.check_dependencies(os.path.join(os.path.dirname(__file__),
-                                                                    'assets',
-                                                                    'requirements_never_there.txt'))
-    assert 'You need these dependencies for' in response
-    assert 'impossible_requirement' in response
-    assert ['impossible_requirement'] == deps
+    response, deps = plugin_manager.check_dependencies(
+        os.path.join(os.path.dirname(__file__), "assets", "requirements_never_there.txt")
+    )
+    assert "You need these dependencies for" in response
+    assert "impossible_requirement" in response
+    assert ["impossible_requirement"] == deps
 
 
 def test_check_dependencies_no_requirements_file():
-    response, deps = plugin_manager.check_dependencies(os.path.join(os.path.dirname(__file__),
-                                                                    'assets',
-                                                                    'requirements_non_existent.txt'))
+    response, deps = plugin_manager.check_dependencies(
+        os.path.join(os.path.dirname(__file__), "assets", "requirements_non_existent.txt")
+    )
     assert response is None
 
 
 def test_check_dependencies_requirements_file_all_installed():
-    response, deps = plugin_manager.check_dependencies(os.path.join(os.path.dirname(__file__),
-                                                                    'assets',
-                                                                    'requirements_already_there.txt'))
+    response, deps = plugin_manager.check_dependencies(
+        os.path.join(os.path.dirname(__file__), "assets", "requirements_already_there.txt")
+    )
     assert response is None
 
 
 def test_find_plugin_roots():
     root = tempfile.mkdtemp()
-    a = os.path.join(root, 'a')
-    b = os.path.join(a, 'b')
-    c = os.path.join(root, 'c')
+    a = os.path.join(root, "a")
+    b = os.path.join(a, "b")
+    c = os.path.join(root, "c")
     os.mkdir(a)
     os.mkdir(b)
     os.mkdir(c)
-    touch(os.path.join(a, 'toto.plug'))
-    touch(os.path.join(b, 'titi.plug'))
-    touch(os.path.join(root, 'tutu.plug'))
+    touch(os.path.join(a, "toto.plug"))
+    touch(os.path.join(b, "titi.plug"))
+    touch(os.path.join(root, "tutu.plug"))
     roots = find_roots(root)
     assert root in roots
     assert a in roots
@@ -56,78 +56,75 @@ def test_find_plugin_roots():
 
 def test_collect_roots():
     toto = tempfile.mkdtemp()
-    touch(os.path.join(toto, 'toto.plug'))
-    touch(os.path.join(toto, 'titi.plug'))
+    touch(os.path.join(toto, "toto.plug"))
+    touch(os.path.join(toto, "titi.plug"))
     titi = tempfile.mkdtemp()
-    touch(os.path.join(titi, 'tata.plug'))
+    touch(os.path.join(titi, "tata.plug"))
     tutu = tempfile.mkdtemp()
-    subtutu = os.path.join(tutu, 'subtutu')
+    subtutu = os.path.join(tutu, "subtutu")
     os.mkdir(subtutu)
-    touch(os.path.join(subtutu, 'tutu.plug'))
+    touch(os.path.join(subtutu, "tutu.plug"))
 
-    assert collect_roots((CORE_PLUGINS, None)) == {CORE_PLUGINS, }
+    assert collect_roots((CORE_PLUGINS, None)) == {CORE_PLUGINS}
     assert collect_roots((CORE_PLUGINS, toto)) == {CORE_PLUGINS, toto}
     assert collect_roots((CORE_PLUGINS, [toto, titi])) == {CORE_PLUGINS, toto, titi}
-    assert collect_roots((CORE_PLUGINS, toto, titi, 'nothing')) == {CORE_PLUGINS, toto, titi}
+    assert collect_roots((CORE_PLUGINS, toto, titi, "nothing")) == {CORE_PLUGINS, toto, titi}
     assert collect_roots((toto, tutu)) == {toto, subtutu}
 
 
 def test_ignore_dotted_directories():
     root = tempfile.mkdtemp()
-    a = os.path.join(root, '.invisible')
+    a = os.path.join(root, ".invisible")
     os.mkdir(a)
-    touch(os.path.join(a, 'toto.plug'))
-    assert collect_roots((CORE_PLUGINS, root)) == {CORE_PLUGINS, }
+    touch(os.path.join(a, "toto.plug"))
+    assert collect_roots((CORE_PLUGINS, root)) == {CORE_PLUGINS}
 
 
 def test_errbot_version_check():
     real_version = plugin_manager.VERSION
 
     too_high_min_1 = ConfigParser()
-    too_high_min_1.add_section('Errbot')
-    too_high_min_1.set('Errbot', 'Min', '1.6.0')
+    too_high_min_1.add_section("Errbot")
+    too_high_min_1.set("Errbot", "Min", "1.6.0")
 
     too_high_min_2 = ConfigParser()
-    too_high_min_2.add_section('Errbot')
-    too_high_min_2.set('Errbot', 'Min', '1.6.0')
-    too_high_min_2.set('Errbot', 'Max', '2.0.0')
+    too_high_min_2.add_section("Errbot")
+    too_high_min_2.set("Errbot", "Min", "1.6.0")
+    too_high_min_2.set("Errbot", "Max", "2.0.0")
 
     too_low_max_1 = ConfigParser()
-    too_low_max_1.add_section('Errbot')
-    too_low_max_1.set('Errbot', 'Max', '1.0.1-beta')
+    too_low_max_1.add_section("Errbot")
+    too_low_max_1.set("Errbot", "Max", "1.0.1-beta")
 
     too_low_max_2 = ConfigParser()
-    too_low_max_2.add_section('Errbot')
-    too_low_max_2.set('Errbot', 'Min', '0.9.0-rc2')
-    too_low_max_2.set('Errbot', 'Max', '1.0.1-beta')
+    too_low_max_2.add_section("Errbot")
+    too_low_max_2.set("Errbot", "Min", "0.9.0-rc2")
+    too_low_max_2.set("Errbot", "Max", "1.0.1-beta")
 
     ok1 = ConfigParser()  # no section
 
     ok2 = ConfigParser()
-    ok2.add_section('Errbot')  # empty section
+    ok2.add_section("Errbot")  # empty section
 
     ok3 = ConfigParser()
-    ok3.add_section('Errbot')
-    ok3.set('Errbot', 'Min', '1.4.0')
+    ok3.add_section("Errbot")
+    ok3.set("Errbot", "Min", "1.4.0")
 
     ok4 = ConfigParser()
-    ok4.add_section('Errbot')
-    ok4.set('Errbot', 'Max', '1.5.2')
+    ok4.add_section("Errbot")
+    ok4.set("Errbot", "Max", "1.5.2")
 
     ok5 = ConfigParser()
-    ok5.add_section('Errbot')
-    ok5 .set('Errbot', 'Min', '1.2.1')
-    ok5 .set('Errbot', 'Max', '1.6.1-rc1')
+    ok5.add_section("Errbot")
+    ok5.set("Errbot", "Min", "1.2.1")
+    ok5.set("Errbot", "Max", "1.6.1-rc1")
 
     try:
-        plugin_manager.VERSION = '1.5.2'
-        for config in (too_high_min_1,
-                       too_high_min_2,
-                       too_low_max_1,
-                       too_low_max_2):
-            assert not plugin_manager.check_errbot_plug_section('should_fail', config)
+        plugin_manager.VERSION = "1.5.2"
+        for config in (too_high_min_1, too_high_min_2, too_low_max_1, too_low_max_2):
+            assert not plugin_manager.check_errbot_plug_section("should_fail", config)
 
         for config in (ok1, ok2, ok3, ok4, ok5):
-            assert plugin_manager.check_errbot_plug_section('should_work', config)
+            assert plugin_manager.check_errbot_plug_section("should_work", config)
     finally:
         plugin_manager.VERSION = real_version

--- a/tests/poller_plugin/poller_plugin.py
+++ b/tests/poller_plugin/poller_plugin.py
@@ -1,26 +1,25 @@
 from __future__ import absolute_import
+
 from errbot import BotPlugin, botcmd
 
 
 class PollerPlugin(BotPlugin):
 
     def delayed_hello(self, frm):
-        self.send(frm, 'Hello world! was sent 5 seconds ago')
+        self.send(frm, "Hello world! was sent 5 seconds ago")
 
     @botcmd
     def hello(self, msg, args):
         """Say hello to the world."""
-        self.start_poller(0.1, self.delayed_hello, times=1,
-                          kwargs={'frm': msg.frm})
+        self.start_poller(0.1, self.delayed_hello, times=1, kwargs={"frm": msg.frm})
         return "Hello, world!"
 
     def delayed_hello_loop(self, frm):
-        self.send(frm, 'Hello world! was sent 5 seconds ago')
-        self.stop_poller(self.delayed_hello_loop, args=(frm, ))
+        self.send(frm, "Hello world! was sent 5 seconds ago")
+        self.stop_poller(self.delayed_hello_loop, args=(frm,))
 
     @botcmd
     def hello_loop(self, msg, args):
         """Say hello to the world."""
-        self.start_poller(0.1, self.delayed_hello_loop,
-                          args=(msg.frm, ))
+        self.start_poller(0.1, self.delayed_hello_loop, args=(msg.frm,))
         return "Hello, world!"

--- a/tests/poller_test.py
+++ b/tests/poller_test.py
@@ -1,23 +1,23 @@
-from os import path
 import time
+from os import path
 
 CURRENT_FILE_DIR = path.dirname(path.realpath(__file__))
-extra_plugin_dir = path.join(CURRENT_FILE_DIR, 'poller_plugin')
+extra_plugin_dir = path.join(CURRENT_FILE_DIR, "poller_plugin")
 
 
 def test_delayed_hello(testbot):
-    assert 'Hello, world!' in testbot.exec_command('!hello')
+    assert "Hello, world!" in testbot.exec_command("!hello")
     time.sleep(1)
-    delayed_msg = 'Hello world! was sent 5 seconds ago'
+    delayed_msg = "Hello world! was sent 5 seconds ago"
     assert delayed_msg in testbot.pop_message(timeout=1)
     # Assert that only one message has been enqueued
     assert testbot.bot.outgoing_message_queue.empty()
 
 
 def test_delayed_hello_loop(testbot):
-    assert 'Hello, world!' in testbot.exec_command('!hello_loop')
+    assert "Hello, world!" in testbot.exec_command("!hello_loop")
     time.sleep(1)
-    delayed_msg = 'Hello world! was sent 5 seconds ago'
+    delayed_msg = "Hello world! was sent 5 seconds ago"
     assert delayed_msg in testbot.pop_message(timeout=1)
     # Assert that only one message has been enqueued
     assert testbot.bot.outgoing_message_queue.empty()

--- a/tests/repo_manager_test.py
+++ b/tests/repo_manager_test.py
@@ -1,78 +1,74 @@
-import tempfile
-import shutil
 import os
+import shutil
+import tempfile
 
 import pytest
 
 from errbot import repo_manager
 from errbot.storage.memory import MemoryStoragePlugin
 
-assets = os.path.join(os.path.dirname(__file__), 'assets')
+assets = os.path.join(os.path.dirname(__file__), "assets")
 
 
 @pytest.fixture
 def plugdir_and_storage(request):
     plugins_dir = tempfile.mkdtemp()
-    storage_plugin = MemoryStoragePlugin('repomgr')
+    storage_plugin = MemoryStoragePlugin("repomgr")
 
     def on_finish():
         shutil.rmtree(plugins_dir)
+
     request.addfinalizer(on_finish)
     return plugins_dir, storage_plugin
 
 
 def test_index_population(plugdir_and_storage):
     plugdir, storage = plugdir_and_storage
-    manager = repo_manager.BotRepoManager(storage,
-                                          plugdir,
-                                          (os.path.join(assets, 'repos', 'simple.json'),))
+    manager = repo_manager.BotRepoManager(storage, plugdir, (os.path.join(assets, "repos", "simple.json"),))
     manager.index_update()
 
     index_entry = manager[repo_manager.REPO_INDEX]
 
     assert repo_manager.LAST_UPDATE in index_entry
-    assert 'pluginname1' in index_entry['name1/err-reponame1']
-    assert 'pluginname2' in index_entry['name2/err-reponame2']
+    assert "pluginname1" in index_entry["name1/err-reponame1"]
+    assert "pluginname2" in index_entry["name2/err-reponame2"]
 
 
 def test_index_merge(plugdir_and_storage):
     plugdir, storage = plugdir_and_storage
-    manager = repo_manager.BotRepoManager(storage,
-                                          plugdir,
-                                          (os.path.join(assets, 'repos', 'b.json'),
-                                           os.path.join(assets, 'repos', 'a.json'),))
+    manager = repo_manager.BotRepoManager(
+        storage, plugdir, (os.path.join(assets, "repos", "b.json"), os.path.join(assets, "repos", "a.json"))
+    )
     manager.index_update()
 
     index_entry = manager[repo_manager.REPO_INDEX]
 
     # First they should be all here
-    assert 'pluginname1' in index_entry['name1/err-reponame1']
-    assert 'pluginname2' in index_entry['name2/err-reponame2']
-    assert 'pluginname3' in index_entry['name3/err-reponame3']
+    assert "pluginname1" in index_entry["name1/err-reponame1"]
+    assert "pluginname2" in index_entry["name2/err-reponame2"]
+    assert "pluginname3" in index_entry["name3/err-reponame3"]
 
     # then it must be the correct one of the overriden one
 
-    assert index_entry['name2/err-reponame2']['pluginname2']['name'] == 'NewPluginName2'
+    assert index_entry["name2/err-reponame2"]["pluginname2"]["name"] == "NewPluginName2"
 
 
 def test_reverse_merge(plugdir_and_storage):
     plugdir, storage = plugdir_and_storage
-    manager = repo_manager.BotRepoManager(storage,
-                                          plugdir,
-                                          (os.path.join(assets, 'repos', 'a.json'),
-                                           os.path.join(assets, 'repos', 'b.json'),))
+    manager = repo_manager.BotRepoManager(
+        storage, plugdir, (os.path.join(assets, "repos", "a.json"), os.path.join(assets, "repos", "b.json"))
+    )
     manager.index_update()
 
     index_entry = manager[repo_manager.REPO_INDEX]
-    assert not index_entry['name2/err-reponame2']['pluginname2']['name'] == 'NewPluginName2'
+    assert not index_entry["name2/err-reponame2"]["pluginname2"]["name"] == "NewPluginName2"
 
 
 def test_no_update_if_one_fails(plugdir_and_storage):
     plugdir, storage = plugdir_and_storage
-    manager = repo_manager.BotRepoManager(storage,
-                                          plugdir,
-                                          (os.path.join(assets, 'repos', 'a.json'),
-                                           os.path.join(assets, 'repos', 'doh.json'),))
+    manager = repo_manager.BotRepoManager(
+        storage, plugdir, (os.path.join(assets, "repos", "a.json"), os.path.join(assets, "repos", "doh.json"))
+    )
     manager.index_update()
     assert repo_manager.REPO_INDEX not in manager
 
@@ -84,47 +80,46 @@ def test_tokenization():
         "path": "/plugin1.plug",
         "avatar_url": "https://avatars.githubusercontent.com/u/588833?v=3",
         "name": "PluginName1",
-        "documentation": "docs1"
+        "documentation": "docs1",
     }
     words = {
-        'https',
-        'com',
-        'name',
-        'err',
-        'docs1',
-        'reponame1',
-        'plug',
-        '2',
-        'plugin1',
-        'avatars',
-        'github',
-        'githubusercontent',
-        'u',
-        'v',
-        '3',
-        '588833',
-        'pluginname1'
+        "https",
+        "com",
+        "name",
+        "err",
+        "docs1",
+        "reponame1",
+        "plug",
+        "2",
+        "plugin1",
+        "avatars",
+        "github",
+        "githubusercontent",
+        "u",
+        "v",
+        "3",
+        "588833",
+        "pluginname1",
     }
     assert repo_manager.tokenizeJsonEntry(e) == words
 
 
 def test_search(plugdir_and_storage):
     plugdir, storage = plugdir_and_storage
-    manager = repo_manager.BotRepoManager(storage,
-                                          plugdir,
-                                          (os.path.join(assets, 'repos', 'simple.json'),))
+    manager = repo_manager.BotRepoManager(storage, plugdir, (os.path.join(assets, "repos", "simple.json"),))
 
-    a = [p for p in manager.search_repos('docs2')]
+    a = [p for p in manager.search_repos("docs2")]
     assert len(a) == 1
-    assert a[0].name == 'pluginname2'
+    assert a[0].name == "pluginname2"
 
-    a = [p for p in manager.search_repos('zorg')]
+    a = [p for p in manager.search_repos("zorg")]
     assert len(a) == 0
 
-    a = [p for p in manager.search_repos('plug')]
+    a = [p for p in manager.search_repos("plug")]
     assert len(a) == 2
 
 
 def test_git_url_name_guessing():
-    assert repo_manager.human_name_for_git_url('https://github.com/errbotio/err-imagebot.git') \
-        == 'errbotio/err-imagebot'
+    assert (
+        repo_manager.human_name_for_git_url("https://github.com/errbotio/err-imagebot.git") == "errbotio/err-imagebot"
+    )

--- a/tests/room_plugin/roomtest.py
+++ b/tests/room_plugin/roomtest.py
@@ -1,6 +1,8 @@
-from errbot import BotPlugin
-from queue import Queue
 import logging
+from queue import Queue
+
+from errbot import BotPlugin
+
 log = logging.getLogger(__name__)
 
 

--- a/tests/simple_identifiers_test.py
+++ b/tests/simple_identifiers_test.py
@@ -1,4 +1,4 @@
-from errbot.backends.test import TestPerson, TestOccupant
+from errbot.backends.test import TestOccupant, TestPerson
 
 
 def test_identifier_eq():

--- a/tests/streaming_test.py
+++ b/tests/streaming_test.py
@@ -1,16 +1,18 @@
 from io import BytesIO
+
+from errbot.backends.base import Stream
 from errbot.backends.test import TestPerson
 from errbot.streaming import Tee
-from errbot.backends.base import Stream
 
 
 class StreamingClient(object):
+
     def callback_stream(self, stream):
         self.response = stream.read()
 
 
 def test_streaming():
-    canary = b'this is my test' * 1000
+    canary = b"this is my test" * 1000
     source = Stream(TestPerson("gbin@gootz.net"), BytesIO(canary))
     clients = [StreamingClient() for _ in range(50)]
     Tee(source, clients).run()

--- a/tests/syntax_plugin/test.py
+++ b/tests/syntax_plugin/test.py
@@ -1,15 +1,17 @@
 from __future__ import absolute_import
-from errbot import BotPlugin, botcmd, re_botcmd, arg_botcmd
+
+from errbot import BotPlugin, arg_botcmd, botcmd, re_botcmd
 
 
 class Test(BotPlugin):
     """Just a test plugin to see if _err_botcmd_syntax is consistent on all types of botcmd
     """
-    @botcmd     # no syntax
+
+    @botcmd  # no syntax
     def foo_nosyntax(self, msg, args):
         pass
 
-    @botcmd(syntax='[optional] <mandatory>')
+    @botcmd(syntax="[optional] <mandatory>")
     def foo(self, msg, args):
         pass
 
@@ -17,7 +19,7 @@ class Test(BotPlugin):
     def re_foo(self, msg, match):
         pass
 
-    @arg_botcmd('value', type=str)
-    @arg_botcmd('--repeat-count', dest='repeat', type=int, default=2)
+    @arg_botcmd("value", type=str)
+    @arg_botcmd("--repeat-count", dest="repeat", type=int, default=2)
     def arg_foo(self, msg, value=None, repeat=None):
         return value * repeat

--- a/tests/syntax_test.py
+++ b/tests/syntax_test.py
@@ -1,19 +1,19 @@
 from os import path
 
-extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), 'syntax_plugin')
+extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), "syntax_plugin")
 
 
 def test_nosyntax(testbot):
-    assert testbot.bot.commands['foo_nosyntax']._err_command_syntax is None
+    assert testbot.bot.commands["foo_nosyntax"]._err_command_syntax is None
 
 
 def test_syntax(testbot):
-    assert testbot.bot.commands['foo']._err_command_syntax == '[optional] <mandatory>'
+    assert testbot.bot.commands["foo"]._err_command_syntax == "[optional] <mandatory>"
 
 
 def test_re_syntax(testbot):
-    assert testbot.bot.re_commands['re_foo']._err_command_syntax == '.*'
+    assert testbot.bot.re_commands["re_foo"]._err_command_syntax == ".*"
 
 
 def test_arg_syntax(testbot):
-    assert testbot.bot.commands['arg_foo']._err_command_syntax == '[-h] [--repeat-count REPEAT] value'
+    assert testbot.bot.commands["arg_foo"]._err_command_syntax == "[-h] [--repeat-count REPEAT] value"

--- a/tests/template_plugin/test.py
+++ b/tests/template_plugin/test.py
@@ -1,20 +1,22 @@
 from __future__ import absolute_import
-from errbot import BotPlugin, botcmd, re_botcmd, arg_botcmd
+
+from errbot import BotPlugin, arg_botcmd, botcmd, re_botcmd
 
 
 class Test(BotPlugin):
+
     @botcmd
     def test_template1(self, msg, args):
-        self.send_templated(msg.frm, 'test', {'variable': 'ok'})
+        self.send_templated(msg.frm, "test", {"variable": "ok"})
 
-    @botcmd(template='test')
+    @botcmd(template="test")
     def test_template2(self, msg, args):
-        return {'variable': 'ok'}
+        return {"variable": "ok"}
 
-    @botcmd(template='test')
+    @botcmd(template="test")
     def test_template3(self, msg, args):
-        yield {'variable': 'ok'}
+        yield {"variable": "ok"}
 
-    @arg_botcmd('my_var', type=str, template='test')
+    @arg_botcmd("my_var", type=str, template="test")
     def test_template4(self, msg, my_var=None):
-        return {'variable': my_var}
+        return {"variable": my_var}

--- a/tests/templates_test.py
+++ b/tests/templates_test.py
@@ -2,24 +2,24 @@ from os import path
 
 # This is to test end2end i18n behavior.
 
-extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), 'template_plugin')
+extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), "template_plugin")
 
 
 def test_templates_1(testbot):
-    assert 'ok' in testbot.exec_command('!test template1')
+    assert "ok" in testbot.exec_command("!test template1")
 
 
 def test_templates_2(testbot):
-    assert 'ok' in testbot.exec_command('!test template2')
+    assert "ok" in testbot.exec_command("!test template2")
 
 
 def test_templates_3(testbot):
-    assert 'ok' in testbot.exec_command('!test template3')
+    assert "ok" in testbot.exec_command("!test template3")
 
 
 def test_templates_4(testbot):
-    assert 'ok' in testbot.exec_command('!test template4 ok')
+    assert "ok" in testbot.exec_command("!test template4 ok")
 
 
 def test_templates_5(testbot):
-    assert 'the following arguments are required: my_var' in testbot.exec_command('!test template4')
+    assert "the following arguments are required: my_var" in testbot.exec_command("!test template4")

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,39 +1,37 @@
 # coding=utf-8
 from datetime import timedelta
+
 import pytest
 
 from errbot.backends.test import ShallowConfig
 from errbot.bootstrap import CORE_STORAGE, bot_config_defaults
 from errbot.specific_plugin_manager import SpecificPluginManager
+from errbot.storage import StoreMixin
 from errbot.storage.base import StoragePluginBase
 from errbot.utils import *
-from errbot.storage import StoreMixin
 
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.parametrize('v1,v2', [
-                         ('2.0.0', '2.0.1'),
-                         ('2.0.0', '2.1.0'),
-                         ('2.0.0', '3.0.0'),
-                         ('2.0.0-alpha', '2.0.0-beta'),
-                         ('2.0.0-beta', '2.0.0-rc1'),
-                         ('2.0.0-rc1', '2.0.0-rc2'),
-                         ('2.0.0-rc2', '2.0.0-rc3'),
-                         ('2.0.0-rc2', '2.0.0'),
-                         ('2.0.0-beta', '2.0.1'),
-                         ])
+@pytest.mark.parametrize(
+    "v1,v2",
+    [
+        ("2.0.0", "2.0.1"),
+        ("2.0.0", "2.1.0"),
+        ("2.0.0", "3.0.0"),
+        ("2.0.0-alpha", "2.0.0-beta"),
+        ("2.0.0-beta", "2.0.0-rc1"),
+        ("2.0.0-rc1", "2.0.0-rc2"),
+        ("2.0.0-rc2", "2.0.0-rc3"),
+        ("2.0.0-rc2", "2.0.0"),
+        ("2.0.0-beta", "2.0.1"),
+    ],
+)
 def test_version_check(v1, v2):
     assert version2array(v1) < version2array(v2)
 
 
-@pytest.mark.parametrize('version', [
-                         '1.2.3.4',
-                         '1.2',
-                         '1.2.-beta',
-                         '1.2.3-toto',
-                         '1.2.3-rc',
-                         ])
+@pytest.mark.parametrize("version", ["1.2.3.4", "1.2", "1.2.-beta", "1.2.3-toto", "1.2.3-rc"])
 def test_version_check_negative(version):
     with pytest.raises(ValueError):
         version2array(version)
@@ -41,28 +39,28 @@ def test_version_check_negative(version):
 
 def test_formattimedelta():
     td = timedelta(0, 60 * 60 + 13 * 60)
-    assert '1 hours and 13 minutes' == format_timedelta(td)
+    assert "1 hours and 13 minutes" == format_timedelta(td)
 
 
 def unescape_test():
-    assert unescape_xml('&#32;') == ' '
+    assert unescape_xml("&#32;") == " "
 
 
 def test_storage():
-    key = 'test'
+    key = "test"
 
-    __import__('errbot.config-template')
+    __import__("errbot.config-template")
     config = ShallowConfig()
-    config.__dict__.update(sys.modules['errbot.config-template'].__dict__)
+    config.__dict__.update(sys.modules["errbot.config-template"].__dict__)
     bot_config_defaults(config)
 
-    spm = SpecificPluginManager(config, 'storage', StoragePluginBase, CORE_STORAGE, None)
-    storage_plugin = spm.get_plugin_by_name('Memory')
+    spm = SpecificPluginManager(config, "storage", StoragePluginBase, CORE_STORAGE, None)
+    storage_plugin = spm.get_plugin_by_name("Memory")
 
     persistent_object = StoreMixin()
-    persistent_object.open_storage(storage_plugin, 'test')
-    persistent_object[key] = 'à value'
-    assert persistent_object[key] == 'à value'
+    persistent_object.open_storage(storage_plugin, "test")
+    persistent_object[key] = "à value"
+    assert persistent_object[key] == "à value"
     assert key in persistent_object
     del persistent_object[key]
     assert key not in persistent_object
@@ -70,28 +68,28 @@ def test_storage():
 
 
 def test_split_string_after_returns_original_string_when_chunksize_equals_string_size():
-    str_ = 'foobar2000' * 2
+    str_ = "foobar2000" * 2
     splitter = split_string_after(str_, len(str_))
     split = [chunk for chunk in splitter]
     assert [str_] == split
 
 
 def test_split_string_after_returns_original_string_when_chunksize_equals_string_size_plus_one():
-    str_ = 'foobar2000' * 2
+    str_ = "foobar2000" * 2
     splitter = split_string_after(str_, len(str_) + 1)
     split = [chunk for chunk in splitter]
     assert [str_] == split
 
 
 def test_split_string_after_returns_two_chunks_when_chunksize_equals_string_size_minus_one():
-    str_ = 'foobar2000' * 2
+    str_ = "foobar2000" * 2
     splitter = split_string_after(str_, len(str_) - 1)
     split = [chunk for chunk in splitter]
-    assert ['foobar2000foobar200', '0'] == split
+    assert ["foobar2000foobar200", "0"] == split
 
 
 def test_split_string_after_returns_two_chunks_when_chunksize_equals_half_length_of_string():
-    str_ = 'foobar2000' * 2
+    str_ = "foobar2000" * 2
     splitter = split_string_after(str_, int(len(str_) / 2))
     split = [chunk for chunk in splitter]
-    assert ['foobar2000', 'foobar2000'] == split
+    assert ["foobar2000", "foobar2000"] == split

--- a/tests/webhooks_plugin/webtest.py
+++ b/tests/webhooks_plugin/webtest.py
@@ -1,33 +1,35 @@
 import logging
+
+from bottle import abort, response
 from errbot import BotPlugin
 from errbot.core_plugins.webserver import webhook
-from bottle import abort, response
 
 log = logging.getLogger(__name__)
 
 
 class WebTest(BotPlugin):
+
     @webhook
     def webhook1(self, payload):
         log.debug(str(payload))
         return str(payload)
 
-    @webhook(r'/custom_webhook')
+    @webhook(r"/custom_webhook")
     def webhook2(self, payload):
         log.debug(str(payload))
         return str(payload)
 
-    @webhook(r'/form', form_param='form')
+    @webhook(r"/form", form_param="form")
     def webhook3(self, payload):
         log.debug(str(payload))
         return str(payload)
 
-    @webhook(r'/custom_form', form_param='form')
+    @webhook(r"/custom_form", form_param="form")
     def webhook4(self, payload):
         log.debug(str(payload))
         return str(payload)
 
-    @webhook(r'/raw', raw=True)
+    @webhook(r"/raw", raw=True)
     def webhook5(self, payload):
         log.debug(str(payload))
         return str(type(payload))
@@ -42,7 +44,7 @@ class WebTest(BotPlugin):
     def webhook7(self, payload):
         abort(403, "Forbidden")
 
-    webhook8 = webhook(r'/lambda')(lambda x, y: str(x) + str(y))
+    webhook8 = webhook(r"/lambda")(lambda x, y: str(x) + str(y))
 
     # Just to test https://github.com/errbotio/errbot/issues/1043
     @webhook(raw=True)

--- a/tests/webhooks_test.py
+++ b/tests/webhooks_test.py
@@ -1,16 +1,17 @@
 import json
 import logging
 import os
+import socket
+from time import sleep
 
 import pytest
 import requests
-import socket
+
 from errbot.backends.test import FullStackTest, testbot
-from time import sleep
 
 log = logging.getLogger(__name__)
 
-PYTHONOBJECT = ['foo', {'bar': ('baz', None, 1.0, 2)}]
+PYTHONOBJECT = ["foo", {"bar": ("baz", None, 1.0, 2)}]
 JSONOBJECT = json.dumps(PYTHONOBJECT)
 # Webserver port is picked based on the process ID so that when tests
 # are run in parallel with pytest-xdist, each process runs the server
@@ -30,26 +31,27 @@ def webserver_ready(host, port):
         return False
 
 
-extra_plugin_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'webhooks_plugin')
+extra_plugin_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "webhooks_plugin")
 
 
 @pytest.fixture
 def webhook_testbot(request):
     tbot = testbot(request)
-    tbot.push_message("!plugin config Webserver " +
-                      "{{'HOST': 'localhost', 'PORT': {}, 'SSL':  None}}".format(WEBSERVER_PORT))
+    tbot.push_message(
+        "!plugin config Webserver " + "{{'HOST': 'localhost', 'PORT': {}, 'SSL':  None}}".format(WEBSERVER_PORT)
+    )
     tbot.pop_message()
-    while not webserver_ready('localhost', WEBSERVER_PORT):
+    while not webserver_ready("localhost", WEBSERVER_PORT):
         log.debug("Webserver not ready yet, sleeping 0.1 second")
         sleep(0.1)
     return tbot
 
 
 def test_not_configured_url_returns_404(webhook_testbot):
-    assert requests.post(
-        'http://localhost:{}/randomness_blah'.format(WEBSERVER_PORT),
-        "{'toto': 'titui'}"
-    ).status_code == 404
+    assert (
+        requests.post("http://localhost:{}/randomness_blah".format(WEBSERVER_PORT), "{'toto': 'titui'}").status_code
+        == 404
+    )
 
 
 def test_webserver_plugin_ok(webhook_testbot):
@@ -57,77 +59,75 @@ def test_webserver_plugin_ok(webhook_testbot):
 
 
 def test_trailing_no_slash_ok(webhook_testbot):
-    assert requests.post(
-        'http://localhost:{}/echo'.format(WEBSERVER_PORT),
-        JSONOBJECT
-    ).text == repr(json.loads(JSONOBJECT))
+    assert (
+        requests.post("http://localhost:{}/echo".format(WEBSERVER_PORT), JSONOBJECT).text
+        == repr(json.loads(JSONOBJECT))
+    )
 
 
 def test_trailing_slash_also_ok(webhook_testbot):
-    assert requests.post(
-        'http://localhost:{}/echo/'.format(WEBSERVER_PORT),
-        JSONOBJECT
-    ).text == repr(json.loads(JSONOBJECT))
+    assert (
+        requests.post("http://localhost:{}/echo/".format(WEBSERVER_PORT), JSONOBJECT).text
+        == repr(json.loads(JSONOBJECT))
+    )
 
 
 def test_json_is_automatically_decoded(webhook_testbot):
-    assert requests.post(
-        'http://localhost:{}/webhook1'.format(WEBSERVER_PORT),
-        JSONOBJECT
-    ).text == repr(json.loads(JSONOBJECT))
+    assert (
+        requests.post("http://localhost:{}/webhook1".format(WEBSERVER_PORT), JSONOBJECT).text
+        == repr(json.loads(JSONOBJECT))
+    )
 
 
 def test_json_on_custom_url_is_automatically_decoded(webhook_testbot):
-    assert requests.post(
-        'http://localhost:{}/custom_webhook'.format(WEBSERVER_PORT),
-        JSONOBJECT
-    ).text == repr(json.loads(JSONOBJECT))
+    assert (
+        requests.post("http://localhost:{}/custom_webhook".format(WEBSERVER_PORT), JSONOBJECT).text
+        == repr(json.loads(JSONOBJECT))
+    )
 
 
 def test_post_form_on_webhook_without_form_param_is_automatically_decoded(webhook_testbot):
-    assert requests.post(
-        'http://localhost:{}/webhook1'.format(WEBSERVER_PORT),
-        data=JSONOBJECT
-    ).text == repr(json.loads(JSONOBJECT))
+    assert (
+        requests.post("http://localhost:{}/webhook1".format(WEBSERVER_PORT), data=JSONOBJECT).text
+        == repr(json.loads(JSONOBJECT))
+    )
 
 
 def test_post_form_on_webhook_with_custom_url_and_without_form_param_is_automatically_decoded(webhook_testbot):
-    assert requests.post(
-        'http://localhost:{}/custom_webhook'.format(WEBSERVER_PORT),
-        data=JSONOBJECT
-    ).text == repr(json.loads(JSONOBJECT))
+    assert (
+        requests.post("http://localhost:{}/custom_webhook".format(WEBSERVER_PORT), data=JSONOBJECT).text
+        == repr(json.loads(JSONOBJECT))
+    )
 
 
 def test_webhooks_with_form_parameter_decode_json_automatically(webhook_testbot):
-    form = {'form': JSONOBJECT}
-    assert requests.post(
-        'http://localhost:{}/form'.format(WEBSERVER_PORT),
-        data=form
-    ).text == repr(json.loads(JSONOBJECT))
+    form = {"form": JSONOBJECT}
+    assert (
+        requests.post("http://localhost:{}/form".format(WEBSERVER_PORT), data=form).text == repr(json.loads(JSONOBJECT))
+    )
 
 
 def test_webhooks_with_form_parameter_on_custom_url_decode_json_automatically(webhook_testbot):
-    form = {'form': JSONOBJECT}
-    assert requests.post(
-        'http://localhost:{}/custom_form'.format(WEBSERVER_PORT),
-        data=form
-    ).text, repr(json.loads(JSONOBJECT))
+    form = {"form": JSONOBJECT}
+    assert requests.post("http://localhost:{}/custom_form".format(WEBSERVER_PORT), data=form).text, repr(
+        json.loads(JSONOBJECT)
+    )
 
 
 def test_webhooks_with_raw_request(webhook_testbot):
-    form = {'form': JSONOBJECT}
-    assert requests.post(
-        'http://localhost:{}/raw'.format(WEBSERVER_PORT),
-        data=form
-    ).text == "<class 'bottle.LocalRequest'>"
+    form = {"form": JSONOBJECT}
+    assert (
+        requests.post("http://localhost:{}/raw".format(WEBSERVER_PORT), data=form).text
+        == "<class 'bottle.LocalRequest'>"
+    )
 
 
 def test_webhooks_with_naked_decorator_raw_request(webhook_testbot):
-    form = {'form': JSONOBJECT}
-    assert requests.post(
-        'http://localhost:{}/raw2'.format(WEBSERVER_PORT),
-        data=form
-    ).text == "<class 'bottle.LocalRequest'>"
+    form = {"form": JSONOBJECT}
+    assert (
+        requests.post("http://localhost:{}/raw2".format(WEBSERVER_PORT), data=form).text
+        == "<class 'bottle.LocalRequest'>"
+    )
 
 
 def test_generate_certificate_creates_usable_cert(webhook_testbot):
@@ -144,41 +144,30 @@ def test_generate_certificate_creates_usable_cert(webhook_testbot):
     assert key_path in webhook_testbot.pop_message(timeout=1)
 
     webserver_config = {
-        'HOST': 'localhost',
-        'PORT': WEBSERVER_PORT,
-        'SSL': {
-            'certificate': cert_path,
-            'key': key_path,
-            'host': 'localhost',
-            'port': WEBSERVER_SSL_PORT,
-            'enabled': True,
-        }
+        "HOST": "localhost",
+        "PORT": WEBSERVER_PORT,
+        "SSL": {
+            "certificate": cert_path, "key": key_path, "host": "localhost", "port": WEBSERVER_SSL_PORT, "enabled": True
+        },
     }
     webhook_testbot.push_message("!plugin config Webserver {!r}".format(webserver_config))
     webhook_testbot.pop_message()
 
-    while not webserver_ready('localhost', WEBSERVER_SSL_PORT):
+    while not webserver_ready("localhost", WEBSERVER_SSL_PORT):
         log.debug("Webserver not ready yet, sleeping 0.1 second")
         sleep(0.1)
 
-    assert requests.post(
-        'https://localhost:{}/webhook1'.format(WEBSERVER_SSL_PORT),
-        JSONOBJECT,
-        verify=False
-    ).text == repr(json.loads(JSONOBJECT))
+    assert (
+        requests.post("https://localhost:{}/webhook1".format(WEBSERVER_SSL_PORT), JSONOBJECT, verify=False).text
+        == repr(json.loads(JSONOBJECT))
+    )
 
 
 def test_custom_headers_and_status_codes(webhook_testbot):
-    assert requests.post(
-        'http://localhost:{}/webhook6'.format(WEBSERVER_PORT)
-    ).headers['X-Powered-By'] == "Err"
+    assert requests.post("http://localhost:{}/webhook6".format(WEBSERVER_PORT)).headers["X-Powered-By"] == "Err"
 
-    assert requests.post(
-        'http://localhost:{}/webhook7'.format(WEBSERVER_PORT)
-    ).status_code == 403
+    assert requests.post("http://localhost:{}/webhook7".format(WEBSERVER_PORT)).status_code == 403
 
 
 def test_lambda_webhook(webhook_testbot):
-    assert requests.post(
-        'http://localhost:{}/lambda'.format(WEBSERVER_PORT)
-    ).status_code == 200
+    assert requests.post("http://localhost:{}/lambda".format(WEBSERVER_PORT)).status_code == 200

--- a/tools/gen_home.py
+++ b/tools/gen_home.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
-from jinja2 import Template
 import json
 
-template = Template(open('plugins.md').read())
+from jinja2 import Template
 
-blacklisted = [repo.strip() for repo in open('blacklisted.txt', 'r').readlines()]
+template = Template(open("plugins.md").read())
 
-PREFIX_LEN = len('https://github.com/')
+blacklisted = [repo.strip() for repo in open("blacklisted.txt", "r").readlines()]
 
-with open('repos.json', 'r') as p:
+PREFIX_LEN = len("https://github.com/")
+
+with open("repos.json", "r") as p:
     repos = json.load(p)
 
     # Removes the weird forks of errbot itself and
@@ -16,13 +17,13 @@ with open('repos.json', 'r') as p:
     filtered_plugins = []
     for repo, plugins in repos.items():
         for name, plugin in plugins.items():
-            if plugin['path'].startswith('errbot/builtins'):
+            if plugin["path"].startswith("errbot/builtins"):
                 continue
-            if plugin['repo'][PREFIX_LEN:] in blacklisted:
+            if plugin["repo"][PREFIX_LEN:] in blacklisted:
                 continue
             filtered_plugins.append(plugin)
 
-    sorted_plugins = sorted(filtered_plugins, key=lambda plugin: -plugin['score'])
+    sorted_plugins = sorted(filtered_plugins, key=lambda plugin: -plugin["score"])
 
-    with open('Home.md', 'w') as out:
+    with open("Home.md", "w") as out:
         out.write(template.render(plugins=sorted_plugins))

--- a/tools/plugin-gen.py
+++ b/tools/plugin-gen.py
@@ -1,80 +1,78 @@
 #!/usr/bin/env python3
+import configparser
+import json
+import logging
+import sys
+import time
 from datetime import datetime
 
 import requests
-import sys
 from requests.auth import HTTPBasicAuth
-from datetime import datetime
-import logging
-import time
-import configparser
-import json
+
 logging.basicConfig()
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
-DEFAULT_AVATAR = 'https://upload.wikimedia.org/wikipedia/commons/5/5f/Err-logo.png'
+DEFAULT_AVATAR = "https://upload.wikimedia.org/wikipedia/commons/5/5f/Err-logo.png"
 
 try:
-    user, token = open('token', 'r').read().strip().split(':')
+    user, token = open("token", "r").read().strip().split(":")
     # token is generated from the personal tokens in github.
     AUTH = HTTPBasicAuth(user, token)
 except FileNotFoundError:
     log.fatal("No token found, cannot access the GitHub API")
 except ValueError:
     log.fatal("Token file cannot be properly read, should be of the form username:token")
-except:
+except Exception:
     log.exception("auth execption:")
 # sys.exit(-1)
 
 user_cache = {}
 
 try:
-    with open('user_cache', 'r') as f:
+    with open("user_cache", "r") as f:
         user_cache = eval(f.read())
 except FileNotFoundError:
     # File doesn't exist, so we continue on
-    log.info("No user cache existing, will be generating it for the " +
-             "first time.")
+    log.info("No user cache existing, will be generating it for the " + "first time.")
 
 
 def add_blacklisted(repo):
-    with open('blacklisted.txt', 'a') as f:
+    with open("blacklisted.txt", "a") as f:
         f.write(repo)
-        f.write('\n')
+        f.write("\n")
+
 
 plugins = {}
 
 
 def save_plugins():
-    with open('repos.json', 'w') as f:
-        json.dump(plugins,
-                  f,
-                  indent=2,
-                  separators=(',', ': '))
+    with open("repos.json", "w") as f:
+        json.dump(plugins, f, indent=2, separators=(",", ": "))
+
 
 BLACKLISTED = []
 try:
-    with open('blacklisted.txt', 'r') as f:
+    with open("blacklisted.txt", "r") as f:
         BLACKLISTED = [line.strip() for line in f.readlines()]
 except FileNotFoundError:
     log.info("No blacklisted.txt found, no plugins will be blacklisted.")
 
 
 def get_avatar_url(repo):
-    username = repo.split('/')[0]
+    username = repo.split("/")[0]
     if username in user_cache:
         user = user_cache[username]
     else:
-        user_res = requests.get('https://api.github.com/users/' + username, auth=AUTH)
+        user_res = requests.get("https://api.github.com/users/" + username, auth=AUTH)
         user = user_res.json()
-        if 'avatar_url' in user:  # don't pollute the presistent cache
+        if "avatar_url" in user:  # don't pollute the presistent cache
             user_cache[username] = user
-            with open('user_cache', 'w') as f:
+            with open("user_cache", "w") as f:
                 f.write(repr(user_cache))
         rate_limit(user_res)
-    return user['avatar_url'] if 'avatar_url' in user else DEFAULT_AVATAR
+    return user["avatar_url"] if "avatar_url" in user else DEFAULT_AVATAR
 
 
 def rate_limit(resp):
@@ -83,15 +81,15 @@ def rate_limit(resp):
     :param resp: the http response from github
     :return:
     """
-    if 'X-RateLimit-Remaining' not in resp.headers:
+    if "X-RateLimit-Remaining" not in resp.headers:
         log.info("No rate limit detected. Hum along...")
         return
-    remain = int(resp.headers['X-RateLimit-Remaining'])
-    limit = int(resp.headers['X-RateLimit-Limit'])
-    log.info('Rate limiter: %s allowed out of %d', remain, limit)
+    remain = int(resp.headers["X-RateLimit-Remaining"])
+    limit = int(resp.headers["X-RateLimit-Limit"])
+    log.info("Rate limiter: %s allowed out of %d", remain, limit)
     if remain > 1:  # margin by one request
         return
-    reset = int(resp.headers['X-RateLimit-Reset'])
+    reset = int(resp.headers["X-RateLimit-Reset"])
     ts = datetime.fromtimestamp(reset)
     delay = (ts - datetime.now()).total_seconds()
     log.info("Hit rate limit. Have to wait for %d seconds", delay)
@@ -100,73 +98,73 @@ def rate_limit(resp):
     time.sleep(delay)
 
 
-def parse_date(gh_date: str)-> datetime:
+def parse_date(gh_date: str) -> datetime:
     return datetime.strptime(gh_date, "%Y-%m-%dT%H:%M:%SZ")
 
 
 def check_repo(repo):
-    repo_name = repo.get('full_name', None)
+    repo_name = repo.get("full_name", None)
     if repo_name is None:
-        log.error('No name in %s', repo)
-    log.debug('Checking %s...', repo_name)
-    code_resp = requests.get('https://api.github.com/search/code?q=extension:plug+repo:%s' % repo_name, auth=AUTH)
+        log.error("No name in %s", repo)
+    log.debug("Checking %s...", repo_name)
+    code_resp = requests.get("https://api.github.com/search/code?q=extension:plug+repo:%s" % repo_name, auth=AUTH)
     if code_resp.status_code != 200:
-        log.error('Error getting https://api.github.com/search/code?q=extension:plug+repo:%s', repo_name)
-        log.error('code %d', code_resp.status_code)
-        log.error('content %s', code_resp.text)
+        log.error("Error getting https://api.github.com/search/code?q=extension:plug+repo:%s", repo_name)
+        log.error("code %d", code_resp.status_code)
+        log.error("content %s", code_resp.text)
 
         return
-    plug_items = code_resp.json()['items']
+    plug_items = code_resp.json()["items"]
     if not plug_items:
-        log.debug('No plugin found in %s, blacklisting it.', repo_name)
+        log.debug("No plugin found in %s, blacklisting it.", repo_name)
         add_blacklisted(repo_name)
         return
-    owner = repo['owner']
-    avatar_url = owner['avatar_url'] if 'avatar_url' in owner else DEFAULT_AVATAR
+    owner = repo["owner"]
+    avatar_url = owner["avatar_url"] if "avatar_url" in owner else DEFAULT_AVATAR
 
-    days_old = (datetime.now() - parse_date(repo['updated_at'])).days
-    score = repo['stargazers_count'] + repo['watchers_count'] * 2 + repo['forks_count'] - days_old / 25
+    days_old = (datetime.now() - parse_date(repo["updated_at"])).days
+    score = repo["stargazers_count"] + repo["watchers_count"] * 2 + repo["forks_count"] - days_old / 25
 
     for plug in plug_items:
-        plugfile_resp = requests.get('https://raw.githubusercontent.com/%s/master/%s' % (repo_name, plug['path']))
-        log.debug('Found a plugin:')
-        log.debug('Repo:  %s', repo_name)
-        log.debug('File:  %s', plug['path'])
+        plugfile_resp = requests.get("https://raw.githubusercontent.com/%s/master/%s" % (repo_name, plug["path"]))
+        log.debug("Found a plugin:")
+        log.debug("Repo:  %s", repo_name)
+        log.debug("File:  %s", plug["path"])
         parser = configparser.ConfigParser()
         try:
             parser.read_string(plugfile_resp.text)
 
-            name = parser['Core']['Name']
-            log.debug('Name: %s', name)
+            name = parser["Core"]["Name"]
+            log.debug("Name: %s", name)
 
-            if 'Documentation' in parser and 'Description' in parser['Documentation']:
-                doc = parser['Documentation']['Description']
-                log.debug('Documentation: %s', doc)
+            if "Documentation" in parser and "Description" in parser["Documentation"]:
+                doc = parser["Documentation"]["Description"]
+                log.debug("Documentation: %s", doc)
             else:
-                doc = ''
+                doc = ""
 
-            if 'Python' in parser:
-                python = parser['Python']['Version']
-                log.debug('Python Version: %s', python)
+            if "Python" in parser:
+                python = parser["Python"]["Version"]
+                log.debug("Python Version: %s", python)
             else:
-                python = '2'
+                python = "2"
 
             plugin = {
-                'path': plug['path'],
-                'repo': repo['html_url'],
-                'documentation': doc,
-                'name': name,
-                'python': python,
-                'avatar_url': avatar_url,
-                'score': score,
+                "path": plug["path"],
+                "repo": repo["html_url"],
+                "documentation": doc,
+                "name": name,
+                "python": python,
+                "avatar_url": avatar_url,
+                "score": score,
             }
 
             repo_entry = plugins.get(repo_name, {})
             repo_entry[name] = plugin
             plugins[repo_name] = repo_entry
-            log.debug('Catalog added plugin %s.', plugin['name'])
-        except:
-            log.error('Invalid syntax in %s, skipping... ' % plug['path'])
+            log.debug("Catalog added plugin %s.", plugin["name"])
+        except Exception:
+            log.error("Invalid syntax in %s, skipping... " % plug["path"])
             continue
 
         rate_limit(plugfile_resp)
@@ -176,56 +174,58 @@ def check_repo(repo):
 
 
 def find_plugins(query):
-    url = 'https://api.github.com/search/repositories?q=%s+in:name+language:python&sort=stars&order=desc' % query
+    url = "https://api.github.com/search/repositories?q=%s+in:name+language:python&sort=stars&order=desc" % query
     while True:
         repo_resp = requests.get(url, auth=AUTH)
         repo_json = repo_resp.json()
-        if repo_json.get('message', None) == 'Bad credentials':
-            log.error('Invalid credentials, check your token file, see README.')
+        if repo_json.get("message", None) == "Bad credentials":
+            log.error("Invalid credentials, check your token file, see README.")
             sys.exit(-1)
-        log.debug("Repo reqs before ratelimit %s/%s" % (
-            repo_resp.headers['X-RateLimit-Remaining'],
-            repo_resp.headers['X-RateLimit-Limit']))
-        if 'message' in repo_json and repo_json['message'].startswith('API rate limit exceeded for'):
-            log.error('API rate limit hit anyway ... wait for 30s')
+        log.debug(
+            "Repo reqs before ratelimit %s/%s"
+            % (repo_resp.headers["X-RateLimit-Remaining"], repo_resp.headers["X-RateLimit-Limit"])
+        )
+        if "message" in repo_json and repo_json["message"].startswith("API rate limit exceeded for"):
+            log.error("API rate limit hit anyway ... wait for 30s")
             time.sleep(30)
             continue
-        items = repo_json['items']
+        items = repo_json["items"]
 
         for i, repo in enumerate(items):
-            if repo['full_name'] in BLACKLISTED:
-                log.debug('Skipping %s.', repo)
+            if repo["full_name"] in BLACKLISTED:
+                log.debug("Skipping %s.", repo)
                 continue
             check_repo(repo)
-        if 'next' not in repo_resp.links:
+        if "next" not in repo_resp.links:
             break
-        url = repo_resp.links['next']['url']
-        log.debug('Next url: %s', url)
+        url = repo_resp.links["next"]["url"]
+        log.debug("Next url: %s", url)
         rate_limit(repo_resp)
 
 
 def main():
-    find_plugins('err')
+    find_plugins("err")
     # Those are found by global search only available on github UI:
     # https://github.com/search?l=&q=Documentation+extension%3Aplug&ref=advsearch&type=Code&utf8=%E2%9C%93
-    url = 'https://api.github.com/repos/%s'
-    with open('extras.txt', 'r') as extras:
+    url = "https://api.github.com/repos/%s"
+    with open("extras.txt", "r") as extras:
         for repo_name in extras:
             repo_name = repo_name.strip()
             repo_resp = requests.get(url % repo_name, auth=AUTH)
             repo = repo_resp.json()
-            if repo.get('message', None) == 'Bad credentials':
-                log.error('Invalid credentials, check your token file, see README.')
+            if repo.get("message", None) == "Bad credentials":
+                log.error("Invalid credentials, check your token file, see README.")
                 sys.exit(-1)
-            if 'message' in repo and repo['message'].startswith('API rate limit exceeded for'):
-                log.error('API rate limit hit anyway ... wait for 30s')
+            if "message" in repo and repo["message"].startswith("API rate limit exceeded for"):
+                log.error("API rate limit hit anyway ... wait for 30s")
                 time.sleep(30)
                 continue
-            if 'message' in repo and repo['message'].startswith('Not Found'):
-                log.error('%s not found.', repo_name)
+            if "message" in repo and repo["message"].startswith("Not Found"):
+                log.error("%s not found.", repo_name)
             else:
                 check_repo(repo)
             rate_limit(repo_resp)
+
 
 if __name__ == "__main__":
     main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = black,codestyle,pypi-lint,py34,py35,py36
+envlist = black,codestyle,isort,pypi-lint,py34,py35,py36
 skip_missing_interpreters = True
 
 [testenv]
@@ -26,6 +26,10 @@ whitelist_externals =
 [testenv:codestyle]
 deps = pycodestyle
 commands = pycodestyle
+
+[testenv:isort]
+deps = isort
+commands = isort --check-only --recursive --diff --line-width 120 --multi-line 3 --trailing-comma --use-parentheses --project errbot --thirdparty pytest --thirdparty mock errbot tests tools
 
 [testenv:pypi-lint]
 deps = docutils

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34,py35,py36,codestyle,pypi-lint
+envlist = black,codestyle,pypi-lint,py34,py35,py36
 skip_missing_interpreters = True
 
 [testenv]
@@ -10,9 +10,22 @@ deps =
 
 commands = py.test
 
+[testenv:black]
+deps = black
+ignore_errors = True
+commands =
+	# Workaround to exclude config-template.py which deliberately ignores some
+	# rules for "config file" readability. ignore_errors above ensures the file
+	# is always moved back in place afterwards.
+	mv --no-clobber errbot/config-template.py errbot/config-template.workaround
+	black --check --diff --line-length 120 errbot setup.py tests tools
+	mv errbot/config-template.workaround errbot/config-template.py
+whitelist_externals =
+	mv
+
 [testenv:codestyle]
 deps = pycodestyle
-commands = pycodestyle errbot tests --ignore=E252
+commands = pycodestyle
 
 [testenv:pypi-lint]
 deps = docutils


### PR DESCRIPTION
This fixes a number of warning and errors that were being reported by
`pycodestyle`, making CI happy again. It also formats all code according
to the rules of [black], simplifying future code-style formatting.
Black is also added to the CI pipeline, enforcing this codestyle going
forward.

Black is opinionated which may initially cause some friction, however I
personally believe this to be a good thing. It ensures a consistent look
and bypasses any ambiguity and pointless bikeshedding over personal
style preferences.

I've personally had good responses to enforcing consistent code style
from similar approaches in Go (via gofmt) and Elixir (mix format) in
other projects.

It should be noted that black is currently calling itself alpha-level
software, however after reviewing the auto-formatted results from this
commit I believe it to be quite reliable already. Furthermore, CI will
run in check-mode only so worst-case, it fails a build which should not
be getting failed.

[black]: https://pypi.org/project/black/