### PR TITLE
chore: Move all tox environments to use py37

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,17 @@ matrix:
   include:
     - python: 3.6
       env: TOXENV=py36
-    - python: 3.7-dev
+    - python: 3.7
+      dist: xenial
+      sudo: true
       env: TOXENV=py37
-    - python: 3.6
+    - python: 3.7
+      dist: xenial
+      sudo: true
       env: TOXENV=pypi-lint
-    - python: 3.6
+    - python: 3.7
+      dist: xenial
+      sudo: true
       env: TOXENV=codestyle
 
 install: pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     slackclient>=1.0.5,<2.0
 
 commands = py.test
+recreate = true
 
 [testenv:codestyle]
 deps = pycodestyle


### PR DESCRIPTION
This makes tox use python 3.7.