### PR TITLE
feat: Ability to set ssl version for xmpp conections

### DIFF
--- a/errbot/backends/xmpp.py
+++ b/errbot/backends/xmpp.py
@@ -302,7 +302,7 @@ class XMPPRoomOccupant(XMPPPerson, RoomOccupant):
 
 
 class XMPPConnection(object):
-    def __init__(self, jid, password, feature=None, keepalive=None, ca_cert=None, server=None, use_ipv6=None, bot=None):
+    def __init__(self, jid, password, feature=None, keepalive=None, ca_cert=None, server=None, use_ipv6=None, bot=None, ssl_version=None):
         if feature is None:
             feature = {}
         self._bot = bot
@@ -321,6 +321,9 @@ class XMPPConnection(object):
 
         if use_ipv6 is not None:
             self.client.use_ipv6 = use_ipv6
+
+        if ssl_version:
+            self.client.ssl_version = ssl_version
 
         self.client.ca_certs = ca_cert  # Used for TLS certificate validation
 
@@ -386,6 +389,7 @@ class XMPPBackend(ErrBot):
         self.ca_cert = config.__dict__.get('XMPP_CA_CERT_FILE', '/etc/ssl/certs/ca-certificates.crt')
         self.xhtmlim = config.__dict__.get('XMPP_XHTML_IM', False)
         self.use_ipv6 = config.__dict__.get('XMPP_USE_IPV6', None)
+        self.ssl_version = config.__dict__.get('XMPP_SSL_VERSION', None)
 
         # generic backend compatibility
         self.bot_identifier = self._build_person(self.jid)
@@ -413,7 +417,8 @@ class XMPPBackend(ErrBot):
             ca_cert=self.ca_cert,
             server=self.server,
             use_ipv6=self.use_ipv6,
-            bot=self
+            bot=self,
+            ssl_version=self.ssl_version,
         )
 
     def _build_room_occupant(self, txtrep):

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -373,6 +373,12 @@ REVERSE_CHATROOM_RELAY = {}
 # Switch it to True to enable XHTML-IM formatting.
 # XMPP_XHTML_IM = False
 
+# XMPP may require a specific ssl protocol version when making connections.
+# This option allows the option to change that behavior.
+# It uses python's built-in ssl module.
+# import ssl
+# XMPP_SSL_VERSION = ssl.PROTOCOL_TLSv1_2
+
 # Message rate limiting for the IRC backend. This will delay subsequent
 # messages by this many seconds (floats are supported). Setting these
 # to a value of 0 effectively disables rate limiting.


### PR DESCRIPTION
Added config option to set the ssl version for xmpp client when making connections to services.

This may address issue #1228 

I'm really unable to fully test this as I do not have access to any xmpp service. Any validation from xmpp users would be greatly appreciated.