### PR TITLE
Support Room Names With Spaces

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ features:
 - backends/test: allow attachments to pytest messages as extras (#1489)
 - core/acl: Add allowargs / denyargs filters to ACL (#1509)
 - core/bootstrap: Small logging fixes to BOT_LOG_FILE and FORMATTER (#1513)
+- core/plugin: Support room names with spaces (#1262)
 
 fixes:
 

--- a/errbot/core_plugins/chatRoom.py
+++ b/errbot/core_plugins/chatRoom.py
@@ -41,7 +41,7 @@ class ChatRoom(BotPlugin):
         self.connected = False
         super().deactivate()
 
-    @botcmd(split_args_with=SeparatorArgParser())
+    @botcmd(split_args_with=ShlexArgParser())
     def room_create(self, message, args):
         """
         Create a chatroom.
@@ -91,7 +91,7 @@ class ChatRoom(BotPlugin):
         room.join(username=self.bot_config.CHATROOM_FN, password=password)
         return f"Joined the room {room_name}."
 
-    @botcmd(split_args_with=SeparatorArgParser())
+    @botcmd(split_args_with=ShlexArgParser())
     def room_leave(self, message, args):
         """
         Leave a chatroom.
@@ -110,7 +110,7 @@ class ChatRoom(BotPlugin):
         self.query_room(args[0]).leave()
         return f"Left the room {args[0]}."
 
-    @botcmd(split_args_with=SeparatorArgParser())
+    @botcmd(split_args_with=ShlexArgParser())
     def room_destroy(self, message, args):
         """
         Destroy a chatroom.
@@ -129,7 +129,7 @@ class ChatRoom(BotPlugin):
         self.query_room(args[0]).destroy()
         return f"Destroyed the room {args[0]}."
 
-    @botcmd(split_args_with=SeparatorArgParser())
+    @botcmd(split_args_with=ShlexArgParser())
     def room_invite(self, message, args):
         """
         Invite one or more people into a chatroom.

--- a/tests/muc_test.py
+++ b/tests/muc_test.py
@@ -123,6 +123,24 @@ def test_botcommands(testbot):  # noqa
     assert room.joined
     assert room in rooms
 
+    assert "Created the room testroom with spaces" in testbot.exec_command(
+        "!room create 'testroom with spaces'"
+    )
+    rooms = testbot.bot.rooms()
+    room = testbot.bot.query_room("testroom with spaces")
+    assert room.exists
+    assert room not in rooms
+    assert not room.joined
+
+    assert "Joined the room testroom with spaces" in testbot.exec_command(
+        "!room join 'testroom with spaces'"
+    )
+    rooms = testbot.bot.rooms()
+    room = testbot.bot.query_room("testroom with spaces")
+    assert room.exists
+    assert room.joined
+    assert room in rooms
+
     assert "testroom" in testbot.exec_command("!room list")
     assert "err" in testbot.exec_command("!room occupants testroom")
     assert "No topic is set for testroom" in testbot.exec_command(


### PR DESCRIPTION
Use ShlexArgParser in lieu of SeparatorArgParser

SOME of the room commands in chatRoom.py use SeparatorArgParser which doesn’t correctly parse room names that contain spaces and are wrapped in double/single quotes. For example the command:

```
> room create "this is a new room"
< Created the room "this

> room create another new room
< Created the room another
```

By using ShlexArgParser the rooms with spaces and wrapped in double/single quotes will be parsed correctly. An arg without quotes or spaces will continue to be parsed correctly. For example:

```
> room create "this is a new room"
< Created the room this is a new room

> room list
< I'm currently in these rooms:
    this is a new room (group)
    <output cut for brevity>

> room create this_is_a_room_with_no_spaces_or_quotes@blah.com
< Created the room this_is_a_room_with_no_spaces_or_quotes@blah.com

> room list
< I'm currently in these rooms:
    this_is_a_room_with_no_spaces_or_quotes@blah.com (group)
    this is a new room (group)
    <output cut for brevity>
```