### PR TITLE
fix: Remove extra spaces in uptime output

### DIFF
--- a/errbot/core_plugins/health.py
+++ b/errbot/core_plugins/health.py
@@ -70,7 +70,7 @@ class Health(BotPlugin):
         """
         u = format_timedelta(datetime.now() - self._bot.startup_time)
         since = self._bot.startup_time.strftime('%A, %b %d at %H:%M')
-        return f"I've been up for {args} {u} (since {since})."
+        return f"I've been up for {u} (since {since})."
 
     # noinspection PyUnusedLocal
     @botcmd(admin_only=True)


### PR DESCRIPTION
For some reason you can pass an argument to `!uptime` but that is really not needed.

Current behavior:
```
[@saviles ➡ @zombie] >>> .uptime
I've been up for  23 seconds (since Thursday, Jun 21 at 17:09).

# ^^ notice the extra space before '23'

[@saviles ➡ @zombie] >>> .uptime random text
I've been up for random text 45 minutes (since Thursday, Jun 21 at 17:09)
```

New behavior
```
[@saviles ➡ @zombie] >>> .uptime
I've been up for 23 seconds (since Thursday, Jun 21 at 13:02).

[@saviles ➡ @zombie] >>> .uptime new text
I've been up for 33 seconds (since Thursday, Jun 21 at 13:02).
```
