### PR TITLE
Sentry migration

### DIFF
--- a/errbot/bootstrap.py
+++ b/errbot/bootstrap.py
@@ -111,6 +111,19 @@ def setup_bot(backend_name: str, logger, config, restore=None) -> ErrBot:
 
         sentry_integrations.append(sentry_logging)
 
+        if hasattr(config, 'BOT_LOG_SENTRY_FLASK') and config.BOT_LOG_SENTRY_FLASK:
+            try:
+                from sentry_sdk.integrations.flask import FlaskIntegration
+            except ImportError:
+                log.exception(
+                    "You have BOT_LOG_SENTRY enabled, but I couldn't import modules "
+                    "needed for Sentry integration. Did you install sentry-sdk? "
+                    "(See https://docs.sentry.io/platforms/python/flask for installation instructions)"
+                )
+                exit(-1)
+
+            sentry_integrations.append(FlaskIntegration())
+
         try:
             if hasattr(config, 'SENTRY_TRANSPORT') and isinstance(config.SENTRY_TRANSPORT, tuple):
                 mod = importlib.import_module(config.SENTRY_TRANSPORT[1])

--- a/errbot/bootstrap.py
+++ b/errbot/bootstrap.py
@@ -117,7 +117,7 @@ def setup_bot(backend_name: str, logger, config, restore=None) -> ErrBot:
             except ImportError:
                 log.exception(
                     "You have BOT_LOG_SENTRY enabled, but I couldn't import modules "
-                    "needed for Sentry integration. Did you install sentry-sdk? "
+                    "needed for Sentry integration. Did you install sentry-sdk[flask]? "
                     "(See https://docs.sentry.io/platforms/python/flask for installation instructions)"
                 )
                 exit(-1)

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -133,9 +133,10 @@ BOT_LOG_LEVEL = logging.INFO
 BOT_LOG_SENTRY = False
 SENTRY_DSN = ''
 SENTRY_LOGLEVEL = BOT_LOG_LEVEL
+SENTRY_EVENTLEVEL = BOT_LOG_LEVEL
 
 # Set an optional Sentry transport other than the default Threaded.
-# For more info, see https://docs.sentry.io/clients/python/transports/
+# For more info, see https://docs.sentry.io/error-reporting/configuration/?platform=python#transport-options
 # SENTRY_TRANSPORT = ('RequestsHTTPTransport', 'raven.transport.requests')
 
 # Execute commands in asynchronous mode. In this mode, Errbot will spawn 10

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -129,8 +129,10 @@ BOT_LOG_FILE = BOT_DATA_DIR + '/err.log'
 BOT_LOG_LEVEL = logging.INFO
 
 # Enable logging to sentry (find out more about sentry at www.getsentry.com).
+# You can also separate Flask exceptions by enabling it. This will give more information in sentry
 # This is optional and disabled by default.
 BOT_LOG_SENTRY = False
+BOT_LOG_SENTRY_FLASK = False
 SENTRY_DSN = ''
 SENTRY_LOGLEVEL = BOT_LOG_LEVEL
 SENTRY_EVENTLEVEL = BOT_LOG_LEVEL


### PR DESCRIPTION
`raven` was deprecated (http://raven.readthedocs.io) in favor of sentry-sdk, so it's time to update! :D
 
- Change raven for sentry-sdk
- Added an option to add Flask special integration for more detailed events on sentry
- Added new options on the config-template with some explanation