### PR TITLE
Typo in TextBackend.change_presence loging

### DIFF
--- a/errbot/backends/text.py
+++ b/errbot/backends/text.py
@@ -352,7 +352,7 @@ class TextBackend(ErrBot):
         self.send(msg.frm, f'reaction {sign}:{reaction}:', in_reply_to=msg)
 
     def change_presence(self, status: str = ONLINE, message: str = '') -> None:
-        log.debug("*** Changed presence to [%s] %s", (status, message))
+        log.debug("*** Changed presence to [%s] %s", status, message)
 
     def build_identifier(self, text_representation):
         if text_representation.startswith('#'):

--- a/tests/backend_tests/text_test.py
+++ b/tests/backend_tests/text_test.py
@@ -1,0 +1,39 @@
+import sys
+from tempfile import mkdtemp
+
+import pytest
+import logging
+import os
+
+
+from errbot.backends.text import TextBackend
+from errbot.bootstrap import bot_config_defaults
+
+
+@pytest.fixture
+def text_backend():
+    tempdir = mkdtemp()
+
+    # reset the config every time
+    sys.modules.pop('errbot.config-template', None)
+    __import__('errbot.config-template')
+    config = sys.modules['errbot.config-template']
+    bot_config_defaults(config)
+    config.BOT_DATA_DIR = tempdir
+    config.BOT_LOG_FILE = os.path.join(tempdir, 'log.txt')
+    config.BOT_EXTRA_PLUGIN_DIR = []
+    config.BOT_LOG_LEVEL = logging.DEBUG
+    config.BOT_PREFIX = '!'
+    config.BOT_IDENTITY['username'] = '@testme'
+    config.BOT_ADMINS = ['@test_admin']
+
+    return TextBackend(config)
+
+
+def test_change_presence(text_backend, caplog):
+    with caplog.at_level(logging.DEBUG):
+        text_backend.change_presence('online', "I'm online")
+    assert len(caplog.messages) == 1
+    a_message = caplog.messages[0]
+    assert a_message.startswith('*** Changed presence')
+

--- a/tests/backend_tests/text_test.py
+++ b/tests/backend_tests/text_test.py
@@ -5,7 +5,6 @@ import pytest
 import logging
 import os
 
-
 from errbot.backends.text import TextBackend
 from errbot.bootstrap import bot_config_defaults
 
@@ -36,4 +35,3 @@ def test_change_presence(text_backend, caplog):
     assert len(caplog.messages) == 1
     a_message = caplog.messages[0]
     assert a_message.startswith('*** Changed presence')
-


### PR DESCRIPTION
There was a typo in TextBackend.change_presence .

It caused a traceback in logging messages when using change_presence on TextBackend.