### PR TITLE
WIP: Adds ability to divert all to private or thread

### DIFF
--- a/errbot/core.py
+++ b/errbot/core.py
@@ -429,9 +429,9 @@ class ErrBot(Backend, StoreMixin):
             the markdown output, if any
 
         """
-        private = ('__magic_all__' in self.bot_config.DIVERT_TO_PRIVATE or
+        private = ('_magic_all_' in self.bot_config.DIVERT_TO_PRIVATE or
                    cmd in self.bot_config.DIVERT_TO_PRIVATE)
-        threaded = ('__magic_all__' in self.bot_config.DIVERT_TO_THREAD or
+        threaded = ('_magic_all_' in self.bot_config.DIVERT_TO_THREAD or
                     cmd in self.bot_config.DIVERT_TO_THREAD)
         commands = self.re_commands if match else self.commands
         try:

--- a/errbot/core.py
+++ b/errbot/core.py
@@ -429,10 +429,10 @@ class ErrBot(Backend, StoreMixin):
             the markdown output, if any
 
         """
-        private = ('_magic_all_' in self.bot_config.DIVERT_TO_PRIVATE or
-                   cmd in self.bot_config.DIVERT_TO_PRIVATE)
-        threaded = ('_magic_all_' in self.bot_config.DIVERT_TO_THREAD or
-                    cmd in self.bot_config.DIVERT_TO_THREAD)
+        private = ('_magic_all_' in self.bot_config.DIVERT_TO_PRIVATE
+                   or cmd in self.bot_config.DIVERT_TO_PRIVATE)
+        threaded = ('_magic_all_' in self.bot_config.DIVERT_TO_THREAD
+                    or cmd in self.bot_config.DIVERT_TO_THREAD)
         commands = self.re_commands if match else self.commands
         try:
             with self._gbl:

--- a/errbot/core.py
+++ b/errbot/core.py
@@ -429,8 +429,10 @@ class ErrBot(Backend, StoreMixin):
             the markdown output, if any
 
         """
-        private = cmd in self.bot_config.DIVERT_TO_PRIVATE
-        threaded = cmd in self.bot_config.DIVERT_TO_THREAD
+        private = ('__magic_all__' in self.bot_config.DIVERT_TO_PRIVATE or
+                   cmd in self.bot_config.DIVERT_TO_PRIVATE)
+        threaded = ('__magic_all__' in self.bot_config.DIVERT_TO_THREAD or
+                    cmd in self.bot_config.DIVERT_TO_THREAD)
         commands = self.re_commands if match else self.commands
         try:
             with self._gbl:


### PR DESCRIPTION
This adds a `__magic_all__` option that you can add to either the
`DIVERT_TO_THREAD` or `DIVERT_TO_PRIVATE` configuration options instead of
adding each command individually.


# To Do: 

- [ ] Manually test that this is correct
- [ ] Write Automated Tests? (doesn't look like the test for `core.py` has much there to begin with
- [ ] Documentation updates to reflect changes.