### PR TITLE
Fix #1360 Cast pathlib.Path objects to strings for use with sys.path

### DIFF
--- a/errbot/backend_plugin_manager.py
+++ b/errbot/backend_plugin_manager.py
@@ -45,7 +45,8 @@ class BackendPluginManager:
     def load_plugin(self) -> Any:
         plugin_path = self.plugin_info.location.parent
         if plugin_path not in sys.path:
-            sys.path.append(plugin_path)
+            # Cast pathlib.Path objects to string type for compatibility with sys.path
+            sys.path.append(str(plugin_path))
         plugin_classes = self.plugin_info.load_plugin_classes(self._base_module, self._base_class)
         if len(plugin_classes) != 1:
             raise PluginNotFoundException(f'Found more that one plugin for {self._base_class}.')


### PR DESCRIPTION
It appears `pathlib.Path` objects are silently ignored when Python searches available paths for submodules.  In the case of backends using subdirectories to store modules (which is the case for mattermost) an exception is raised because the submodule can't be found.

This patch casts `pathlib.Path` objects to Python strings as they are appended to the `sys.path` list.