### PR TITLE
Implementing support for updating topics in XMPP-groupchats

### DIFF
--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -263,7 +263,7 @@ class Message(object):
     def clone(self):
         return Message(body=self._body, frm=self._from, to=self._to, parent=self._parent,
                        delayed=self._delayed, partial=self._partial, extras=self._extras, flow=self._flow,
-                       msubject = self._msubject)
+                       msubject=self._msubject)
 
     @property
     def to(self) -> Identifier:

--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -227,7 +227,8 @@ class Message(object):
                  delayed: bool = False,
                  partial: bool = False,
                  extras: Mapping = None,
-                 flow=None):
+                 flow=None,
+                 msubject: str = None):
         """
         :param body:
             The markdown body of the message.
@@ -240,6 +241,8 @@ class Message(object):
         :param partial:
             Indicates whether the message was obtained by breaking down the message to fit
             the ``MESSAGE_SIZE_LIMIT``.
+        :param msubject:
+            New topic for XMPP groupchat
         """
         self._body = body
         self._from = frm
@@ -249,6 +252,7 @@ class Message(object):
         self._extras = extras or dict()
         self._flow = flow
         self._partial = partial
+        self._msubject = msubject
 
         # Convenience shortcut to the flow context
         if flow:
@@ -258,7 +262,8 @@ class Message(object):
 
     def clone(self):
         return Message(body=self._body, frm=self._from, to=self._to, parent=self._parent,
-                       delayed=self._delayed, partial=self._partial, extras=self._extras, flow=self._flow)
+                       delayed=self._delayed, partial=self._partial, extras=self._extras, flow=self._flow,
+                       msubject = self._msubject)
 
     @property
     def to(self) -> Identifier:
@@ -344,6 +349,20 @@ class Message(object):
             A :class:`~errbot.Flow`
         """
         return self._from
+
+    @property
+    def msubject(self) -> str:
+        """
+        Get the plaintext body of the message.
+
+        :returns:
+            The body as a string.
+        """
+        return self._msubject
+
+    @msubject.setter
+    def msubject(self, msubject: str):
+        self._msubject = msubject
 
     def __str__(self):
         return self._body

--- a/errbot/backends/xmpp.py
+++ b/errbot/backends/xmpp.py
@@ -214,11 +214,11 @@ class XMPPRoom(XMPPIdentifier, Room):
         :param topic:
             The topic to set.
         """
-        self._bot.conn.client.send_message(mto = str(self),
-                                           mbody = topic,
-                                           msubject = topic,
-                                           mhtml = None,
-                                           mtype = 'groupchat')
+        self._bot.conn.client.send_message(mto=str(self),
+                                           mbody=topic,
+                                           msubject=topic,
+                                           mhtml=None,
+                                           mtype='groupchat')
 
     @property
     def occupants(self):

--- a/errbot/botplugin.py
+++ b/errbot/botplugin.py
@@ -512,7 +512,8 @@ class BotPlugin(BotPluginBase):
              identifier: Identifier,
              text: str,
              in_reply_to: Message = None,
-             groupchat_nick_reply: bool = False) -> None:
+             groupchat_nick_reply: bool = False,
+             msubject: bool=False) -> None:
         """
             Send a message to a room or a user.
 
@@ -522,10 +523,11 @@ class BotPlugin(BotPluginBase):
             :param text: markdown formatted text to send to the user.
             :param identifier: An Identifier representing the user or room to message.
                                Identifiers may be created with :func:`build_identifier`.
+            :param msubject: Whether or not this is a message to update topic for XMPP
         """
         if not isinstance(identifier, Identifier):
             raise ValueError("identifier needs to be of type Identifier, the old string behavior is not supported")
-        return self._bot.send(identifier, text, in_reply_to, groupchat_nick_reply)
+        return self._bot.send(identifier, text, in_reply_to, groupchat_nick_reply, msubject)
 
     def send_card(self,
                   body: str = '',

--- a/errbot/core.py
+++ b/errbot/core.py
@@ -112,7 +112,7 @@ class ErrBot(Backend, StoreMixin):
             except Exception:
                 log.exception('%s on %s crashed.', method, plugin_name)
 
-    def send(self, identifier, text, in_reply_to=None, groupchat_nick_reply=False):
+    def send(self, identifier, text, in_reply_to=None, groupchat_nick_reply=False, msubject=False):
         """ Sends a simple message to the specified user.
 
             :param identifier:
@@ -123,6 +123,8 @@ class ErrBot(Backend, StoreMixin):
                 the markdown text you want to send
             :param groupchat_nick_reply:
                 authorized the prefixing with the nick form the user
+            :param msubject:
+                Whether or not this is a message to update topic for XMPP
         """
         # protect a little bit the backends here
         if not isinstance(identifier, Identifier):
@@ -132,6 +134,7 @@ class ErrBot(Backend, StoreMixin):
         msg.to = identifier
         msg.frm = in_reply_to.to if in_reply_to else self.bot_identifier
         msg.parent = in_reply_to
+        msg.msubject = text if msubject else None
 
         nick_reply = self.bot_config.GROUPCHAT_NICK_PREFIXED
         if isinstance(identifier, Room) and in_reply_to and (nick_reply or groupchat_nick_reply):

--- a/errbot/core_plugins/chatRoom.py
+++ b/errbot/core_plugins/chatRoom.py
@@ -218,7 +218,7 @@ class ChatRoom(BotPlugin):
                 return f'Topic for {args[0]}: {topic}.'
         else:
             try:
-                self.query_room(args[0]).topic = args[1]
+                self.query_room(args[0]).topic = " ".join(args[1:])
             except RoomNotJoinedError as e:
                 return f'Cannot set the topic for {args[0]}: {e}.'
             return f"Topic for {args[0]} set."


### PR DESCRIPTION
I've added support for updating the topic in XMPP groupchats, and it is working for me, but i'm not 100% sure whether the code might cause issues for other backends, as i don't have any other backends to test with.   
The tests are passing, aside from a webhooks test that sometimes passes, sometimes fails. I didn't touch that file at all though. 

`errbot/backends/base.py`:
- `class Message` can now contain a `msubject`-string

`errbot/backends/xmpp.py`:
- Changed `send_message` to include msubject. Will either be None or string
- Fixed `@topic.setter` so it sends a message to update the topic

`errbot/botplugin.py`
- `send()` now accepts msubject bool. If True, `text` will be used as new topic by `send()` in `errbot/core.py`

`errbot/core.py`
- `send()` now accepts msubject bool. If True, `text` will be used as new topic

`errbot/core_plugins/chatRoom.py`
- New topic will now be `" ".join(args[1:])`. Otherwise only the first word of the new topic was used