### PR TITLE
Enforce BOT_EXTRA_BACKEND_DIR is a list type.

### DIFF
--- a/errbot/bootstrap.py
+++ b/errbot/bootstrap.py
@@ -129,8 +129,17 @@ def setup_bot(backend_name: str, logger, config, restore=None) -> ErrBot:
     if isinstance(plugin_indexes, str):
         plugin_indexes = (plugin_indexes, )
 
-    backendpm = BackendPluginManager(config, 'errbot.backends', backend_name,
-                                     ErrBot, CORE_BACKENDS, getattr(config, 'BOT_EXTRA_BACKEND_DIR', []))
+    # Extra backend is expected to be a list type, convert string to list.
+    extra_backend = getattr(config, 'BOT_EXTRA_BACKEND_DIR', [])
+    if isinstance(extra_backend, str):
+        extra_backend = [extra_backend]
+
+    backendpm = BackendPluginManager(config,
+                                     'errbot.backends',
+                                     backend_name,
+                                     ErrBot,
+                                     CORE_BACKENDS,
+                                     extra_backend)
 
     log.info(f'Found Backend plugin: {backendpm.plugin_info.name}')
 
@@ -175,8 +184,8 @@ def setup_bot(backend_name: str, logger, config, restore=None) -> ErrBot:
 def restore_bot_from_backup(backup_filename, *, bot, log):
     """Restores the given bot by executing the 'backup' script.
 
-    The backup file is a python script which manually execute a series of commands on the bot to restore it
-    to its previous state.
+    The backup file is a python script which manually execute a series of commands on the bot
+    to restore it to its previous state.
 
     :param backup_filename: the full path to the backup script.
     :param bot: the bot instance to restore

--- a/errbot/cli.py
+++ b/errbot/cli.py
@@ -200,10 +200,15 @@ def main():
 
     config = get_config(config_path)  # will exit if load fails
 
+    # Extra backend is expected to be a list type, convert string to list.
+    extra_backend = getattr(config, 'BOT_EXTRA_BACKEND_DIR', [])
+    if isinstance(extra_backend, str):
+        extra_backend = [extra_backend]
+
     if args['list']:
         from errbot.backend_plugin_manager import enumerate_backend_plugins
         print('Available backends:')
-        roots = [CORE_BACKENDS] + getattr(config, 'BOT_EXTRA_BACKEND_DIR', [])
+        roots = [CORE_BACKENDS] + extra_backend
         for backend in enumerate_backend_plugins(collect_roots(roots)):
             print(f'\t\t{backend.name}')
         sys.exit(0)


### PR DESCRIPTION
In the configuration template, `BOT_EXTRA_BACKEND_DIR` is defined as a string and doesn't appear to be well publicised that it is meant to be a list type.

When defined in the configuration as a string
```
BOT_ROOT_DIR = "/opt/errbot"
BOT_DATA_DIR = f"{BOT_ROOT_DIR}/data"
BOT_EXTRA_BACKEND_DIR = f"{BOT_ROOT_DIR}/backends/"
```
An exception is raised by errbot when listing available backends:
```(errbot) host:~$ errbot -l -c mattermost_config.py
Available backends:
Traceback (most recent call last):
  File "/opt/errbot/bin/errbot", line 10, in <module>
    sys.exit(main())
  File "/opt/errbot/lib/python3.6/site-packages/errbot/cli.py", line 206, in main
    roots = [CORE_BACKENDS] + getattr(config, 'BOT_EXTRA_BACKEND_DIR', [])
TypeError: can only concatenate list (not "str") to list
```

This patch tests for presence of `BOT_EXTRA_BACKEND_DIR` in the configuration, if defined and a string type, the variable will be wrapped in a list.