### PR TITLE
Replace sleekxmpp with slixmpp

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -80,4 +80,4 @@ Extensive plugin framework
 .. _jabberbot: http://thp.io/2007/python-jabberbot/
 .. _jinja2: http://jinja.pocoo.org/
 .. _six: https://pypi.python.org/pypi/six/
-.. _sleekxmpp: http://sleekxmpp.com/
+.. _slixmpp: https://slixmpp.readthedocs.io/

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ sphinx>=1.2
 sphinx-autodoc-annotation
 
 -e .
-sleekxmpp
+slixmpp
 irc
 pyfire
 python-telegram-bot

--- a/docs/user_guide/configuration/hipchat.rst
+++ b/docs/user_guide/configuration/hipchat.rst
@@ -11,7 +11,7 @@ Extra Dependencies
 
 You need to install this dependency before using Errbot with Hipchat::
 
-    pip install sleekxmpp pyasn1 pyasn1-modules hypchat
+    pip install slixmpp pyasn1 pyasn1-modules hypchat
 
 
 Account setup

--- a/docs/user_guide/configuration/xmpp.rst
+++ b/docs/user_guide/configuration/xmpp.rst
@@ -10,7 +10,7 @@ Extra Dependencies
 
 You need to install this dependency before using Errbot with XMPP::
 
-      pip install sleekxmpp pyasn1 pyasn1-modules
+      pip install slixmpp pyasn1 pyasn1-modules
 
 Account setup
 -------------

--- a/docs/user_guide/plugin_development/backend_specifics.rst
+++ b/docs/user_guide/plugin_development/backend_specifics.rst
@@ -82,15 +82,15 @@ The following table lists these attributes for the official backends, along with
 ============================================  =========================  ================================================
 Backend                                       Library                    Attribute(s)
 ============================================  =========================  ================================================
-:class:`~errbot.backends.hipchat`             `sleekxmpp`_ + `hypchat`_  ``self._bot.conn`` ``self._bot.conn.hypchat``
+:class:`~errbot.backends.hipchat`             `slixmpp`_ + `hypchat`_    ``self._bot.conn`` ``self._bot.conn.hypchat``
 :class:`~errbot.backends.irc`                 `irc`_                     ``self._bot.conn`` ``self._bot.conn.connection``
 :class:`~errbot.backends.slack`               `slackclient`_             ``self._bot.sc``
 :class:`~errbot.backends.telegram_messenger`  `telegram-python-bot`_     ``self._bot.telegram``
-:class:`~errbot.backends.xmpp`                `sleekxmpp`_               ``self._bot.conn``
+:class:`~errbot.backends.xmpp`                `slixmpp`_                 ``self._bot.conn``
 ============================================  =========================  ================================================
 
 .. _hypchat: https://pypi.python.org/pypi/hypchat/
 .. _irc: https://pypi.python.org/pypi/irc/
 .. _`telegram-python-bot`: https://pypi.python.org/pypi/python-telegram-bot
 .. _slackclient: https://pypi.python.org/pypi/slackclient/
-.. _sleekxmpp: https://pypi.python.org/pypi/sleekxmpp
+.. _slixmpp: https://pypi.python.org/pypi/slixmpp

--- a/errbot/backends/xmpp.py
+++ b/errbot/backends/xmpp.py
@@ -297,7 +297,8 @@ class XMPPRoomOccupant(XMPPPerson, RoomOccupant):
 
 class XMPPConnection(object):
     def __init__(self, jid, password, feature=None, keepalive=None,
-                 ca_cert=None, server=None, use_ipv6=None, bot=None):
+                 ca_cert=None, server=None, use_ipv6=None, bot=None,
+                 ssl_version=None):
         if feature is None:
             feature = {}
         self._bot = bot

--- a/errbot/backends/xmpp.py
+++ b/errbot/backends/xmpp.py
@@ -2,7 +2,6 @@ import logging
 import sys
 from functools import lru_cache
 
-from threading import Thread
 from time import sleep
 
 from errbot.backends.base import Message, Room, Presence, RoomNotJoinedError, Identifier, RoomOccupant, Person
@@ -13,10 +12,10 @@ from errbot.rendering import text, xhtml, xhtmlim
 log = logging.getLogger(__name__)
 
 try:
-    from sleekxmpp import ClientXMPP
-    from sleekxmpp.xmlstream import resolver, cert
-    from sleekxmpp import JID
-    from sleekxmpp.exceptions import IqError
+    from slixmpp import ClientXMPP
+    from slixmpp.xmlstream import resolver, cert
+    from slixmpp import JID
+    from slixmpp.exceptions import IqError
 
 except ImportError:
     log.exception("Could not start the XMPP backend")
@@ -114,15 +113,10 @@ class XMPPRoom(XMPPIdentifier, Room):
         :meth:`create` on it first.
         """
         room = str(self)
-        self.xep0045.joinMUC(room, username, password=password, wait=True)
+        self.xep0045.join_muc(room, username, password=password, wait=True)
         self._bot.conn.add_event_handler(f'muc::{room}::got_online', self._bot.user_joined_chat)
         self._bot.conn.add_event_handler(f'muc::{room}::got_offline', self._bot.user_left_chat)
-        # Room configuration can only be done once a MUC presence stanza
-        # has been received from the server. This HAS to take place in a
-        # separate thread because of how SleekXMPP processes these stanzas.
-        t = Thread(target=self.configure)
-        t.setDaemon(True)
-        t.start()
+        self.configure()
         self._bot.callback_room_joined(self)
         log.info('Joined room %s.', room)
 
@@ -137,7 +131,7 @@ class XMPPRoom(XMPPIdentifier, Room):
             reason = ""
         room = str(self)
         try:
-            self.xep0045.leaveMUC(room=room, nick=self.xep0045.ourNicks[room], msg=reason)
+            self.xep0045.leave_muc(room=room, nick=self.xep0045.ourNicks[room], msg=reason)
 
             self._bot.conn.del_event_handler(f'muc::{room}::got_online', self._bot.user_joined_chat)
             self._bot.conn.del_event_handler(f'muc::{room}::got_offline', self._bot.user_left_chat)
@@ -148,7 +142,7 @@ class XMPPRoom(XMPPIdentifier, Room):
 
     def create(self):
         """
-        Not supported on this back-end (SleekXMPP doesn't support it).
+        Not supported on this back-end (Slixmpp doesn't support it).
         Will join the room to ensure it exists, instead.
         """
         logging.warning(
@@ -186,7 +180,7 @@ class XMPPRoom(XMPPIdentifier, Room):
         :getter:
             Returns `True` if the room has been joined, `False` otherwise.
         """
-        return str(self) in self.xep0045.getJoinedRooms()
+        return str(self) in self.xep0045.get_joined_rooms()
 
     @property
     def topic(self):
@@ -214,7 +208,7 @@ class XMPPRoom(XMPPIdentifier, Room):
         :param topic:
             The topic to set.
         """
-        # Not supported by SleekXMPP at the moment :(
+        # Not supported by Slixmpp at the moment :(
         raise NotImplementedError("Setting the topic is not supported on this back-end.")
 
     @property
@@ -261,16 +255,16 @@ class XMPPRoom(XMPPIdentifier, Room):
         affiliation = None
         while affiliation is None:
             sleep(0.5)
-            affiliation = self.xep0045.getJidProperty(
+            affiliation = self.xep0045.get_jid_property(
                 room=room,
-                nick=self.xep0045.ourNicks[room],
-                jidProperty='affiliation'
+                nick=self.xep0045.our_nicks[room],
+                jid_property='affiliation'
             )
 
         if affiliation == "owner":
             log.debug('Configuring room %s: we have owner affiliation.', room)
-            form = self.xep0045.getRoomConfig(room)
-            self.xep0045.configureRoom(room, form)
+            form = yield from self.xep0045.get_room_config(room)
+            self.xep0045.configure_room(room, form)
         else:
             log.debug("Not configuring room %s: we don't have owner affiliation (affiliation=%s)", room, affiliation)
 
@@ -291,7 +285,7 @@ class XMPPRoomOccupant(XMPPPerson, RoomOccupant):
         Will only work if the errbot is moderator in the MUC or it is not anonymous.
         """
         room_jid = self._node + '@' + self._domain
-        jid = JID(self._room.xep0045.getJidProperty(room_jid, self.resource, 'jid'))
+        jid = JID(self._room.xep0045.get_jid_property(room_jid, self.resource, 'jid'))
         return jid.bare
 
     @property
@@ -317,7 +311,7 @@ class XMPPConnection(object):
         self.client.register_plugin('xep_0249')  # XMPP direct MUC invites
 
         if keepalive is not None:
-            self.client.whitespace_keepalive = True  # Just in case SleekXMPP's default changes to False in the future
+            self.client.whitespace_keepalive = True  # Just in case Slixmpp's default changes to False in the future
             self.client.whitespace_keepalive_interval = keepalive
 
         if use_ipv6 is not None:
@@ -348,7 +342,7 @@ class XMPPConnection(object):
         self.connected = False
 
     def serve_forever(self):
-        self.client.process(block=True)
+        self.client.process()
 
     def add_event_handler(self, name, cb):
         self.client.add_event_handler(name, cb)
@@ -447,7 +441,7 @@ class XMPPBackend(ErrBot):
             msg.to = self._build_person(xmppmsg['to'].full)
 
         msg.nick = xmppmsg['mucnick']
-        msg.delayed = bool(xmppmsg['delay']._get_attr('stamp'))  # this is a bug in sleekxmpp it should be ['from']
+        msg.delayed = bool(xmppmsg['delay']._get_attr('stamp'))  # this is a bug in slixmpp it should be ['from']
         self.callback_message(msg)
 
     def _idd_from_event(self, event):
@@ -582,7 +576,7 @@ class XMPPBackend(ErrBot):
             A list of :class:`~errbot.backends.base.XMPPMUCRoom` instances.
         """
         xep0045 = self.conn.client.plugin['xep_0045']
-        return [XMPPRoom(room, self) for room in xep0045.getJoinedRooms()]
+        return [XMPPRoom(room, self) for room in xep0045.get_joined_rooms()]
 
     def query_room(self, room):
         """

--- a/setup.py
+++ b/setup.py
@@ -105,12 +105,12 @@ if __name__ == "__main__":
         },
         extras_require={
             'graphic': ['PySide', ],
-            'hipchat': ['hypchat', 'sleekxmpp', 'pyasn1', 'pyasn1-modules'],
+            'hipchat': ['hypchat', 'slixmpp', 'pyasn1', 'pyasn1-modules'],
             'IRC': ['irc', ],
             'slack': ['slackclient>=1.0.5,<2.0', ],
             'slack-rtm': ['slackclient>=2.0', ],
             'telegram': ['python-telegram-bot', ],
-            'XMPP': ['sleekxmpp', 'pyasn1', 'pyasn1-modules'],
+            'XMPP': ['slixmpp', 'pyasn1', 'pyasn1-modules'],
             ':python_version<"3.7"': ['dataclasses'],  # backward compatibility for 3.3->3.6 for dataclasses
             ':sys_platform!="win32"': ['daemonize'],
         },


### PR DESCRIPTION
This commit tries to replace the SleekXMPP dependency with Slixmpp. Code changes are limited to the xmpp backend file, I've updated the imports and all the method names and arguments that were changed in Slixmpp.
There is one place where a Thread was used with a reference to how SleekXMPP works, but no details- I've replaced that and it still works without the Thread.
Manual tests I've done worked without problems, I've talked to the bot directly and through a XMPP conference room, but maybe I've missed something, so if anyone could do another test that would be great.

Beware that Slixmpp only supports Python 3.7+.

This fixes #1380 