### PR TITLE
Install missing repo's

### DIFF
--- a/errbot/core_plugins/plugins.py
+++ b/errbot/core_plugins/plugins.py
@@ -121,11 +121,9 @@ class Plugins(BotPlugin):
         for d, success, feedback in results:
             if success:
                 yield f'Update of {d} succeeded...\n\n{feedback}\n\n'
-            else:
-                yield f'Update of {d} failed...\n\n{feedback}'
 
-            for plugin in self._bot.plugin_manager.getAllPlugins():
-                if plugin.path.startswith(d) and hasattr(plugin, 'is_activated') and plugin.is_activated:
+                plugin = self._bot.plugin_manager.get_plugin_by_path(d)
+                if hasattr(plugin, 'is_activated') and plugin.is_activated:
                     name = plugin.name
                     yield f'/me is reloading plugin {name}'
                     try:
@@ -133,6 +131,9 @@ class Plugins(BotPlugin):
                         yield f'Plugin {plugin.name} reloaded.'
                     except PluginActivationException as pae:
                         yield f'Error reactivating plugin {plugin.name}: {pae}'
+            else:
+                yield f'Update of {d} failed...\n\n{feedback}'
+
         yield "Done."
 
     @botcmd(split_args_with=' ', admin_only=True)

--- a/errbot/repo_manager.py
+++ b/errbot/repo_manager.py
@@ -282,6 +282,9 @@ class BotRepoManager(StoreMixin):
         names = set(self.get_installed_plugin_repos().keys()).intersection(set(repos))
 
         for d in (path.join(self.plugin_dir, name) for name in names):
+            if not path.exists(d):
+                log.debug('Repo marked as installed but is missing install files, attempting to install')
+                self.install_repo(path.relpath(d, self.plugin_dir))
             p = subprocess.Popen([git_path, 'pull'], cwd=d, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             feedback = p.stdout.read().decode('utf-8') + '\n' + '-' * 50 + '\n'
             err = p.stderr.read().strip().decode('utf-8')


### PR DESCRIPTION
This is useful for bootstraping, when you do not want to use the extra plugs directory. On deploy I insert the repo manually into repomgr.db as installed, then run repos update and it will download what is missing.