### PR TITLE
fix: backup command exporting plugin values

### DIFF
--- a/errbot/core_plugins/backup.py
+++ b/errbot/core_plugins/backup.py
@@ -33,7 +33,7 @@ class Backup(BotPlugin):
                     f.write('pobj = bot.plugin_manager.plugins["' + plugin.name + '"]\n')
                     f.write('pobj.init_storage()\n')
 
-                    for key, value in plugin:
+                    for key, value in plugin.items():
                         f.write('pobj["' + key + '"] = ' + repr(value) + '\n')
                     f.write('pobj.close_storage()\n')
 


### PR DESCRIPTION
This fixes an error noticed when using the `!backup` command.

```
[@sijis ➡ @errbot] >>> !backup
Computer says nooo. See logs for details:
too many values to unpack (expected 2)
```
It now shows the following

```
[@sijis ➡ @errbot] >>> !backup
The backup file has been written in "/tmp/sijis/data/backup.py".
```