### PR TITLE
fix: Set email property as non-abstract

### DIFF
--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -70,14 +70,13 @@ class Person(Identifier):
         pass
 
     @property
-    @abstractmethod
     def email(self) -> str:
         """
         Some backends have the email of a user.
 
         :return: the email of this user if available.
         """
-        pass
+        return ''
 
 
 class RoomOccupant(Identifier):


### PR DESCRIPTION
This should ensure that existing and external backends do not break with
when this property is not defined.

Resolves #1460.