### PR TITLE
Add unsupported update message to the plugin API

### DIFF
--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -657,6 +657,10 @@ class Backend(ABC):
         """Should be overridden by backends with a super().send_message() call."""
 
     @abstractmethod
+    def update_message(self, msg: Message) -> None:
+        """Update a message. Should be overridden by backends with a super().update_message() call if applicable."""
+
+    @abstractmethod
     def change_presence(self, status: str = ONLINE, message: str = '') -> None:
         """Signal a presence change for the bot. Should be overridden by backends with a super().send_message() call."""
 

--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -656,9 +656,9 @@ class Backend(ABC):
     def send_message(self, msg: Message) -> None:
         """Should be overridden by backends with a super().send_message() call."""
 
-    @abstractmethod
     def update_message(self, msg: Message) -> None:
         """Update a message. Should be overridden by backends with a super().update_message() call if applicable."""
+        raise UnsupportedException("This method is unsupported by the chosen backend.")
 
     @abstractmethod
     def change_presence(self, status: str = ONLINE, message: str = '') -> None:


### PR DESCRIPTION
From #1189, adds a method for updating messages to the base API that should be overridden by any backends that support it.

Uses the exception defined in #1265 