### PR TITLE
A typo and name with .py does not work

### DIFF
--- a/docs/user_guide/flow_development/basics.rst
+++ b/docs/user_guide/flow_development/basics.rst
@@ -9,8 +9,8 @@ They are defined by a ``.flow`` file, similar to the plugin ones:
 .. code-block:: ini
 
     [Core]
-    Name = MyFlows.
-    Module = myflows.py
+    Name = MyFlows
+    Module = myflows
 
     [Documentation]
     Description = my documentation.


### PR DESCRIPTION
* I think the dot at the end of `Name` is not needed (nor useful)
* If you put the `.py` in the `Module` in `[Core]` there is an error because the plugin loader adds the .py extension.