### PR TITLE
Matrix backend link does not exist

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -15,7 +15,6 @@ Currently, the following networks are supported:
   * `Cisco Webex Teams`_ (maintained `separately <https://github.com/marksull/err-backend-cisco-webex-teams>`__)
   * Discord_ (maintained `separately <https://github.com/gbin/err-backend-discord>`__)
   * Gitter_ (maintained `separately <https://github.com/errbotio/err-backend-gitter>`__)
-  * Matrix_ (maintained `separately <https://github.com/SShrike/err-backend-matrix>`__)
   * Mattermost_ (maintained `separately <https://github.com/Vaelor/errbot-mattermost-backend>`__)
   * Skype_ (maintained `separately <https://github.com/errbotio/errbot-backend-skype>`__)
   * Tox_ (maintained `separately <https://github.com/errbotio/err-backend-tox>`__)


### PR DESCRIPTION
There are several alternatives but nobody claims it is working:
https://github.com/wilypomegranate/err-backend-matrix
https://github.com/0xffea/err-backend-matrix

Maybe this works:
https://github.com/clouetb/errbot-backend-matrix-nio (maybe working)