### PR TITLE
FIX msg.delayed value in XMPP backend

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ features:
 
 fixes:
 
+- backend/xmpp: include message delayed for send/recieved messages (#1270)
 - backend/xmpp: "unexpected keyword argument 'wait'" when connecting (#1507)
 - docs: update broken readme link to plugin development docs (#1504)
 - close threadpool on exit (#1486)

--- a/errbot/backends/xmpp.py
+++ b/errbot/backends/xmpp.py
@@ -2,6 +2,7 @@ import logging
 import sys
 from functools import lru_cache
 from time import sleep
+from datetime import datetime
 
 from errbot.backends.base import (
     AWAY,
@@ -495,10 +496,10 @@ class XMPPBackend(ErrBot):
             msg.frm = self._build_person(xmppmsg["from"].full)
             msg.to = self._build_person(xmppmsg["to"].full)
 
-        msg.nick = xmppmsg["mucnick"]
-        msg.delayed = bool(
-            xmppmsg["delay"]._get_attr("stamp")
-        )  # this is a bug in slixmpp it should be ['from']
+        msg.nick = xmppmsg['mucnick']
+        now = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+        delay = xmppmsg['delay']._get_attr('stamp')  # this is a bug in sleekxmpp it should be ['from']
+        msg.delayed = bool(delay and delay != now)
         self.callback_message(msg)
 
     def _idd_from_event(self, event):

--- a/errbot/backends/xmpp.py
+++ b/errbot/backends/xmpp.py
@@ -1,8 +1,8 @@
 import logging
 import sys
+from datetime import datetime
 from functools import lru_cache
 from time import sleep
-from datetime import datetime
 
 from errbot.backends.base import (
     AWAY,
@@ -496,9 +496,11 @@ class XMPPBackend(ErrBot):
             msg.frm = self._build_person(xmppmsg["from"].full)
             msg.to = self._build_person(xmppmsg["to"].full)
 
-        msg.nick = xmppmsg['mucnick']
-        now = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
-        delay = xmppmsg['delay']._get_attr('stamp')  # this is a bug in sleekxmpp it should be ['from']
+        msg.nick = xmppmsg["mucnick"]
+        now = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+        delay = xmppmsg["delay"]._get_attr(
+            "stamp"
+        )  # this is a bug in sleekxmpp it should be ['from']
         msg.delayed = bool(delay and delay != now)
         self.callback_message(msg)
 


### PR DESCRIPTION
In case of a delayed value defined in message is equal to localtime, it means there is no delay