### PR TITLE
docs: Auto-create CHANGES from git

### DIFF
--- a/.gitchangelog.rc
+++ b/.gitchangelog.rc
@@ -1,0 +1,44 @@
+# Reference: https://github.com/vaab/gitchangelog/blob/master/src/gitchangelog/gitchangelog.rc.reference
+
+FILENAME = 'CHANGES.rst'
+
+unreleased_version_label = 'Unreleased (master)'
+include_merge = False
+
+section_regexps = [
+    ('New', [
+        r'^[Nn]ew',
+        r'^[Aa]dd',
+     ]),
+    ('Fixes', [
+        r'^[Ff]ix',
+        r'^[Uu]pdate',
+        r'[Aa]llow',
+     ]),
+    ('Docs', [
+        r'([Dd]ocs|[Dd]ocumentation)',
+        r'[Bb]adges?',
+     ]),
+    ('Other', None ## Match all lines
+     ),
+]
+
+subject_process = (strip | ucfirst | final_dot)
+ignore_regexps = [
+    r'[Pp][Ee][Pp]\-?8',
+    r'[Tt][Yy][Pp][Oo]',
+    r'spelling',
+    #r'[Ff]ormat(ing)?',
+    r'^$',  ## ignore commits with empty messages
+]
+
+body_process = ReSub(r'.*', r'') | strip
+
+revs = ["^4.0.0", "HEAD"]
+
+def write_changelog(lines):
+    """Write changelog to file."""
+    with open(FILENAME, 'wt') as f:
+        f.writelines(lines)
+
+publish = write_changelog

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,6 +130,10 @@ def run_repos_builder(*_):
     subprocess.check_call("pwd; cp repos.json ../docs/html_extras/", shell=True)
     os.chdir(last_dir)
 
+# -- Changelog -----------------------------------------------------------------
+
+def run_changelog(_):
+    subprocess.check_call("gitchangelog", shell=True)
 
 # -- Options for HTML output ---------------------------------------------------
 
@@ -321,3 +325,4 @@ def setup(app):
     app.connect("autodoc-skip-member", autodoc_skip_member)
     app.connect("builder-inited", run_apidoc)
     #app.connect("html-page-context", run_repos_builder)
+    app.connect("builder-inited", run_changelog)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,9 +3,10 @@ sphinx>=1.2
 sphinx-autodoc-annotation
 
 -e .
-slixmpp
+gitchangelog
+hypchat
 irc
 pyfire
 python-telegram-bot
 slackclient
-hypchat
+slixmpp


### PR DESCRIPTION
This dynamically creates `CHANGES.rst` using [gitchangelog](https://github.com/vaab/gitchangelog).

Since this file is shared with the website, a generated output looks like below:

![errbot-auto-changelog-01](https://user-images.githubusercontent.com/40614191/55808447-b68a4a80-5aa9-11e9-8a29-312770901848.png)
