### PR TITLE
Fix check_configuration documentation

### DIFF
--- a/errbot/botplugin.py
+++ b/errbot/botplugin.py
@@ -361,7 +361,7 @@ class BotPlugin(BotPluginBase):
         2. in case of an array or tuple, it will assume array members of the
            same type of first element of the template (no mix typed is supported)
 
-        In case of validation error it should raise a errbot.utils.ValidationException
+        In case of validation error it should raise a errbot.ValidationException
 
         :param configuration: the configuration to be checked.
         """


### PR DESCRIPTION
errbot.utils.ValidationException has been moved to errbot.ValidationException as of 5.0.0. 

Update this docstring so we can update the docs as well.