### PR TITLE
Add deletion functionality to Slack backend

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -688,6 +688,22 @@ class SlackBackend(ErrBot):
                 "to %s: %s" % (to_humanreadable, msg.body)
             )
 
+    def delete_message(self, msg: Message):
+        channel_id = self._get_channel_id(msg)
+        data = {
+            'ts': self._bot._ts_for_message(msg),
+            'channel': channel_id
+        }
+        return self._bot.api_call('chat.delete', data=data)
+
+    def _get_channel_id(self, msg: Message):
+        """Get relevant channel/person ID from a message"""
+        if msg.is_group:
+            to_channel_id = msg.to.id
+        else:
+            to_channel_id = msg.to.channelid
+        return to_channel_id
+
     def _slack_upload(self, stream):
         """Perform upload defined in a stream."""
         try:


### PR DESCRIPTION
From #1189, adds a method for deleting messages to the slack API.