### PR TITLE
Increase Slack message size limit.  Fixes #1325

### DIFF
--- a/docs/user_guide/configuration/slack.rst
+++ b/docs/user_guide/configuration/slack.rst
@@ -76,3 +76,13 @@ then you can set `CHATROOM_PRESENCE` to a list of channels and groups to join.
 
     You may leave the value for `CHATROOM_FN` at its default
     as it is ignored by this backend.
+
+
+Message size limit
+------------------
+
+As of the 12th August 2018 the Slack API has a message limit size of 40,000 characters.  Messages 
+larger than 40,000 will be truncated by Slack's API.  Errbot includes the functionality to split 
+messages larger than 40,000 characters into multiple parts.  To reduce the message limit size, set the 
+`MESSAGE_SIZE_LIMIT` variable in the configuration file.  Errbot will use the smallest value between 
+the default 40,000 and `MESSAGE_SIZE_LIMIT`.

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -36,8 +36,9 @@ except ImportError:
 # token matching this regex.
 SLACK_CLIENT_CHANNEL_HYPERLINK = re.compile(r'^<#(?P<id>(C|G)[0-9A-Z]+)>$')
 
-# Empirically determined message size limit.
-SLACK_MESSAGE_LIMIT = 4096
+# https://api.slack.com/changelog/2018-04-truncating-really-long-messages
+# On August 12, 2018 we started truncating messages containing more than 40,000 characters.
+SLACK_MESSAGE_LIMIT = 40000
 
 USER_IS_BOT_HELPTEXT = (
     "Connected to Slack using a bot account, which cannot manage "


### PR DESCRIPTION
As per the information provided in issue #1325 the slack message limit has been increased from the empirical 4000 characters to the documented 40000 (https://api.slack.com/changelog/2018-04-truncating-really-long-messages).  The original limit of 4000 can always to achieved by setting the `MESSAGE_SIZE_LIMIT=4000` in the bot configuration.

Documentation about this feature has also been added.