### PR TITLE
Fixing Deprecation Warning

### DIFF
--- a/errbot/storage/__init__.py
+++ b/errbot/storage/__init__.py
@@ -1,5 +1,5 @@
 import types
-from collections import MutableMapping
+from collections.abc import MutableMapping
 from contextlib import contextmanager
 import logging
 log = logging.getLogger(__name__)


### PR DESCRIPTION
When using pytest I get the following Deprecation Warning
```
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    from collections import MutableMapping
```
So thought I would fix it, hope you will accept it 😃