### PR TITLE
Support Chatroom Names With Spaces

### DIFF
--- a/errbot/core_plugins/chatRoom.py
+++ b/errbot/core_plugins/chatRoom.py
@@ -37,7 +37,7 @@ class ChatRoom(BotPlugin):
         self.connected = False
         super().deactivate()
 
-    @botcmd(split_args_with=SeparatorArgParser())
+    @botcmd(split_args_with=ShlexArgParser())
     def room_create(self, message, args):
         """
         Create a chatroom.
@@ -87,7 +87,7 @@ class ChatRoom(BotPlugin):
         room.join(username=self.bot_config.CHATROOM_FN, password=password)
         return "Joined the room {}".format(room_name)
 
-    @botcmd(split_args_with=SeparatorArgParser())
+    @botcmd(split_args_with=ShlexArgParser())
     def room_leave(self, message, args):
         """
         Leave a chatroom.
@@ -106,7 +106,7 @@ class ChatRoom(BotPlugin):
         self.query_room(args[0]).leave()
         return "Left the room {}".format(args[0])
 
-    @botcmd(split_args_with=SeparatorArgParser())
+    @botcmd(split_args_with=ShlexArgParser())
     def room_destroy(self, message, args):
         """
         Destroy a chatroom.
@@ -125,7 +125,7 @@ class ChatRoom(BotPlugin):
         self.query_room(args[0]).destroy()
         return "Destroyed the room {}".format(args[0])
 
-    @botcmd(split_args_with=SeparatorArgParser())
+    @botcmd(split_args_with=ShlexArgParser())
     def room_invite(self, message, args):
         """
         Invite one or more people into a chatroom.

--- a/errbot/version.py
+++ b/errbot/version.py
@@ -1,3 +1,3 @@
 # Just the current version of Errbot.
 # It is used for deployment on pypi AND for version checking at plugin load time.
-VERSION = '9.9.9'  # leave it at 9.9.9 on master until it is branched to a version.
+VERSION = '5.2.0'


### PR DESCRIPTION
Use ShlexArgParser in lieu of SeparatorArgParser

Some of the room commands in chatRoom.py use SeparatorArgParser which doesn’t correctly parse room names that contain spaces and are wrapped in double/single quotes. For example the command:

```
> room create "this is a new room"
< Created the room "this

> room create another new room
< Created the room another
```

By using ShlexArgParser the rooms with spaces and wrapped in double/single quotes will be parsed correctly. An arg without quotes or spaces will continue to be parsed correctly. For example:

```
> room create "this is a new room"
< Created the room this is a new room

> room list
< I'm currently in these rooms:
    this is a new room (group)
    <output cut for brevity>

> room create this_is_a_room_with_no_spaces_or_quotes@blah.com
< Created the room this_is_a_room_with_no_spaces_or_quotes@blah.com

> room list
< I'm currently in these rooms:
    this_is_a_room_with_no_spaces_or_quotes@blah.com (group)
    this is a new room (group)
    <output cut for brevity>
```