### PR TITLE
Fixing the slack backend deprecated methods (Web API)

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -574,13 +574,20 @@ class SlackBackend(ErrBot):
             and group (https://api.slack.com/types/group) types.
 
         See also:
-          * https://api.slack.com/methods/conversations.list
+          * https://api.slack.com/methods/channels.list
           * https://api.slack.com/methods/groups.list
         """
-        response = self.api_call('conversations.list', data={'exclude_archived': exclude_archived})
+        response = self.api_call('channels.list', data={'exclude_archived': exclude_archived})
         channels = [channel for channel in response['channels']
                     if channel['is_member'] or not joined_only]
-        return channels
+
+        response = self.api_call('groups.list', data={'exclude_archived': exclude_archived})
+        # No need to filter for 'is_member' in this next call (it doesn't
+        # (even exist) because leaving a group means you have to get invited
+        # back again by somebody else.
+        groups = [group for group in response['groups']]
+
+        return channels + groups
 
     @lru_cache(1024)
     def get_im_channel(self, id_):
@@ -1060,12 +1067,13 @@ class SlackRoom(Room):
         Channel info as returned by the Slack API.
 
         See also:
-          * https://api.slack.com/methods/conversations.list
+          * https://api.slack.com/methods/channels.list
+          * https://api.slack.com/methods/groups.list
         """
         if self.private:
             return self._bot.api_call('groups.info', data={'channel': self.id})["group"]
         else:
-            return self._bot.api_call('conversations.info', data={'channel': self.id})["channel"]
+            return self._bot.api_call('channels.info', data={'channel': self.id})["channel"]
 
     @property
     def private(self):
@@ -1089,7 +1097,7 @@ class SlackRoom(Room):
     def join(self, username=None, password=None):
         log.info("Joining channel %s", str(self))
         try:
-            self._bot.api_call('conversations.join', data={'name': self.name})
+            self._bot.api_call('channels.join', data={'name': self.name})
         except SlackAPIResponseError as e:
             if e.error == 'user_is_bot':
                 raise RoomError(f'Unable to join channel. {USER_IS_BOT_HELPTEXT}')
@@ -1100,7 +1108,7 @@ class SlackRoom(Room):
         try:
             if self.id.startswith('C'):
                 log.info('Leaving channel %s (%s)', self, self.id)
-                self._bot.api_call('conversations.leave', data={'channel': self.id})
+                self._bot.api_call('channels.leave', data={'channel': self.id})
             else:
                 log.info('Leaving group %s (%s)', self, self.id)
                 self._bot.api_call('groups.leave', data={'channel': self.id})
@@ -1118,7 +1126,7 @@ class SlackRoom(Room):
                 self._bot.api_call('groups.create', data={'name': self.name})
             else:
                 log.info('Creating channel %s.', self)
-                self._bot.api_call('conversations.create', data={'name': self.name})
+                self._bot.api_call('channels.create', data={'name': self.name})
         except SlackAPIResponseError as e:
             if e.error == 'user_is_bot':
                 raise RoomError(f"Unable to create channel. {USER_IS_BOT_HELPTEXT}")
@@ -1129,7 +1137,7 @@ class SlackRoom(Room):
         try:
             if self.id.startswith('C'):
                 log.info('Archiving channel %s (%s)', self, self.id)
-                self._bot.api_call('conversations.archive', data={'channel': self.id})
+                self._bot.api_call('channels.archive', data={'channel': self.id})
             else:
                 log.info('Archiving group %s (%s)', self, self.id)
                 self._bot.api_call('groups.archive', data={'channel': self.id})
@@ -1164,7 +1172,7 @@ class SlackRoom(Room):
             self._bot.api_call('groups.setTopic', data={'channel': self.id, 'topic': topic})
         else:
             log.info('Setting topic of %s (%s) to %s.', self, self.id, topic)
-            self._bot.api_call('conversations.setTopic', data={'channel': self.id, 'topic': topic})
+            self._bot.api_call('channels.setTopic', data={'channel': self.id, 'topic': topic})
 
     @property
     def purpose(self):
@@ -1180,7 +1188,7 @@ class SlackRoom(Room):
             self._bot.api_call('groups.setPurpose', data={'channel': self.id, 'purpose': purpose})
         else:
             log.info('Setting purpose of %s (%s) to %s.', str(self), self.id, purpose)
-            self._bot.api_call('conversations.setPurpose', data={'channel': self.id, 'purpose': purpose})
+            self._bot.api_call('channels.setPurpose', data={'channel': self.id, 'purpose': purpose})
 
     @property
     def occupants(self):
@@ -1193,7 +1201,7 @@ class SlackRoom(Room):
             if user not in users:
                 raise UserDoesNotExistError(f'User "{user}" not found.')
             log.info('Inviting %s into %s (%s)', user, self, self.id)
-            method = 'groups.invite' if self.private else 'conversations.invite'
+            method = 'groups.invite' if self.private else 'channels.invite'
             response = self._bot.api_call(
                 method,
                 data={'channel': self.id, 'user': users[user]},

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -574,26 +574,19 @@ class SlackBackend(ErrBot):
             and group (https://api.slack.com/types/group) types.
 
         See also:
-          * https://api.slack.com/methods/channels.list
+          * https://api.slack.com/methods/conversations.list
           * https://api.slack.com/methods/groups.list
         """
-        response = self.api_call('channels.list', data={'exclude_archived': exclude_archived})
+        response = self.api_call('conversations.list', data={'exclude_archived': exclude_archived})
         channels = [channel for channel in response['channels']
                     if channel['is_member'] or not joined_only]
-
-        response = self.api_call('groups.list', data={'exclude_archived': exclude_archived})
-        # No need to filter for 'is_member' in this next call (it doesn't
-        # (even exist) because leaving a group means you have to get invited
-        # back again by somebody else.
-        groups = [group for group in response['groups']]
-
-        return channels + groups
+        return channels
 
     @lru_cache(1024)
     def get_im_channel(self, id_):
         """Open a direct message channel to a user"""
         try:
-            response = self.api_call('im.open', data={'user': id_})
+            response = self.api_call('conversations.open', data={'users': id_})
             return response['channel']['id']
         except SlackAPIResponseError as e:
             if e.error == "cannot_dm_bot":
@@ -1067,13 +1060,12 @@ class SlackRoom(Room):
         Channel info as returned by the Slack API.
 
         See also:
-          * https://api.slack.com/methods/channels.list
-          * https://api.slack.com/methods/groups.list
+          * https://api.slack.com/methods/conversations.list
         """
         if self.private:
             return self._bot.api_call('groups.info', data={'channel': self.id})["group"]
         else:
-            return self._bot.api_call('channels.info', data={'channel': self.id})["channel"]
+            return self._bot.api_call('conversations.info', data={'channel': self.id})["channel"]
 
     @property
     def private(self):
@@ -1097,7 +1089,7 @@ class SlackRoom(Room):
     def join(self, username=None, password=None):
         log.info("Joining channel %s", str(self))
         try:
-            self._bot.api_call('channels.join', data={'name': self.name})
+            self._bot.api_call('conversations.join', data={'name': self.name})
         except SlackAPIResponseError as e:
             if e.error == 'user_is_bot':
                 raise RoomError(f'Unable to join channel. {USER_IS_BOT_HELPTEXT}')
@@ -1108,7 +1100,7 @@ class SlackRoom(Room):
         try:
             if self.id.startswith('C'):
                 log.info('Leaving channel %s (%s)', self, self.id)
-                self._bot.api_call('channels.leave', data={'channel': self.id})
+                self._bot.api_call('conversations.leave', data={'channel': self.id})
             else:
                 log.info('Leaving group %s (%s)', self, self.id)
                 self._bot.api_call('groups.leave', data={'channel': self.id})
@@ -1126,7 +1118,7 @@ class SlackRoom(Room):
                 self._bot.api_call('groups.create', data={'name': self.name})
             else:
                 log.info('Creating channel %s.', self)
-                self._bot.api_call('channels.create', data={'name': self.name})
+                self._bot.api_call('conversations.create', data={'name': self.name})
         except SlackAPIResponseError as e:
             if e.error == 'user_is_bot':
                 raise RoomError(f"Unable to create channel. {USER_IS_BOT_HELPTEXT}")
@@ -1137,7 +1129,7 @@ class SlackRoom(Room):
         try:
             if self.id.startswith('C'):
                 log.info('Archiving channel %s (%s)', self, self.id)
-                self._bot.api_call('channels.archive', data={'channel': self.id})
+                self._bot.api_call('conversations.archive', data={'channel': self.id})
             else:
                 log.info('Archiving group %s (%s)', self, self.id)
                 self._bot.api_call('groups.archive', data={'channel': self.id})
@@ -1172,7 +1164,7 @@ class SlackRoom(Room):
             self._bot.api_call('groups.setTopic', data={'channel': self.id, 'topic': topic})
         else:
             log.info('Setting topic of %s (%s) to %s.', self, self.id, topic)
-            self._bot.api_call('channels.setTopic', data={'channel': self.id, 'topic': topic})
+            self._bot.api_call('conversations.setTopic', data={'channel': self.id, 'topic': topic})
 
     @property
     def purpose(self):
@@ -1188,7 +1180,7 @@ class SlackRoom(Room):
             self._bot.api_call('groups.setPurpose', data={'channel': self.id, 'purpose': purpose})
         else:
             log.info('Setting purpose of %s (%s) to %s.', str(self), self.id, purpose)
-            self._bot.api_call('channels.setPurpose', data={'channel': self.id, 'purpose': purpose})
+            self._bot.api_call('conversations.setPurpose', data={'channel': self.id, 'purpose': purpose})
 
     @property
     def occupants(self):
@@ -1201,7 +1193,7 @@ class SlackRoom(Room):
             if user not in users:
                 raise UserDoesNotExistError(f'User "{user}" not found.')
             log.info('Inviting %s into %s (%s)', user, self, self.id)
-            method = 'groups.invite' if self.private else 'channels.invite'
+            method = 'groups.invite' if self.private else 'conversations.invite'
             response = self._bot.api_call(
                 method,
                 data={'channel': self.id, 'user': users[user]},


### PR DESCRIPTION
This should work on all apps, old and new.  I left a few of the 'group' lines in but you may want to go ahead and get rid of them as well.  Groups are now being called 'private_channel' and are creates with 'is_private=True'.  Let me know how this looks and if I missed anything.

https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api