### PR TITLE
fix: merging configs via --storage-merge cli

### DIFF
--- a/errbot/cli.py
+++ b/errbot/cli.py
@@ -244,12 +244,11 @@ def main():
 
     if args['storage_merge']:
         def merge(sdm):
+            from deepmerge import always_merger
             new_dict = _read_dict()
-            if list(new_dict.keys()) == ['config']:
-                with sdm.mutable('configs') as conf:
-                    conf.update(new_dict['configs'])
-            else:
-                sdm.update(new_dict)
+            for key in new_dict.keys():
+                with sdm.mutable(key) as conf:
+                    always_merger.merge(conf, new_dict[key])
         err_value = storage_action(args['storage_merge'][0], merge)
         sys.exit(err_value)
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ deps = ['webtest',
         'ansi',
         'Pygments>=2.0.2',
         'pygments-markdown-lexer>=0.1.0.dev39',  # sytax coloring to debug md
-        'dulwich>=0.19.16'  # python implementation of git
+        'dulwich>=0.19.16',  # python implementation of git
+        'deepmerge>=0.1.0',
         ]
 
 src_root = os.curdir


### PR DESCRIPTION
This should allow partial dictionary merges to work properly.

```
$ errbot --storage-get core
{'configs': {'Webserver': {'HOST': '0.0.0.0', 'PORT': 3141, 'SSL': {'certificate': '', 'enabled': False, 'host': '127.0.0.1', 'key': '', 'port': 3142}}}}
$ echo "{'configs': {'Webserver': {'SSL': {'port': 100}}}}" | errbot --storage-merge core
$ errbot --storage-get core
{'configs': {'Webserver': {'HOST': '0.0.0.0', 'PORT': 3141, 'SSL': {'certificate': '', 'enabled': False, 'host': '127.0.0.1', 'key': '', 'port': 100}}}}
```

Resolves https://github.com/errbotio/errbot/issues/1444