### PR TITLE
(#1181) Add unsupported delete message to the plugin API

### DIFF
--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -657,6 +657,10 @@ class Backend(ABC):
         """Should be overridden by backends with a super().send_message() call."""
 
     @abstractmethod
+    def delete_message(self, msg: Message) -> None:
+        """Delete a message. Should be overridden by backends with a super().delete_message() call if applicable."""
+
+    @abstractmethod
     def change_presence(self, status: str = ONLINE, message: str = '') -> None:
         """Signal a presence change for the bot. Should be overridden by backends with a super().send_message() call."""
 

--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -10,6 +10,11 @@ from collections import deque, defaultdict
 log = logging.getLogger('errbot.backends.base')
 
 
+class UnsupportedException(Exception):
+    """This method is unsupported by the chosen backend."""
+    pass
+
+
 class Identifier(ABC):
     """This is just use for type hinting representing the Identifier contract,
     NEVER TRY TO SUBCLASS IT OUTSIDE OF A BACKEND, it is just here to show you what you can expect from an Identifier.
@@ -656,9 +661,9 @@ class Backend(ABC):
     def send_message(self, msg: Message) -> None:
         """Should be overridden by backends with a super().send_message() call."""
 
-    @abstractmethod
     def delete_message(self, msg: Message) -> None:
         """Delete a message. Should be overridden by backends with a super().delete_message() call if applicable."""
+        raise UnsupportedException("This method is unsupported by the chosen backend.")
 
     @abstractmethod
     def change_presence(self, status: str = ONLINE, message: str = '') -> None:


### PR DESCRIPTION
From #1189, adds a method for deleting messages to the base API that should be overridden by any backends that support it.

Not sure if there's anything I should do beyond the below, so please let me know if there's unit tests or anything else that needs to be added. Would also appreciate some advice/structure help if there is :)