### PR TITLE
 errbot/plugin_manager: only check for /proc/cgroup if file exists

### DIFF
--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -64,6 +64,8 @@ def install_packages(req_path: Path):
         Return an exc_info if it fails otherwise None.
     """
     def is_docker():
+        if not os.path.exists('/proc/1/cgroup'):
+            return false
         with open('/proc/1/cgroup') as d:
             return 'docker' in d.read()
 


### PR DESCRIPTION
* errbot is mandatorily checking for this file for non-docker builds too
* Fixes https://github.com/errbotio/errbot/issues/1383