### PR TITLE
Fix missing string formatting in "Command not found" output

### DIFF
--- a/errbot/core.py
+++ b/errbot/core.py
@@ -484,7 +484,7 @@ class ErrBot(Backend, StoreMixin):
         matches = set(matches)
         if matches:
             alternatives = ('" or "' + self.bot_config.BOT_PREFIX).join(matches)
-            msg += '\n\nDid you mean "{self.bot_config.BOT_PREFIX}{alternatives}" ?'
+            msg += f'\n\nDid you mean "{self.bot_config.BOT_PREFIX}{alternatives}" ?'
         return msg
 
     def inject_commands_from(self, instance_to_inject):


### PR DESCRIPTION
95bb61f0 attempted to switch the string formatting in `unknown_command()` to use
f-strings instead of string concatenation, but failed to add the `f` prefix to
the string, meaning the "Did you mean" part of the output when a nonexisting
command is attempted is outputted literally as:

> Did you mean "{self.bot_config.BOT_PREFIX}{alternatives}" ?

This fixes that so the variables will be replaced in the string as intended.