### PR TITLE
Add identifier for callbacks room join and room leave

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ v6.1.8 (unreleased)
 features:
 
 - core/plugin: method to append argparse options to Command object (#1394)
+- backends: Add identifier for room join and room leave callbacks (#1500)
 
 fixes:
 

--- a/errbot/backends/irc.py
+++ b/errbot/backends/irc.py
@@ -205,6 +205,7 @@ class IRCRoom(Room):
             password = ""  # nosec
 
         self.connection.join(self.room, key=password)
+        self._bot.callback_room_joined(self, self._bot.bot_identifier)
         log.info("Joined room %s.", self.room)
 
     def leave(self, reason=None):
@@ -218,6 +219,7 @@ class IRCRoom(Room):
             reason = ""
 
         self.connection.part(self.room, reason)
+        self._bot.callback_room_left(self, self._bot.bot_identifier)
         log.info(
             "Leaving room %s with reason %s.",
             self.room,

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -601,7 +601,8 @@ class SlackBackend(ErrBot):
         """Event handler for the 'member_joined_channel' event"""
         user = SlackPerson(self.sc, event["user"])
         if user == self.bot_identifier:
-            self.callback_room_joined(SlackRoom(channelid=event["channel"], bot=self))
+            user = self.bot_identifier
+        self.callback_room_joined(SlackRoom(channelid=event["channel"], bot=self), user)
 
     def _reaction_event_handler(self, event):
         """Event handler for the 'reaction_added'

--- a/errbot/backends/slack_rtm.py
+++ b/errbot/backends/slack_rtm.py
@@ -572,9 +572,11 @@ class SlackRTMBackend(ErrBot):
         """Event handler for the 'member_joined_channel' event"""
         user = SlackPerson(webclient, event["user"])
         if user == self.bot_identifier:
-            self.callback_room_joined(
-                SlackRoom(webclient=webclient, channelid=event["channel"], bot=self)
-            )
+            user = self.bot_identifier
+        self.callback_room_joined(
+            SlackRoom(webclient=webclient, channelid=event["channel"], bot=self),
+            user
+        )
 
     def userid_to_username(self, id_: str):
         """Convert a Slack user ID to their user name"""

--- a/errbot/backends/slack_rtm.py
+++ b/errbot/backends/slack_rtm.py
@@ -574,8 +574,7 @@ class SlackRTMBackend(ErrBot):
         if user == self.bot_identifier:
             user = self.bot_identifier
         self.callback_room_joined(
-            SlackRoom(webclient=webclient, channelid=event["channel"], bot=self),
-            user
+            SlackRoom(webclient=webclient, channelid=event["channel"], bot=self), user
         )
 
     def userid_to_username(self, id_: str):

--- a/errbot/backends/test.py
+++ b/errbot/backends/test.py
@@ -167,7 +167,7 @@ class TestRoom(Room):
         room = self.find_croom()
         room._occupants.append(self._bot_mucid)
         log.info("Joined room %s.", self)
-        self._bot.callback_room_joined(room)
+        self._bot.callback_room_joined(room, self._bot_mucid)
 
     def leave(self, reason=None):
         if not self.joined:
@@ -177,7 +177,7 @@ class TestRoom(Room):
         room = self.find_croom()
         room._occupants.remove(self._bot_mucid)
         log.info("Left room %s.", self)
-        self._bot.callback_room_left(room)
+        self._bot.callback_room_left(room, self._bot_mucid)
 
     @property
     def exists(self):

--- a/errbot/backends/xmpp.py
+++ b/errbot/backends/xmpp.py
@@ -141,7 +141,7 @@ class XMPPRoom(XMPPIdentifier, Room):
             f"muc::{room}::got_offline", self._bot.user_left_chat
         )
         self.configure()
-        self._bot.callback_room_joined(self)
+        self._bot.callback_room_joined(self, self._bot.bot_identifier)
         log.info("Joined room %s.", room)
 
     def leave(self, reason=None):
@@ -166,7 +166,7 @@ class XMPPRoom(XMPPIdentifier, Room):
                 f"muc::{room}::got_offline", self._bot.user_left_chat
             )
             log.info("Left room %s.", room)
-            self._bot.callback_room_left(self)
+            self._bot.callback_room_left(self, self._bot.bot_identifier)
         except KeyError:
             log.debug("Trying to leave %s while not in this room.", room)
 

--- a/errbot/botplugin.py
+++ b/errbot/botplugin.py
@@ -541,9 +541,12 @@ class BotPlugin(BotPluginBase):
         """
         pass
 
-    def callback_room_joined(self, room: Room,
-                             identifier: Identifier,
-                             invited_by: Optional[Identifier] = None):
+    def callback_room_joined(
+        self,
+        room: Room,
+        identifier: Identifier,
+        invited_by: Optional[Identifier] = None,
+    ):
         """
         Triggered when a user has joined a MUC.
 
@@ -555,9 +558,9 @@ class BotPlugin(BotPluginBase):
         """
         pass
 
-    def callback_room_left(self, room: Room,
-                           identifier: Identifier,
-                           kicked_by: Optional[Identifier] = None):
+    def callback_room_left(
+        self, room: Room, identifier: Identifier, kicked_by: Optional[Identifier] = None
+    ):
         """
         Triggered when a user has left a MUC.
 

--- a/errbot/botplugin.py
+++ b/errbot/botplugin.py
@@ -4,7 +4,7 @@ import shlex
 from io import IOBase
 from threading import Timer, current_thread
 from types import ModuleType
-from typing import Callable, Mapping, Sequence, Tuple
+from typing import Callable, Mapping, Sequence, Tuple, Optional
 
 from errbot.backends.base import (
     ONLINE,
@@ -541,23 +541,31 @@ class BotPlugin(BotPluginBase):
         """
         pass
 
-    def callback_room_joined(self, room: Room):
+    def callback_room_joined(self, room: Room,
+                             identifier: Identifier,
+                             invited_by: Optional[Identifier] = None):
         """
-        Triggered when the bot has joined a MUC.
+        Triggered when a user has joined a MUC.
 
         :param room:
             An instance of :class:`~errbot.backends.base.MUCRoom`
             representing the room that was joined.
+        :param identifier: An instance of Identifier (Person). Defaults to bot
+        :param invited_by: An instance of Identifier (Person). Defaults to None
         """
         pass
 
-    def callback_room_left(self, room: Room):
+    def callback_room_left(self, room: Room,
+                           identifier: Identifier,
+                           kicked_by: Optional[Identifier] = None):
         """
-        Triggered when the bot has left a MUC.
+        Triggered when a user has left a MUC.
 
         :param room:
             An instance of :class:`~errbot.backends.base.MUCRoom`
             representing the room that was left.
+        :param identifier: An instance of Identifier (Person). Defaults to bot
+        :param kicked_by: An instance of Identifier (Person). Defaults to None
         """
         pass
 

--- a/errbot/botplugin.py
+++ b/errbot/botplugin.py
@@ -4,7 +4,7 @@ import shlex
 from io import IOBase
 from threading import Timer, current_thread
 from types import ModuleType
-from typing import Callable, Mapping, Sequence, Tuple, Optional
+from typing import Callable, Mapping, Optional, Sequence, Tuple
 
 from errbot.backends.base import (
     ONLINE,

--- a/errbot/core.py
+++ b/errbot/core.py
@@ -709,25 +709,35 @@ class ErrBot(Backend, StoreMixin):
     def callback_presence(self, pres):
         self._dispatch_to_plugins("callback_presence", pres)
 
-    def callback_room_joined(self, room):
+    def callback_room_joined(self, room: Room,
+                             identifier=None, invited_by=None):
         """
-        Triggered when the bot has joined a MUC.
+        Triggered when a user has joined a MUC.
 
         :param room:
             An instance of :class:`~errbot.backends.base.MUCRoom`
             representing the room that was joined.
+        :param identifier: An instance of Identifier (Person). Defaults to bot
+        :param invited_by: An instance of Identifier (Person). Defaults to None
         """
-        self._dispatch_to_plugins("callback_room_joined", room)
+        if identifier is None:
+            identifier = self.bot_identifier
+        self._dispatch_to_plugins("callback_room_joined", room, identifier, invited_by)
 
-    def callback_room_left(self, room):
+    def callback_room_left(self, room: Room,
+                           identifier=None, kicked_by=None):
         """
-        Triggered when the bot has left a MUC.
+        Triggered when a user has left a MUC.
 
         :param room:
             An instance of :class:`~errbot.backends.base.MUCRoom`
             representing the room that was left.
+        :param identifier: An instance of Identifier (Person). Defaults to bot
+        :param kicked_by: An instance of Identifier (Person). Defaults to None
         """
-        self._dispatch_to_plugins("callback_room_left", room)
+        if identifier is None:
+            identifier = self.bot_identifier
+        self._dispatch_to_plugins("callback_room_left", room, identifier, kicked_by)
 
     def callback_room_topic(self, room):
         """

--- a/errbot/core.py
+++ b/errbot/core.py
@@ -709,8 +709,7 @@ class ErrBot(Backend, StoreMixin):
     def callback_presence(self, pres):
         self._dispatch_to_plugins("callback_presence", pres)
 
-    def callback_room_joined(self, room: Room,
-                             identifier=None, invited_by=None):
+    def callback_room_joined(self, room: Room, identifier=None, invited_by=None):
         """
         Triggered when a user has joined a MUC.
 
@@ -724,8 +723,7 @@ class ErrBot(Backend, StoreMixin):
             identifier = self.bot_identifier
         self._dispatch_to_plugins("callback_room_joined", room, identifier, invited_by)
 
-    def callback_room_left(self, room: Room,
-                           identifier=None, kicked_by=None):
+    def callback_room_left(self, room: Room, identifier=None, kicked_by=None):
         """
         Triggered when a user has left a MUC.
 

--- a/tests/room_plugin/roomtest.py
+++ b/tests/room_plugin/roomtest.py
@@ -11,11 +11,11 @@ class RoomTest(BotPlugin):
         super().activate()
         self.purge()
 
-    def callback_room_joined(self, room):
+    def callback_room_joined(self, room, user, invited_by):
         log.info("join")
         self.events.put("callback_room_joined {!s}".format(room))
 
-    def callback_room_left(self, room):
+    def callback_room_left(self, room, user, kicked_by):
         self.events.put("callback_room_left {!s}".format(room))
 
     def callback_room_topic(self, room):


### PR DESCRIPTION
Enable to use **callback_room_joined** and **callback_room_left** with other identities (Persons), rather than the bot itself only.
Not sure if this is a breaking change, currently testing with Slack Events Backend (custom).