### PR TITLE
Dynamic versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 sudo: false
 language: python
+
+git:
+  depth: false
+
 matrix:
   include:
     - python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,14 @@ matrix:
   include:
     - python: 3.6
       env: TOXENV=py36
-    - python: 3.7-dev
-      env: TOXENV=py37
     - python: 3.6
       env: TOXENV=pypi-lint
     - python: 3.6
       env: TOXENV=codestyle
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      env: TOXENV=py37
 
 install: pip install tox
 before_script: cp tests/config-travisci.py config.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,19 @@ notifications:
     on_success: always  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
     on_start: true     # default: false
+deploy:
+- provider: pypi
+  user: gbin
+  password:
+    secure: xyzABC123
+  distributions: bdist_wheel
+  on:
+    condition: $TOXENV = lint
+- provider: pypi
+  user: gbin
+  password:
+    secure: xyzABC123
+  distributions: bdist_wheel
+  on:
+    condition: $TOXENV = lint
+    tags: true

--- a/errbot/core_plugins/help.py
+++ b/errbot/core_plugins/help.py
@@ -27,11 +27,7 @@ class Help(BotPlugin):
     @botcmd(template='about')
     def about(self, msg, args):
         """Return information about this Errbot instance and version"""
-        git_version = self.is_git_directory()
-        if git_version:
-            return dict(version=f"{git_version.decode('utf-8')} GIT CHECKOUT")
-        else:
-            return {'version': VERSION}
+        return {'version': VERSION}
 
     # noinspection PyUnusedLocal
     @botcmd

--- a/errbot/utils.py
+++ b/errbot/utils.py
@@ -18,6 +18,7 @@ PLUGINS_SUBDIR = 'plugins'
 # noinspection PyPep8Naming
 class deprecated(object):
     """ deprecated decorator. emits a warning on a call on an old method and call the new method anyway """
+
     def __init__(self, new=None):
         self.new = new
 
@@ -68,10 +69,11 @@ INVALID_VERSION_EXCEPTION = 'version %s in not in format "x.y.z" or "x.y.z-{beta
 
 
 def version2tuple(version):
-    vsplit = version.split('-')
 
-    if len(vsplit) == 2:
-        main, sub = vsplit
+    main, _sep, sub = version.partition('-')
+    sub_int = sys.maxsize
+
+    if sub:
         if sub == 'alpha':
             sub_int = -1
         elif sub == 'beta':
@@ -81,11 +83,9 @@ def version2tuple(version):
         else:
             raise ValueError(INVALID_VERSION_EXCEPTION % version)
 
-    elif len(vsplit) == 1:
-        main = vsplit[0]
-        sub_int = sys.maxsize
-    else:
-        raise ValueError(INVALID_VERSION_EXCEPTION % version)
+    if '.dev' in main:
+        sub_int = -2
+        main, *_ = main.rpartition('.dev')
 
     response = [int(el) for el in main.split('.')]
     response.append(sub_int)
@@ -108,6 +108,7 @@ def rate_limited(min_interval):
     :param min_interval: minimum interval allowed between 2 consecutive calls.
     :return: the decorated function
     """
+
     def decorate(func):
         last_time_called = [0.0]
 

--- a/errbot/version.py
+++ b/errbot/version.py
@@ -1,3 +1,8 @@
 # Just the current version of Errbot.
 # It is used for deployment on pypi AND for version checking at plugin load time.
-VERSION = '9.9.9'  # leave it at 9.9.9 on master until it is branched to a version.
+from pkg_resources import get_distribution, DistributionNotFound
+try:
+    VERSION = get_distribution('errbot').version
+except DistributionNotFound:
+    # package is not installed
+    VERSION = '9.9.9'

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,6 @@ ON_WINDOWS = system() == 'Windows'
 if py_version < (3, 6):
     raise RuntimeError('Errbot requires Python 3.6 or later')
 
-VERSION_FILE = os.path.join('errbot', 'version.py')
-
 deps = ['webtest',
         'setuptools',
         'flask',
@@ -52,33 +50,15 @@ if not ON_WINDOWS:
 src_root = os.curdir
 
 
-def read_version():
-    """
-    Read directly the errbot/version.py and gives the version without loading Errbot.
-    :return: errbot.version.VERSION
-    """
-
-    variables = {}
-    with open(VERSION_FILE) as f:
-        exec(compile(f.read(), 'version.py', 'exec'), variables)
-    return variables['VERSION']
-
-
 def read(fname, encoding='ascii'):
     return open(os.path.join(os.path.dirname(__file__), fname), 'r', encoding=encoding).read()
 
 
 if __name__ == "__main__":
 
-    VERSION = read_version()
-
-    args = set(sys.argv)
-
     changes = read('CHANGES.rst', 'utf8')
 
-    if changes.find(VERSION) == -1:
-        raise Exception('You forgot to put a release note in CHANGES.rst ?!')
-
+    args = set(sys.argv)
     if args & {'bdist', 'bdist_dumb', 'bdist_rpm', 'bdist_wininst', 'bdist_msi'}:
         raise Exception("err doesn't support binary distributions")
 
@@ -86,7 +66,10 @@ if __name__ == "__main__":
 
     setup(
         name="errbot",
-        version=VERSION,
+        setup_requires=['setuptools_scm'],
+        use_scm_version={
+            'local_scheme': 'dirty-tag',
+        },
         packages=packages,
         entry_points={
             'console_scripts': [

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -22,6 +22,8 @@ log = logging.getLogger(__name__)
                          ('2.0.0-rc2', '2.0.0-rc3'),
                          ('2.0.0-rc2', '2.0.0'),
                          ('2.0.0-beta', '2.0.1'),
+                         ('3.1.1.dev1239+dirty', '3.1.2'),
+                         ('3.1.1.dev5+dirty', '3.2.0'),
                          ])
 def test_version_check(v1, v2):
     assert version2tuple(v1) < version2tuple(v2)

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
     pytest
     slackclient
 
-commands = py.test
+commands = pytest
 
 [testenv:codestyle]
 deps = pycodestyle

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     slackclient
 
 commands = pytest
+recreate = True
 
 [testenv:codestyle]
 deps = pycodestyle


### PR DESCRIPTION
This attempts to use git annotated tags as the errbot versions. This can be helpful as we can [leverage travis](https://docs.travis-ci.com/user/deployment/pypi/#deploying-tags) to create development/pre-releases upon merges to `master`. It can also help with us to easily create errbot releases and [publishing them to pypi](https://docs.travis-ci.com/user/deployment/pypi/#releasing-build-artifacts).

I've added some configs in `.travis.yml` to make this functional (pending real creds are added).