### PR TITLE
chore: Use twine to check dist

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -37,10 +37,10 @@ jobs:
       run: |
         tox -e py
 
-    - name: Lint
+    - name: Check Distribution
       if: ${{ matrix.python-version == '3.8' }}
       run: |
-        tox -e pypi-lint
+        tox -e dist-check
 
     - name: Codestyle
       if: ${{ matrix.python-version == '3.8' }}

--- a/CHANGES-4x.rst
+++ b/CHANGES-4x.rst
@@ -162,8 +162,10 @@ v4.2 New features
 -  Errbot initial installation. The initial installation has been
    drastically simplified::
 
-   $ pip install errbot $ mkdir errbot; cd errbot $ errbot –init $
-   errbot -T >>> <- You are game !!
+   $ pip install errbot
+   $ mkdir errbot; cd errbot
+   $ errbot –init
+   $ errbot -T >>> <- You are game !!
 
    Not only that but it also install a development directory in there so
    it now takes only seconds to have an Errbot development environment.

--- a/CHANGES-4x.rst
+++ b/CHANGES-4x.rst
@@ -473,10 +473,8 @@ Further info on identifier changes
 
 The relationship is as follow:
 
-.. image::
-https://raw.githubusercontent.com/errbotio/errbot/master/docs/_static/arch/identifiers.png
-:target:
-https://github.com/errbotio/errbot/blob/master/errbot/backends/base.py
+.. image:: https://raw.githubusercontent.com/errbotio/errbot/master/docs/_static/arch/identifiers.png
+   :target: https://github.com/errbotio/errbot/blob/master/errbot/backends/base.py
 
 For example: A Message sent from a room will have a RoomOccupant as frm
 and a Room as to.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,6 @@ fixes:
 - chore: minor code cleanup (#1465)
 - chore: Use black codestyle (#1457)
 
-
 v6.1.6 (2020-11-16)
 -------------------
 
@@ -31,7 +30,6 @@ fixes:
 - plugins: Fix error when plugin plug file is missing description (#1462)
 - docs: typographical issues in setup guide (#1475)
 - refactor: Split changelog by major versions (#1474)
-
 
 v6.1.5 (2020-10-10)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,8 @@ fixes:
 - core: AttributeError on Blacklisted plugins (#1369)
 - chore: Remove travis configuration (#1478)
 - chore: minor code cleanup (#1465)
-- chore: Use black codestyle (#1457)
+- chore: Use black codestyle (#1457, #1485)
+- chore: Use twine to check dist (#1485)
 
 v6.1.6 (2020-11-16)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ fixes:
 - core: AttributeError on Blacklisted plugins (#1369)
 - chore: Remove travis configuration (#1478)
 - chore: minor code cleanup (#1465)
+- chore: Use black codestyle (#1457)
 
 
 v6.1.6 (2020-11-16)

--- a/tox.ini
+++ b/tox.ini
@@ -17,8 +17,10 @@ commands =
     black --check errbot/ tests/ tools/
 
 [testenv:pypi-lint]
-deps = docutils
-commands = python setup.py check --restructured --strict --metadata
+deps =
+  twine
+commands =
+  twine check {toxworkdir}/dist/*
 
 [testenv:sort]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,codestyle,pypi-lint,sort,security
+envlist = py36,py37,py38,py39,codestyle,dist-check,sort,security
 skip_missing_interpreters = True
 
 [testenv]
@@ -16,7 +16,7 @@ deps = black
 commands =
     black --check errbot/ tests/ tools/
 
-[testenv:pypi-lint]
+[testenv:dist-check]
 deps =
   twine
 commands =


### PR DESCRIPTION
Adding missing entries from #1457.

I also included a change in how rst markup is checked. This in turn also checks the validity of the distribution.