### PR TITLE
Split the command on _all_ whitespace when matching commands

### DIFF
--- a/errbot/core.py
+++ b/errbot/core.py
@@ -266,7 +266,7 @@ class ErrBot(Backend, StoreMixin):
             prefixed = True
 
         text = text.strip()
-        text_split = text.split(' ')
+        text_split = text.split()
         cmd = None
         command = None
         args = ''


### PR DESCRIPTION
Solves #1307 by treating all whitespace as things that could potentially
separate a command from its arguments