### PR TITLE
Advanced loop graph does not reflect the image

### DIFF
--- a/docs/user_guide/flow_development/advanced.rst
+++ b/docs/user_guide/flow_development/advanced.rst
@@ -102,7 +102,8 @@ instead of the command name in that case.
     def example(self, flow: FlowRoot):
         first_step = flow.connect('first')
         second_step = first_step.connect('second')
-        third_step = second_step.connect(first_step, predicate=...)
+        third_step = second_step.connect('third')
+        third_step.connect(first_step, predicate=...)
         final_step = third_step.connect('final', predicate=...)
 
 You can represent this flow like this:


### PR DESCRIPTION
`FlowNode.connect` returns a `FlowNode` instance.
If `node_or_command` is as string, a `FlowNode` is created for the string.
If `node_or_command` is a `FlowNode` instance, `node_or_command` is returned directly

This means the present sample the following is true `assert third_step is first_step`.
`!third` does not exist as an actual command / `FlowNode`
Additionally, this means `final_step` is attached to `first_node` directly.
Accordingly on entry to `second_step` it can only transition to `first_step`.
`final_step` is not accessible from phantom `third_step`

This change allows it to match the image

I chose a code update, as I do not deal with SVG. Though I suspect an image & code update should occur to shorten the example, remove !third, then attach / loop from !second and connect final to !second