### PR TITLE
Fix/backend import error messages

### DIFF
--- a/errbot/backends/hipchat.py
+++ b/errbot/backends/hipchat.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     log.exception("Could not start the HipChat backend")
     log.fatal(
-        "You need to install the hipchat support in order to use the HipChat.\n "
+        "You need to install the hipchat support in order to use the HipChat backend.\n "
         "You should be able to install this package using:\n"
         "pip install errbot[hipchat]"
     )

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -25,7 +25,7 @@ try:
 except ImportError:
     log.exception("Could not start the Slack back-end")
     log.fatal(
-        "You need to install the slackclient support in order to use the Slack.\n"
+        "You need to install the slackclient support in order to use the Slack backend.\n"
         "You can do `pip install errbot[slack]` to install it"
     )
     sys.exit(1)

--- a/errbot/backends/xmpp.py
+++ b/errbot/backends/xmpp.py
@@ -21,7 +21,7 @@ try:
 except ImportError:
     log.exception("Could not start the XMPP backend")
     log.fatal("""
-    If you intend to use the XMPP backend pleas install the support for XMPP with:
+    If you intend to use the XMPP backend please install the support for XMPP with:
     pip install errbot[XMPP]
     """)
     sys.exit(-1)


### PR DESCRIPTION
Fix small typos/omissions in the error messages when using a backend without the appropriate dependencies installed.

Originally found this issue with Slack, but figured I'd clean up the other while at it.