### PR TITLE
fix: merging configs via cli with unknown keys

### DIFF
--- a/errbot/cli.py
+++ b/errbot/cli.py
@@ -246,9 +246,10 @@ def main():
         def merge(sdm):
             from deepmerge import always_merger
             new_dict = _read_dict()
-            for key in new_dict.keys():
-                with sdm.mutable(key) as conf:
-                    always_merger.merge(conf, new_dict[key])
+            for key, value in new_dict.items():
+                with sdm.mutable(key, {}) as conf:
+                    always_merger.merge(conf, value)
+
         err_value = storage_action(args['storage_merge'][0], merge)
         sys.exit(err_value)
 


### PR DESCRIPTION
This should handle scenarios where using the `--storage-merge` cli option
does not properly create keys that are not currently stored in storage
backend.

Fixes #1468.