### PR TITLE
fix: whoami formatting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,5 @@
-6.1.8 (unreleased)
-------------------
+v6.1.8 (unreleased)
+-------------------
 
 fixes:
 
@@ -8,6 +8,7 @@ fixes:
 - docs: Update backend screenshots (#1499)
 - docs: Remove Google+ references (#1497)
 - core: Split messages using `split()` instead of whitespace (#1496)
+- chore/plugin: whoami formatting (#1459)
 
 v6.1.7 (2020-12-18)
 -------------------

--- a/errbot/core_plugins/utils.py
+++ b/errbot/core_plugins/utils.py
@@ -22,7 +22,12 @@ class Utils(BotPlugin):
             frm = self.build_identifier(str(args).strip('"'))
         else:
             frm = msg.frm
-        resp = "| key      | value\n"
+
+        resp = ""
+        if self.bot_config.GROUPCHAT_NICK_PREFIXED:
+            resp += "\n\n"
+
+        resp += "| key      | value\n"
         resp += "| -------- | --------\n"
         resp += f"| person   | `{frm.person}`\n"
         resp += f"| nick     | `{frm.nick}`\n"


### PR DESCRIPTION
This fixes the output of the `!whoami` botcommand.
The output is misformatted if `GROUPCHAT_NICK_PREFIXED` is enabled.

## Original output
![whoami-original](https://user-images.githubusercontent.com/618177/95418458-2f679e00-08fd-11eb-8a81-af6429f9522c.png)


## New output
![whoami-fixes](https://user-images.githubusercontent.com/618177/95418473-37bfd900-08fd-11eb-8fc2-772e2fcb5979.png)

