### PR TITLE
fix: arg_botcmd decorator now can be used as plain method

### DIFF
--- a/errbot/__init__.py
+++ b/errbot/__init__.py
@@ -335,6 +335,9 @@ def arg_botcmd(*args,
         The `unpack_args=False` only needs to be specified once, on the bottom `@args_botcmd`
         statement.
     """
+    argparse_args = args
+    if len(args) >= 1 and callable(args[0]):
+        argparse_args = args[1:]
 
     def decorator(func):
 
@@ -394,14 +397,14 @@ def arg_botcmd(*args,
             # alias it so we can update it's arguments below
             wrapper = func
 
-        wrapper._err_command_parser.add_argument(*args, **kwargs)
+        wrapper._err_command_parser.add_argument(*argparse_args, **kwargs)
         wrapper.__doc__ = wrapper._err_command_parser.format_help()
         fmt = wrapper._err_command_parser.format_usage()
         wrapper._err_command_syntax = fmt[len('usage: ') + len(wrapper._err_command_parser.prog) + 1:-1]
 
         return wrapper
 
-    return decorator
+    return decorator(args[0]) if callable(args[0]) else decorator
 
 
 def _tag_webhook(func, uri_rule, methods, form_param, raw):

--- a/errbot/bootstrap.py
+++ b/errbot/bootstrap.py
@@ -103,12 +103,12 @@ def setup_bot(backend_name: str, logger, config, restore=None) -> ErrBot:
 
         try:
             if hasattr(config, 'SENTRY_TRANSPORT') and isinstance(config.SENTRY_TRANSPORT, tuple):
-                    mod = importlib.import_module(config.SENTRY_TRANSPORT[1])
-                    transport = getattr(mod, config.SENTRY_TRANSPORT[0])
+                mod = importlib.import_module(config.SENTRY_TRANSPORT[1])
+                transport = getattr(mod, config.SENTRY_TRANSPORT[0])
 
-                    sentryhandler = SentryHandler(config.SENTRY_DSN,
-                                                  level=config.SENTRY_LOGLEVEL,
-                                                  transport=transport)
+                sentryhandler = SentryHandler(config.SENTRY_DSN,
+                                              level=config.SENTRY_LOGLEVEL,
+                                              transport=transport)
             else:
                 sentryhandler = SentryHandler(config.SENTRY_DSN, level=config.SENTRY_LOGLEVEL)
             logger.addHandler(sentryhandler)

--- a/tests/dyna_plugin/dyna.py
+++ b/tests/dyna_plugin/dyna.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from errbot import BotPlugin, botcmd, Command, botmatch
+from errbot import BotPlugin, botcmd, Command, botmatch, arg_botcmd
 
 
 def say_foo(plugin, msg, args):
@@ -7,7 +7,7 @@ def say_foo(plugin, msg, args):
 
 
 class Dyna(BotPlugin):
-    """Just a test plugin to see if synamic plugin API works.
+    """Just a test plugin to see if dynamic plugin API works.
     """
     @botcmd
     def add_simple(self, _, _1):
@@ -21,6 +21,23 @@ class Dyna(BotPlugin):
     @botcmd
     def remove_simple(self, msg, args):
         self.destroy_dynamic_plugin('simple with special#')
+        return 'removed'
+
+    @botcmd
+    def add_arg(self, _, _1):
+        cmd1_name = 'echo_to_me'
+        cmd1 = Command(lambda plugin, msg, args: 'string to echo is %s' % args.positional_arg,
+                       cmd_type=arg_botcmd, cmd_args=('positional_arg',),
+                       cmd_kwargs={'unpack_args': False, 'name': cmd1_name},
+                       name=cmd1_name)
+
+        self.create_dynamic_plugin('arg', (cmd1,), doc='documented')
+
+        return 'added'
+
+    @botcmd
+    def remove_arg(self, msg, args):
+        self.destroy_dynamic_plugin('arg')
         return 'removed'
 
     @botcmd

--- a/tests/dynaplug_test.py
+++ b/tests/dynaplug_test.py
@@ -12,6 +12,13 @@ def test_simple(testbot):
     assert 'Command "say_foo" not found' in testbot.exec_command('!say_foo')
 
 
+def test_arg(testbot):
+    assert 'added' in testbot.exec_command('!add_arg')
+    assert 'string to echo is string_to_echo' in testbot.exec_command('!echo_to_me string_to_echo')
+    assert 'removed' in testbot.exec_command('!remove_arg')
+    assert 'Command "echo_to_me" / "echo_to_me string_to_echo" not found' in testbot.exec_command('!echo_to_me string_to_echo')
+
+
 def test_re(testbot):
     assert 'added' in testbot.exec_command('!add_re')
     assert 'fffound' in testbot.exec_command('I said cheese')

--- a/tests/dynaplug_test.py
+++ b/tests/dynaplug_test.py
@@ -16,7 +16,8 @@ def test_arg(testbot):
     assert 'added' in testbot.exec_command('!add_arg')
     assert 'string to echo is string_to_echo' in testbot.exec_command('!echo_to_me string_to_echo')
     assert 'removed' in testbot.exec_command('!remove_arg')
-    assert 'Command "echo_to_me" / "echo_to_me string_to_echo" not found' in testbot.exec_command('!echo_to_me string_to_echo')
+    assert ('Command "echo_to_me" / "echo_to_me string_to_echo" not found'
+            in testbot.exec_command('!echo_to_me string_to_echo'))
 
 
 def test_re(testbot):


### PR DESCRIPTION
Dynamic command creation with Command(cmd_type=arg_botcmd)
now works just like with any other cmd_type

Fixes #1081