### PR TITLE
Remove empty "text" body on Slack send_card

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -748,7 +748,6 @@ class SlackBackend(ErrBot):
                 attachment['footer'] = f'{footer} [{i + 1}/{part_count}]'
             attachment['text'] = parts[i]
             data = {
-                'text': ' ',
                 'channel': to_channel_id,
                 'attachments': json.dumps([attachment]),
                 'link_names': '1',


### PR DESCRIPTION
When "text" is provided, Slack uses this empty message as the body when
sharing (cross-posting) messages from one room to another.

If you remove this "text" field, it uses the content of the attachments.

## Before the patch

Original message:
<img width="414" alt="image" src="https://user-images.githubusercontent.com/97087/57746467-2df16200-7686-11e9-8057-104b507200a4.png">


Share dialog (blank preview):
<img width="542" alt="image" src="https://user-images.githubusercontent.com/97087/57746486-39448d80-7686-11e9-9315-c6c00bdd5bfe.png">

Cross-posted:
<img width="430" alt="image" src="https://user-images.githubusercontent.com/97087/57746495-406b9b80-7686-11e9-80ff-a62de89ba9a7.png">


## After the patch

Original message:
<img width="404" alt="image" src="https://user-images.githubusercontent.com/97087/57746530-5e390080-7686-11e9-8645-32e8f1ef3a23.png">

Share dialog:
<img width="537" alt="image" src="https://user-images.githubusercontent.com/97087/57746538-62fdb480-7686-11e9-85c2-d95c3ec2a69b.png">

Cross-posted:
<img width="479" alt="image" src="https://user-images.githubusercontent.com/97087/57746545-6c871c80-7686-11e9-8da2-89f6fad1ac4e.png">


