### PR TITLE
Split the command on _all_ whitespace when matching commands

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ fixes:
 - docs: remove matrix link (#1502)
 - docs: Update backend screenshots (#1499)
 - docs: Remove Google+ references (#1497)
+- core: Split messages using `split()` instead of whitespace (#1496)
 
 v6.1.7 (2020-12-18)
 -------------------

--- a/errbot/core.py
+++ b/errbot/core.py
@@ -324,7 +324,7 @@ class ErrBot(Backend, StoreMixin):
             prefixed = True
 
         text = text.strip()
-        text_split = text.split(" ")
+        text_split = text.split()
         cmd = None
         command = None
         args = ""


### PR DESCRIPTION
Solves #1307 by treating all whitespace as things that could potentially
separate a command from its arguments

rebase of https://github.com/errbotio/errbot/pull/1308.