### PR TITLE
sanitize comma quotation marks too

### DIFF
--- a/errbot/__init__.py
+++ b/errbot/__init__.py
@@ -28,7 +28,7 @@ webroute = route  # this allows plugins to expose dynamic webpages on Errbot emb
 # Same happens with quotations marks, which are required for parsing
 # complex strings in arguments
 # Map of characters to sanitized equivalents
-ARG_BOTCMD_CHARACTER_REPLACEMENTS = {'—': '--', '“': '"', '”': '"'}
+ARG_BOTCMD_CHARACTER_REPLACEMENTS = {'—': '--', '“': '"', '”': '"', '’': '\'', '‘': '\''}
 
 
 class ArgumentParseError(Exception):


### PR DESCRIPTION
Slack client converts apostrophes into comma quotation marks. This PR adds them to the list of characters to be sanitized.