### PR TITLE
fix simple typo

### DIFF
--- a/docs/user_guide/plugin_development/persistence.rst
+++ b/docs/user_guide/plugin_development/persistence.rst
@@ -7,7 +7,7 @@ if Errbot is restarted.
 How to use it
 -------------
 
-You plugin *is* the store, simply use self as a dictionary.
+Your plugin *is* the store, simply use self as a dictionary.
 
 Here is a simple example storing are retreiving value from the store.
 


### PR DESCRIPTION
fixing a simple typo in the errbot documentation in persistence section