### PR TITLE
Chore: 6.1.1 Release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+v6.1.1 (2019-06-22)
+-------------------
+
+fixes:
+
+- Installation using wheel distribution on python 3.6 or older
+
 v6.1.0 (2019-06-16)
 -------------------
 

--- a/errbot/version.py
+++ b/errbot/version.py
@@ -1,3 +1,3 @@
 # Just the current version of Errbot.
 # It is used for deployment on pypi AND for version checking at plugin load time.
-VERSION = '6.1.0'
+VERSION = '6.1.1'


### PR DESCRIPTION
This adds a changelog and bumps the version for a 6.1.1 release.

This PR depends on https://github.com/errbotio/errbot/pull/1349 being merged to `master` and `6.1` branches.