### PR TITLE
test: Add security linter with bandit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ matrix:
       dist: xenial
       sudo: true
       env: TOXENV=codestyle
+    - python: 3.6
+      env: TOXENV=security
 
 install: pip install tox
 before_script: cp tests/config-travisci.py config.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       dist: xenial
       sudo: true
       env: TOXENV=codestyle
-    - python: 3.6
+    - python: 3.7
       env: TOXENV=security
 
 install: pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,codestyle,pypi-lint
+envlist = py36,py37,codestyle,pypi-lint,security
 skip_missing_interpreters = True
 
 [testenv]
@@ -18,3 +18,9 @@ commands = pycodestyle errbot tests --ignore=E252
 [testenv:pypi-lint]
 deps = docutils
 commands = python setup.py check --restructured --strict --metadata
+
+[testenv:security]
+deps =
+    bandit
+commands =
+    bandit -r errbot/

--- a/tox.ini
+++ b/tox.ini
@@ -22,5 +22,7 @@ commands = python setup.py check --restructured --strict --metadata
 [testenv:security]
 deps =
     bandit
+
+; ignoring errors
 commands =
-    bandit -r errbot/
+    - bandit -r errbot/


### PR DESCRIPTION
This is adding a security linter named [bandit](https://pypi.org/project/bandit/) to our testing process.

I thought it would be educational to see what potential security issues we may be introducing.