### PR TITLE
Fix webhook test to not call testbot fixture directly

### DIFF
--- a/tests/webhooks_test.py
+++ b/tests/webhooks_test.py
@@ -45,12 +45,11 @@ def wait_for_server(port: int):
 
 
 @pytest.fixture
-def webhook_testbot(request):
-    tbot = testbot(request)
-    tbot.push_message("!plugin config Webserver {'HOST': 'localhost', 'PORT': %s, 'SSL': None}" % WEBSERVER_PORT)
-    log.info(tbot.pop_message())
+def webhook_testbot(request, testbot):
+    testbot.push_message("!plugin config Webserver {'HOST': 'localhost', 'PORT': %s, 'SSL': None}" % WEBSERVER_PORT)
+    log.info(testbot.pop_message())
     wait_for_server(WEBSERVER_PORT)
-    return tbot
+    return testbot
 
 
 def test_not_configured_url_returns_404(webhook_testbot):


### PR DESCRIPTION
https://github.com/pytest-dev/pytest/issues/3950

Fixes https://github.com/errbotio/errbot/issues/1275

In pytest 4.0, calling a figure directly is now no longer ok so they introduced a breaking change.