### PR TITLE
Issue #1206: Check for git before starting the bot

### DIFF
--- a/docs/user_guide/setup.rst
+++ b/docs/user_guide/setup.rst
@@ -6,6 +6,10 @@ Prerequisites
 
 Errbot runs under Python 3.3+ on Linux, Windows and Mac.
 
+Errbot uses the system's `git` package to clone plugin repositories. You must have git installed, in the path, and
+executable by the user that Errbot runs as.
+
+
 Installation
 ------------
 


### PR DESCRIPTION
This solves https://github.com/errbotio/errbot/issues/1206 by checking for git before the bot starts. It also adds a new validate_prerequisites we could use for further validation as we find other things we might want to check before launching the bot.

Tested this with the python:3.6-slim docker image. It does not come with git by default
```
root@c504a7b40ae5:/errbot-test# git
bash: git: command not found
root@c504a7b40ae5:/errbot-test# errbot -T
git is not found in your PATH
The required 'git' package is either not installed or accessible in your system path. Please install 'git' or ensure it's added to your system path.
root@c504a7b40ae5:/errbot-test#
```

After installing git
```
root@c504a7b40ae5:/errbot-test# git --version
git version 2.11.0
root@c504a7b40ae5:/errbot-test# errbot -T
02:12:07 INFO     errbot.bootstrap          Found Storage plugin: Shelf.
02:12:07 INFO     errbot.bootstrap          Found Backend plugin: Text
02:12:07 DEBUG    errbot.storage            Opening storage 'repomgr'
02:12:07 DEBUG    errbot.storage.shelf      Open shelf storage /errbot-test/data/repomgr.db
02:12:07 DEBUG    errbot.core               ErrBot init.
02:12:07 DEBUG    errbot.backends.base      Backend init.
02:12:07 DEBUG    errbot.core               created a thread pool of size 10.
02:12:07 DEBUG    errbot.backends.text      Text Backend Init.
02:12:07 DEBUG    errbot.backends.text      Bot username set at @errbot.
02:12:07 DEBUG    MARKDOWN                  Successfully loaded extension "markdown.extensions.fenced_code.FencedCodeExtension".
02:12:07 DEBUG    MARKDOWN                  Successfully loaded extension "markdown.extensions.footnotes.FootnoteExtension".
02:12:07 DEBUG    MARKDOWN                  Successfully loaded extension "markdown.extensions.attr_list.AttrListExtension".
02:12:07 DEBUG    MARKDOWN                  Successfully loaded extension "markdown.extensions.def_list.DefListExtension".
02:12:07 DEBUG    MARKDOWN                  Successfully loaded extension "markdown.extensions.tables.TableExtension".
02:12:07 DEBUG    MARKDOWN                  Successfully loaded extension "markdown.extensions.abbr.AbbrExtension".
02:12:07 DEBUG    MARKDOWN                  Successfully loaded extension "markdown.extensions.extra.ExtraExtension".
02:12:07 DEBUG    MARKDOWN                  Successfully loaded extension "errbot.rendering.ansiext.AnsiExtension".
02:12:07 DEBUG    errbot.storage            Opening storage 'core'
02:12:07 DEBUG    errbot.storage.shelf      Open shelf storage /errbot-test/data/core.db
02:12:07 DEBUG    errbot.core               Initializing backend storage
02:12:07 DEBUG    errbot.storage            Opening storage 'text_backend'
02:12:07 DEBUG    errbot.storage.shelf      Open shelf storage /errbot-test/data/text_backend.db
02:12:07 DEBUG    errbot.plugin_manager     New entries added to sys.path:
02:12:07 DEBUG    errbot.plugin_manager     /errbot-test/plugins/err-example
02:12:07 DEBUG    errbot.plugin_manager     /errbot-test/errbot/core_plugins
02:12:07 DEBUG    errbot.plugins.Example    Logger for plugin initialized...
02:12:07 DEBUG    errbot.plugins.Utils      Logger for plugin initialized...
02:12:07 DEBUG    errbot.plugins.Health     Logger for plugin initialized...
02:12:07 INFO     errbot                    webhooks:  Flag to bind /echo to echo
02:12:07 DEBUG    errbot.plugins.Webserver  Logger for plugin initialized...
02:12:07 DEBUG    errbot.plugins.TextCmds   Logger for plugin initialized...
02:12:07 DEBUG    errbot.plugins.Flows      Logger for plugin initialized...
02:12:07 DEBUG    errbot.plugins.Backup     Logger for plugin initialized...
02:12:07 DEBUG    errbot.plugins.VersionChe Logger for plugin initialized...
02:12:07 DEBUG    errbot.plugins.ACLs       Logger for plugin initialized...
02:12:07 DEBUG    errbot.plugins.ChatRoom   Logger for plugin initialized...
02:12:07 DEBUG    errbot.plugins.Help       Logger for plugin initialized...
02:12:07 DEBUG    errbot.plugins.Plugins    Logger for plugin initialized...
02:12:07 DEBUG    errbot.plugins.CommandNot Logger for plugin initialized...
02:12:07 DEBUG    errbot.bootstrap          Start serving commands from the text backend.
────────────────────────────────────────────────────────────────────────────────
 You start as a bot admin in a one-on-one conversation with the bot.

    Context of the chat

• Use !inroom to switch to a room conversation.
• Use !inperson to switch back to a one-on-one conversation.
• Use !asuser to talk as a normal user.
• Use !asadmin to switch back as a bot admin.

    Preferences

• Use !ml to flip on/off the multiline mode (Enter twice at the end to send).
────────────────────────────────────────────────────────────────────────────────

[@CHANGE_ME ➡ @errbot] >>>
```