### PR TITLE
fix double threading in slack backend if DIVERT_TO_THREAD is used

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -892,12 +892,12 @@ class SlackBackend(ErrBot):
     def build_reply(self, msg, text=None, private=False, threaded=False):
         response = self.build_message(text)
 
-        if threaded:
-            response.parent = msg
-
-        elif 'thread_ts' in msg.extras['slack_event']:
+        if 'thread_ts' in msg.extras['slack_event']:
             # If we reply to a threaded message, keep it in the thread.
             response.extras['thread_ts'] = msg.extras['slack_event']['thread_ts']
+        elif threaded:
+            # otherwise check if we should start a new thread
+            response.parent = msg
 
         response.frm = self.bot_identifier
         if private:


### PR DESCRIPTION
Current code tries to start a new thread (`if threaded:` statement) regardless of the current state.
We should check if we are in a thread before setting `response.parent`.