### PR TITLE
Set markdown version below 3.0 to preserve functionality until fixed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ deps = ['webtest',
         'jinja2',
         'pyOpenSSL',
         'colorlog',
-        'markdown',  # rendering stuff
+        'markdown<3.0',  # rendering stuff, 3.0+ deprecates 'safe()'
         'ansi',
         'Pygments>=2.0.2',
         'pygments-markdown-lexer>=0.1.0.dev39',  # sytax coloring to debug md


### PR DESCRIPTION
Set limit on Python-markdown version as 3.0+ deprecated `safe()` which breaks Webserver at this time as indicated [here](https://github.com/errbotio/errbot/issues/1255)