### PR TITLE
docs: Sync current release notes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ v6.1.7 (unreleased)
 features:
 
 - core: Add support for python3.9 (#1477)
+- chore: Allow dependabot to check GitHub actions weekly (#1464)
 
 
 v6.1.6 (2020-11-16)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ features:
 - core: Add support for python3.9 (#1477)
 - chore: Allow dependabot to check GitHub actions weekly (#1464)
 
+fixes:
+
+- chore: Remove travis configuration (#1478)
+- chore: minor code cleanup (#1465)
+
 
 v6.1.6 (2020-11-16)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ features:
 
 fixes:
 
+- core: AttributeError on Blacklisted plugins (#1369)
 - chore: Remove travis configuration (#1478)
 - chore: minor code cleanup (#1465)
 


### PR DESCRIPTION
This should sync up the current pull requests slated for the next release.