### PR TITLE
description seems to be read from bootcmd definition

### DIFF
--- a/errbot/core_plugins/flows.py
+++ b/errbot/core_plugins/flows.py
@@ -48,7 +48,10 @@ class Flows(BotPlugin):
         """
         with io.StringIO() as response:
             for name, flow_node in self._bot.flow_executor.flow_roots.items():
-                response.write("- **" + name + "** " + flow_node.description + "\n")
+                if flow_node.description:
+                    response.write("- **" + name + "** " + flow_node.description + "\n")
+                else:
+                    response.write("- **" + name + "** " + "No description" + "\n")
             return response.getvalue()
 
     @botcmd(split_args_with=' ', syntax='<name> [initial_payload]')


### PR DESCRIPTION
Since description seems to be read from `@bootcmd` definition and this is not easy to see in the documentation (even the examples don't use it, see https://github.com/errbotio/errbot/blob/master/docs/user_guide/flow_development/basics.rst ) maybe it is better to change this code to not produce an error in the command `flows list` when no description is available.