### PR TITLE
Fixed rendering issue in docs

### DIFF
--- a/docs/user_guide/plugin_development/development_environment.rst
+++ b/docs/user_guide/plugin_development/development_environment.rst
@@ -53,7 +53,7 @@ containing the actual code of your plugin
 Errbot can automatically generate these files for you
 so that you do not have to write boilerplate code by hand.
 
-To create a new plugin, run `errbot --new-plugin`
+To create a new plugin, run :option:`errbot --new-plugin`
 (optionally specifying a directory where to create the new plugin -
 it will use the current directory by default).
 It will ask you a few questions such as the name for your plugin,


### PR DESCRIPTION
It seems Sphinx render `--` as `–` when it isn't tagged as an option, resulting this to be listed as "errbot –new-plugin" on the [Docs page](https://errbot.readthedocs.io/en/latest/user_guide/plugin_development/development_environment.html).