### PR TITLE
Replace back Bottle & Rocket by Flask

### DIFF
--- a/docs/user_guide/plugin_development/webhooks.rst
+++ b/docs/user_guide/plugin_development/webhooks.rst
@@ -57,10 +57,10 @@ parameter:
         def test(self, request, name, action):
             return "User %s is performing %s" % (name, action)
 
-Refer to the documentation on Bottle's
-`request routing <http://bottlepy.org/docs/dev/routing.html>`_
+Refer to the documentation on Flask's
+`route <http://flask.pocoo.org/docs/1.0/api/#flask.Flask.route>`_
 for details on the supported syntax
-(Errbot uses Bottle internally).
+(Errbot uses Flask internally).
 
 
 Handling JSON request
@@ -123,31 +123,33 @@ Returning custom headers and status codes
 
 Adjusting the response headers, setting cookies or returning a
 different status code can all be done by manipulating the
-`bottle.response <http://bottlepy.org/docs/dev/api.html#bottle.response>`_
-object. The bottle docs on `the response object
-<http://bottlepy.org/docs/dev/tutorial.html#the-response-object>`_
+`flask response <http://flask.pocoo.org/docs/1.0/patterns/deferredcallbacks/>`_
+object. The Flask docs on `the response object
+<http://flask.pocoo.org/docs/1.0/api/#response-objects>`_
 explain this in more detail. Here's an example of setting a 
 custom header:
 
 .. code-block:: python
 
     from errbot import BotPlugin, webhook
-    from bottle import response
+    from flask import after_this_request
 
     class PluginExample(BotPlugin):
         @webhook
         def example(self, incoming_request):
-            response.set_header("X-Powered-By", "Errbot")
+            @after_this_request
+            def add_header(response):
+                response.headers['X-Powered-By'] = 'Errbot'
             return "OK"
 
-Bottle also has various helpers such as the `abort()` method.
+Flask also has various helpers such as the `abort()` method.
 Using this method we could, for example, return a 403 forbidden
 response like so:
 
 .. code-block:: python
 
     from errbot import BotPlugin, webhook
-    from bottle import abort
+    from flask import abort
 
     class PluginExample(BotPlugin):
         @webhook

--- a/errbot/__init__.py
+++ b/errbot/__init__.py
@@ -9,21 +9,20 @@ import inspect
 import sys
 from typing import Callable, Any, Tuple
 
-from .core_plugins.wsview import bottle_app, WebView
+from .core_plugins.wsview import WebView
 from .backends.base import Message, ONLINE, OFFLINE, AWAY, DND  # noqa
 from .botplugin import BotPlugin, SeparatorArgParser, ShlexArgParser, CommandError, Command, ValidationException  # noqa
 from .flow import FlowRoot, BotFlow, Flow, FLOW_END
-from .core_plugins.wsview import route, view  # noqa
+from .core_plugins.wsview import route
 from . import core
 
-__all__ = ['BotPlugin', 'CommandError', 'Command', 'webhook', 'webroute', 'webview', 'cmdfilter',
+__all__ = ['BotPlugin', 'CommandError', 'Command', 'webhook', 'webroute', 'cmdfilter',
            'botcmd', 're_botcmd', 'arg_botcmd', 'botflow', 'botmatch', 'BotFlow', 'FlowRoot', 'Flow', 'FLOW_END',
            ]
 
 log = logging.getLogger(__name__)
 
 webroute = route  # this allows plugins to expose dynamic webpages on Errbot embedded webserver
-webview = view  # this allows to use the templating system
 
 # TODO: Remove, this is for backend backward compatibility
 sys.modules["errbot.errBot"] = core

--- a/errbot/core_plugins/__init__.py
+++ b/errbot/core_plugins/__init__.py
@@ -1,0 +1,2 @@
+from flask.app import Flask
+flask_app = Flask(__name__)

--- a/errbot/core_plugins/webserver.py
+++ b/errbot/core_plugins/webserver.py
@@ -90,9 +90,6 @@ class Webserver(BotPlugin):
             self.log.info('Webserver is not configured. Forbid activation')
             return
 
-        #self.webserver = Rocket(interfaces=interfaces,
-        #                        app_info={'wsgi_app': bottle_app}, )
-
         if self.server_thread:
             raise Exception('Invalid state, you should not have a webserver already running.')
         self.server_thread = Thread(target=self.run_server, name='Webserver Thread')

--- a/errbot/core_plugins/webserver.py
+++ b/errbot/core_plugins/webserver.py
@@ -114,7 +114,8 @@ class Webserver(BotPlugin):
             ssl = self.config['SSL']
             self.log.info('Starting the webserver on %s:%i' % (host, port))
             ssl_context = (ssl['certificate'], ssl['key']) if ssl['enabled'] else None
-            self.server = ThreadedWSGIServer(host, ssl['port'] if ssl_context else port, flask_app, ssl_context=ssl_context)
+            self.server = ThreadedWSGIServer(host, ssl['port'] if ssl_context else port, flask_app,
+                                             ssl_context=ssl_context)
             self.server.serve_forever()
             self.log.debug('Webserver stopped')
         except KeyboardInterrupt as _:

--- a/errbot/core_plugins/webserver.py
+++ b/errbot/core_plugins/webserver.py
@@ -104,7 +104,7 @@ class Webserver(BotPlugin):
             self.server.shutdown()
             self.log.info('Waiting for the webserver thread to quit.')
             self.server_thread.join()
-            self.log.info('Webserver shut down correcly.')
+            self.log.info('Webserver shut down correctly.')
         super().deactivate()
 
     def run_server(self):
@@ -118,11 +118,10 @@ class Webserver(BotPlugin):
                                              ssl_context=ssl_context)
             self.server.serve_forever()
             self.log.debug('Webserver stopped')
-        except KeyboardInterrupt as _:
-            self.log.exception('Keyboard interrupt, request a global shutdown.')
-            self.log.info('webserver is ThreadedWSGIServer')
+        except KeyboardInterrupt:
+            self.log.info('Keyboard interrupt, request a global shutdown.')
             self.server.shutdown()
-        except Exception as _:
+        except Exception:
             self.log.exception('The webserver exploded.')
 
     @botcmd(template='webstatus')

--- a/errbot/core_plugins/webserver.py
+++ b/errbot/core_plugins/webserver.py
@@ -90,7 +90,7 @@ class Webserver(BotPlugin):
             self.log.info('Webserver is not configured. Forbid activation')
             return
 
-        if self.server_thread:
+        if self.server_thread and self.server_thread.is_alive():
             raise Exception('Invalid state, you should not have a webserver already running.')
         self.server_thread = Thread(target=self.run_server, name='Webserver Thread')
         self.server_thread.start()
@@ -114,7 +114,7 @@ class Webserver(BotPlugin):
             ssl = self.config['SSL']
             self.log.info('Starting the webserver on %s:%i' % (host, port))
             ssl_context = (ssl['certificate'], ssl['key']) if ssl['enabled'] else None
-            self.server = ThreadedWSGIServer(host, port, flask_app, ssl_context=ssl_context)
+            self.server = ThreadedWSGIServer(host, ssl['port'] if ssl_context else port, flask_app, ssl_context=ssl_context)
             self.server.serve_forever()
             self.log.debug('Webserver stopped')
         except KeyboardInterrupt as _:

--- a/errbot/core_plugins/wsview.py
+++ b/errbot/core_plugins/wsview.py
@@ -2,44 +2,20 @@ from inspect import getmembers, ismethod
 from json import loads
 import logging
 
-from bottle import Bottle, request
-
-# noinspection PyUnresolvedReferences
-from bottle import jinja2_view as view
-# noinspection PyUnresolvedReferences
-from bottle import jinja2_template as template
+from flask.app import Flask
+from flask.views import View
+from flask import request
+from errbot.core_plugins import flask_app
 
 log = logging.getLogger(__name__)
-
 
 def strip_path():
     # strip the trailing slashes on incoming requests
     request.environ['PATH_INFO'] = request.environ['PATH_INFO'].rstrip('/')
 
 
-class DynamicBottle(Bottle):
-
-    def __init__(self, catchall=True, autojson=True):
-        super().__init__(catchall, autojson)
-        self.add_hook('before_request', strip_path)
-
-    def del_route(self, route_name):
-        deleted_route = None
-        for route_ in self.routes[:]:
-            if route_.name == route_name:
-                self.routes.remove(route_)
-                deleted_route = route_
-                break
-        if not deleted_route:
-            raise ValueError('Cannot find the route %s to delete' % route_name)
-        del (self.router.rules[deleted_route.rule])
-
-
-bottle_app = DynamicBottle()
-
-
 def try_decode_json(req):
-    data = req.body.read().decode()
+    data = req.data.decode()
     try:
         return loads(data)
     except Exception:
@@ -49,8 +25,8 @@ def try_decode_json(req):
 def reset_app():
     """Zap everything here, useful for unit tests
     """
-    global bottle_app
-    bottle_app = DynamicBottle()
+    global flask_app
+    flask_app = Flask(__name__)
 
 
 def route(obj):
@@ -60,15 +36,24 @@ def route(obj):
     for name, func in getmembers(obj, ismethod):
         if getattr(func, '_err_webhook_uri_rule', False):
             log.info("Webhook routing %s", func.__name__)
-            for verb in func._err_webhook_methods:
-                wv = WebView(func,
-                             func._err_webhook_form_param,
-                             func._err_webhook_raw)
-                bottle_app.route(func._err_webhook_uri_rule, verb,
-                                 callback=wv, name=func.__name__ + '_' + verb)
+            form_param = func._err_webhook_form_param
+            uri_rule = func._err_webhook_uri_rule
+            verbs = func._err_webhook_methods
+            raw = func._err_webhook_raw
+
+            callable_view = WebView.as_view(func.__name__ + '_' + '_'.join(verbs), func, form_param, raw)
+
+            # Change existing rule.
+            for rule in flask_app.url_map._rules:
+                if rule.rule == uri_rule:
+                    flask_app.view_functions[rule.endpoint] = callable_view
+                    return
+
+            # Add a new rule
+            flask_app.add_url_rule(uri_rule, view_func=callable_view, methods=verbs, strict_slashes=False)
 
 
-class WebView(object):
+class WebView(View):
     def __init__(self, func, form_param, raw):
         if form_param is not None and raw:
             raise Exception("Incompatible parameters: form_param cannot be set if raw is True")
@@ -77,11 +62,12 @@ class WebView(object):
         self.form_param = form_param
         self.method_filter = lambda obj: ismethod(obj) and self.func.__name__ == obj.__name__
 
-    def __call__(self, *args, **kwargs):
+    def dispatch_request(self, *args, **kwargs):
+
         if self.raw:  # override and gives the request directly
             response = self.func(request, **kwargs)
         elif self.form_param:
-            content = request.forms.get(self.form_param)
+            content = request.form.get(self.form_param)
             if content is None:
                 raise Exception("Received a request on a webhook with a form_param defined, "
                                 "but that key ({}) is missing from the request.".format(self.form_param))
@@ -96,6 +82,6 @@ class WebView(object):
                 if hasattr(request, 'forms'):
                     data = dict(request.forms)  # form encoded
                 else:
-                    data = request.body.read().decode()
+                    data = request.data.decode()
             response = self.func(data, **kwargs)
         return response if response else ''  # assume None as an OK response (simplifies the client side)

--- a/errbot/core_plugins/wsview.py
+++ b/errbot/core_plugins/wsview.py
@@ -5,9 +5,9 @@ import logging
 from flask.app import Flask
 from flask.views import View
 from flask import request
-from errbot.core_plugins import flask_app
 
 log = logging.getLogger(__name__)
+
 
 def strip_path():
     # strip the trailing slashes on incoming requests
@@ -25,8 +25,8 @@ def try_decode_json(req):
 def reset_app():
     """Zap everything here, useful for unit tests
     """
-    global flask_app
-    flask_app = Flask(__name__)
+    import errbot.core_plugins
+    errbot.core_plugins.flask_app = Flask(__name__)
 
 
 def route(obj):

--- a/errbot/core_plugins/wsview.py
+++ b/errbot/core_plugins/wsview.py
@@ -5,6 +5,7 @@ import logging
 from flask.app import Flask
 from flask.views import View
 from flask import request
+import errbot.core_plugins
 
 log = logging.getLogger(__name__)
 
@@ -25,12 +26,12 @@ def try_decode_json(req):
 def reset_app():
     """Zap everything here, useful for unit tests
     """
-    import errbot.core_plugins
     errbot.core_plugins.flask_app = Flask(__name__)
 
 
 def route(obj):
     """Check for functions to route in obj and route them."""
+    flask_app = errbot.core_plugins.flask_app
     classname = obj.__class__.__name__
     log.info("Checking %s for webhooks", classname)
     for name, func in getmembers(obj, ismethod):

--- a/errbot/templating.py
+++ b/errbot/templating.py
@@ -1,7 +1,6 @@
 import logging
 import os
 from jinja2 import Environment, FileSystemLoader
-from bottle import TEMPLATE_PATH
 
 log = logging.getLogger(__name__)
 
@@ -12,7 +11,6 @@ def make_templates_path(root):
 
 system_templates_path = make_templates_path(os.path.dirname(__file__))
 template_path = [system_templates_path]
-TEMPLATE_PATH.insert(0, system_templates_path)  # for views
 env = Environment(loader=FileSystemLoader(template_path),
                   trim_blocks=True,
                   keep_trailing_newline=False,
@@ -32,8 +30,7 @@ def add_plugin_templates_path(path):
     tmpl_path = make_templates_from_plugin_path(path)
     if os.path.exists(tmpl_path):
         log.debug("Templates directory found for this plugin [%s]" % tmpl_path)
-        template_path.append(tmpl_path)  # for webhooks
-        TEMPLATE_PATH.insert(0, tmpl_path)  # for webviews
+        template_path.append(tmpl_path)
         # Ditch and recreate a new templating environment
         env = Environment(loader=FileSystemLoader(template_path), autoescape=True)
         return
@@ -44,7 +41,6 @@ def remove_plugin_templates_path(path):
     global env
     tmpl_path = make_templates_from_plugin_path(path)
     if tmpl_path in template_path:
-        template_path.remove(tmpl_path)  # for webhooks
-        TEMPLATE_PATH.remove(tmpl_path)  # for webviews
+        template_path.remove(tmpl_path)
         # Ditch and recreate a new templating environment
         env = Environment(loader=FileSystemLoader(template_path), autoescape=True)

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,7 @@ VERSION_FILE = os.path.join('errbot', 'version.py')
 
 deps = ['webtest',
         'setuptools',
-        'bottle',
-        'rocket-errbot',
+        'flask',
         'requests',
         'jinja2',
         'pyOpenSSL',

--- a/tests/webhooks_plugin/webtest.py
+++ b/tests/webhooks_plugin/webtest.py
@@ -1,7 +1,7 @@
 import logging
 from errbot import BotPlugin
 from errbot.core_plugins.webserver import webhook
-from bottle import abort, response
+from flask import abort, after_this_request
 
 log = logging.getLogger(__name__)
 
@@ -35,7 +35,11 @@ class WebTest(BotPlugin):
     @webhook
     def webhook6(self, payload):
         log.debug(str(payload))
-        response.set_header("X-Powered-By", "Err")
+
+        @after_this_request
+        def add_header(response):
+            response.headers['X-Powered-By'] = 'Errbot'
+            return response
         return str(payload)
 
     @webhook

--- a/tests/webhooks_test.py
+++ b/tests/webhooks_test.py
@@ -132,7 +132,6 @@ def test_webhooks_with_naked_decorator_raw_request(webhook_testbot):
     assert 'LocalProxy' in requests.post('http://localhost:{}/raw2'.format(WEBSERVER_PORT), data=form).text
 
 
-#@pytest.mark.skip()
 def test_generate_certificate_creates_usable_cert(webhook_testbot):
     d = webhook_testbot.bot.bot_config.BOT_DATA_DIR
     key_path = os.sep.join((d, "webserver_key.pem"))

--- a/tests/webhooks_test.py
+++ b/tests/webhooks_test.py
@@ -121,20 +121,15 @@ def test_webhooks_with_form_parameter_on_custom_url_decode_json_automatically(we
 
 def test_webhooks_with_raw_request(webhook_testbot):
     form = {'form': JSONOBJECT}
-    assert requests.post(
-        'http://localhost:{}/raw'.format(WEBSERVER_PORT),
-        data=form
-    ).text == "<class 'bottle.LocalRequest'>"
+    assert 'LocalProxy' in requests.post('http://localhost:{}/raw'.format(WEBSERVER_PORT), data=form).text
 
 
 def test_webhooks_with_naked_decorator_raw_request(webhook_testbot):
     form = {'form': JSONOBJECT}
-    assert requests.post(
-        'http://localhost:{}/raw2'.format(WEBSERVER_PORT),
-        data=form
-    ).text == "<class 'bottle.LocalRequest'>"
+    assert 'LocalProxy' in requests.post('http://localhost:{}/raw2'.format(WEBSERVER_PORT), data=form).text
 
 
+@pytest.mark.skip()
 def test_generate_certificate_creates_usable_cert(webhook_testbot):
     d = webhook_testbot.bot.bot_config.BOT_DATA_DIR
     key_path = os.sep.join((d, "webserver_key.pem"))
@@ -176,7 +171,7 @@ def test_generate_certificate_creates_usable_cert(webhook_testbot):
 def test_custom_headers_and_status_codes(webhook_testbot):
     assert requests.post(
         'http://localhost:{}/webhook6'.format(WEBSERVER_PORT)
-    ).headers['X-Powered-By'] == "Err"
+    ).headers['X-Powered-By'] == 'Errbot'
 
     assert requests.post(
         'http://localhost:{}/webhook7'.format(WEBSERVER_PORT)

--- a/tests/webhooks_test.py
+++ b/tests/webhooks_test.py
@@ -33,13 +33,9 @@ def webserver_ready(host, port):
 extra_plugin_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'webhooks_plugin')
 
 
-@pytest.fixture
-def webhook_testbot(request):
-    tbot = testbot(request)
-    tbot.push_message("!plugin config Webserver {'HOST': 'localhost', 'PORT': %s, 'SSL': None}" % WEBSERVER_PORT)
-    log.info(tbot.pop_message())
+def wait_for_server(port: int):
     failure_count = 10
-    while not webserver_ready('localhost', WEBSERVER_PORT):
+    while not webserver_ready('localhost', port):
         waiting_time = 1.0 / failure_count
         log.info('Webserver not ready yet, sleeping for %f second.', waiting_time)
         sleep(waiting_time)
@@ -47,6 +43,13 @@ def webhook_testbot(request):
         if failure_count == 0:
             raise TimeoutError("Could not start the internal Webserver to test.")
 
+
+@pytest.fixture
+def webhook_testbot(request):
+    tbot = testbot(request)
+    tbot.push_message("!plugin config Webserver {'HOST': 'localhost', 'PORT': %s, 'SSL': None}" % WEBSERVER_PORT)
+    log.info(tbot.pop_message())
+    wait_for_server(WEBSERVER_PORT)
     return tbot
 
 
@@ -129,7 +132,7 @@ def test_webhooks_with_naked_decorator_raw_request(webhook_testbot):
     assert 'LocalProxy' in requests.post('http://localhost:{}/raw2'.format(WEBSERVER_PORT), data=form).text
 
 
-@pytest.mark.skip()
+#@pytest.mark.skip()
 def test_generate_certificate_creates_usable_cert(webhook_testbot):
     d = webhook_testbot.bot.bot_config.BOT_DATA_DIR
     key_path = os.sep.join((d, "webserver_key.pem"))
@@ -154,12 +157,10 @@ def test_generate_certificate_creates_usable_cert(webhook_testbot):
             'enabled': True,
         }
     }
-    webhook_testbot.push_message("!plugin config Webserver {!r}".format(webserver_config))
-    webhook_testbot.pop_message()
+    webhook_testbot.push_message('!plugin config Webserver {!r}'.format(webserver_config))
+    assert 'Plugin configuration done.' in webhook_testbot.pop_message(timeout=2)
 
-    while not webserver_ready('localhost', WEBSERVER_SSL_PORT):
-        log.debug("Webserver not ready yet, sleeping 0.1 second")
-        sleep(0.1)
+    wait_for_server(WEBSERVER_SSL_PORT)
 
     assert requests.post(
         'https://localhost:{}/webhook1'.format(WEBSERVER_SSL_PORT),


### PR DESCRIPTION
This is an initial port of the errbot webhook feature to Flask.

Rocket is not only abandoned but we had to maintain a lot of patches out of the official tree. It is time to come back to something more maintained and standard: Flask.

Flask can replace both Bottle and Rocket so let's remove one dependency.