### PR TITLE
test: Rename assertCommand -> assertInCommand

### DIFF
--- a/docs/user_guide/plugin_development/testing.rst
+++ b/docs/user_guide/plugin_development/testing.rst
@@ -58,7 +58,7 @@ Then we set `extra_plugin_dir` to `.`, the current directory so that the test bo
 
 After that we define our first `test_` method which simply sends a command to the bot using :func:`~errbot.backends.test.TestBot.push_message` and then asserts that the response we expect, *"This is my awesome command"* is in the message we receive from the bot which we get by calling :func:`~errbot.backends.test.TestBot.pop_message`.
 
-You can assert the response of a command using the method assertCommand of the testbot. `testbot.assertCommand('!mycommand', 'This is my awesome command')` to achieve the equivalent of pushing message and asserting the response in the popped message.`
+You can assert the response of a command using the method assertInCommand of the testbot. `testbot.assertInCommand('!mycommand', 'This is my awesome command')` to achieve the equivalent of pushing message and asserting the response in the popped message.`
 
 Helper methods
 --------------

--- a/errbot/backends/test.py
+++ b/errbot/backends/test.py
@@ -15,6 +15,7 @@ from errbot.backends.base import Message, Room, Person, RoomOccupant, ONLINE
 from errbot.core_plugins.wsview import reset_app
 from errbot.core import ErrBot
 from errbot.bootstrap import setup_bot
+from errbot.utils import deprecated
 
 log = logging.getLogger(__name__)
 
@@ -451,13 +452,18 @@ class TestBot(object):
     def zap_queues(self):
         return self.bot.zap_queues()
 
-    def assertCommand(self, command, response, timeout=5, dedent=False):
+    def assertInCommand(self, command, response, timeout=5, dedent=False):
         """Assert the given command returns the given response"""
         if dedent:
             command = '\n'.join(textwrap.dedent(command).splitlines()[1:])
         self.bot.push_message(command)
         msg = self.bot.pop_message(timeout)
         assert response in msg, f'{response} not in {msg}.'
+
+    @deprecated(assertInCommand)
+    def assertCommand(self, command, response, timeout=5, dedent=False):
+        """Assert the given command returns the given response"""
+        pass
 
     def assertCommandFound(self, command, timeout=5):
         """Assert the given command exists"""

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -67,8 +67,8 @@ def test_config_cycle(testbot):
     assert 'Default configuration for this plugin (you can copy and paste this directly as a command)' in m
     assert 'Current configuration' not in m
 
-    testbot.assertCommand("!plugin config Webserver {'HOST': 'localhost', 'PORT': 3141, 'SSL':  None}",
-                          'Plugin configuration done.')
+    testbot.assertInCommand("!plugin config Webserver {'HOST': 'localhost', 'PORT': 3141, 'SSL':  None}",
+                            'Plugin configuration done.')
 
     assert 'Current configuration' in testbot.exec_command('!plugin config Webserver')
     assert 'localhost' in testbot.exec_command('!plugin config Webserver')
@@ -106,7 +106,7 @@ def test_plugin_cycle(testbot):
     ]
 
     for plugin in plugins:
-        testbot.assertCommand(
+        testbot.assertInCommand(
             '!repos install {0}'.format(plugin),
             'Installing {0}...'.format(plugin)
         ),
@@ -205,7 +205,7 @@ def test_encoding_preservation(testbot):
 def test_webserver_webhook_test(testbot):
     testbot.push_message("!plugin config Webserver {'HOST': 'localhost', 'PORT': 3141, 'SSL':  None}")
     assert 'Plugin configuration done.' in testbot.pop_message()
-    testbot.assertCommand("!webhook test /echo toto", 'Status code : 200')
+    testbot.assertInCommand("!webhook test /echo toto", 'Status code : 200')
 
 
 def test_activate_reload_and_deactivate(testbot):
@@ -367,7 +367,7 @@ def test_mock_injection(testbot):
 
 
 def test_multiline_command(testbot):
-    testbot.assertCommand(
+    testbot.assertInCommand(
         '''
         !bar title
         first line of body


### PR DESCRIPTION
This renames the `assertCommand` to `assertInCommand`. Its a more accurate description of what this method is actually doing.

I also deprecate the `assertCommand`.

Closes https://github.com/errbotio/errbot/issues/1069.