### PR TITLE
Update webserver.py

### DIFF
--- a/errbot/core_plugins/webserver.py
+++ b/errbot/core_plugins/webserver.py
@@ -67,13 +67,13 @@ class Webserver(BotPlugin):
         super().__init__(*args, **kwargs)
 
     def get_configuration_template(self):
-        return {'HOST': '0.0.0.0',
-                'PORT': 3141,
-                'SSL': {'enabled': False,
-                        'host': '0.0.0.0',
-                        'port': 3142,
-                        'certificate': '',
-                        'key': ''}}
+        return {"HOST": "0.0.0.0",
+                "PORT": 3141,
+                "SSL": {"enabled": False,
+                        "host": "0.0.0.0",
+                        "port": 3142,
+                        "certificate": "",
+                        "key": ""}}
 
     def check_configuration(self, configuration):
         # it is a pain, just assume a default config if SSL is absent or set to None


### PR DESCRIPTION
In the default get_configuration call triggered by `!plugin config Webserver` the single quotes will not process properly, yielding a syntax error. If they are changed to double-quotes it configures correctly.

_err.log_
```
[...]
    node_or_string = parse(node_or_string, mode='eval')
  File "/usr/local/lib/python3.7/ast.py", line 35, in parse
    return compile(source, filename, mode, PyCF_ONLY_AST)
  File "<unknown>", line 1
    {‘HOST’: ‘127.0.0.1’, ‘PORT’: 3141, ‘SSL’: {‘certificate’: ‘’, ‘enabled’: False, ‘host’: ‘127.0.0.1’, ‘key’: ‘’, ‘port’: 3142}}
          ^
SyntaxError: invalid character in identifier
```

However, if altered to double quotes in the config command:
_err.log_
```
[...]
2019-01-18 19:23:42,260 INFO     errbot.core               Processing command 'plugin_config' with parameters 'Webserver { "HOST": "127.0.0.1" }' from @userperson
2019-01-18 19:23:42,283 INFO     errbot.plugin_manager     Activating Webserver with min_err_version = 5.2.0 and max_version = 5.2.0
```