### PR TITLE
Set user-agent to prevent 403 on RTD

### DIFF
--- a/errbot/repo_manager.py
+++ b/errbot/repo_manager.py
@@ -12,7 +12,7 @@ from os import path
 import tarfile
 from pathlib import Path
 from urllib.error import HTTPError, URLError
-from urllib.request import urlopen
+from urllib.request import urlopen, Request
 from urllib.parse import urlparse
 
 from errbot.storage import StoreMixin
@@ -154,7 +154,13 @@ class BotRepoManager(StoreMixin):
         for source in reversed(self.plugin_indexes):
             try:
                 if urlparse(source).scheme in ('http', 'https'):
-                    with urlopen(url=source, timeout=10) as request:  # nosec
+                    with urlopen(
+                        Request(
+                            source,
+                            headers={'User-Agent': 'Errbot'}
+                        ),
+                        timeout=10
+                    ) as request:  # nosec
                         log.debug('Update from remote source %s...', source)
                         encoding = request.headers.get_content_charset()
                         content = request.read().decode(encoding if encoding else 'utf-8')

--- a/errbot/repo_manager.py
+++ b/errbot/repo_manager.py
@@ -154,13 +154,8 @@ class BotRepoManager(StoreMixin):
         for source in reversed(self.plugin_indexes):
             try:
                 if urlparse(source).scheme in ('http', 'https'):
-                    with urlopen(
-                        Request(
-                            source,
-                            headers={'User-Agent': 'Errbot'}
-                        ),
-                        timeout=10
-                    ) as request:  # nosec
+                    req = Request(source, headers={'User-Agent': 'Errbot'})
+                    with urlopen(url=req, timeout=10) as request:  # nosec
                         log.debug('Update from remote source %s...', source)
                         encoding = request.headers.get_content_charset()
                         content = request.read().decode(encoding if encoding else 'utf-8')


### PR DESCRIPTION
When trying to perform any `repo` action, it first tries to update the repo list and fails due to the webserver throwing a 403:

```
2020-04-27 11:56:45,009 INFO     errbot.repo_manager       No repo index, creating it.
2020-04-27 11:56:45,095 ERROR    errbot.repo_manager       Could not update from source https://errbot.readthedocs.io/en/latest/repos.json, keep the index as it is.
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/errbot/repo_manager.py", line 157, in index_update
    with urlopen(url=source, timeout=10) as request:  # nosec
  File "/usr/local/lib/python3.6/urllib/request.py", line 223, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/local/lib/python3.6/urllib/request.py", line 532, in open
    response = meth(req, response)
  File "/usr/local/lib/python3.6/urllib/request.py", line 642, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/local/lib/python3.6/urllib/request.py", line 570, in error
    return self._call_chain(*args)
  File "/usr/local/lib/python3.6/urllib/request.py", line 504, in _call_chain
    result = func(*args)
  File "/usr/local/lib/python3.6/urllib/request.py", line 650, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 403: Forbidden
```

It looks like this is due to readthedocs denying access to any clients with the default user agent string that urllib uses (`Python-urllib/*`).

This PR makes the call to urlopen use a custom user-agent string of `Errbot`, which in turn means the RTD hosting responds to the request.