### PR TITLE
Pass telegram message id to the callback

### DIFF
--- a/errbot/backends/telegram_messenger.py
+++ b/errbot/backends/telegram_messenger.py
@@ -274,6 +274,7 @@ class TelegramBackend(ErrBot):
                 username=message.from_user.username
             )
             message_instance.to = room
+        message_instance.extras['message_id'] = message.message_id
         self.callback_message(message_instance)
 
     def send_message(self, msg):


### PR DESCRIPTION
In order to get the bot to delete the telegram join messages, the first thing we need is the message ID:
https://github.com/elopio/zos-bot/blob/master/backends/telegram_messenger_patched.py#L325