### PR TITLE
Fix README href to plugin development docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ v6.1.8 (unreleased)
 
 fixes:
 
+- docs: update broken readme link to plugin development docs (#1504)
 - close threadpool on exit (#1486)
 - docs: remove matrix link (#1502)
 - docs: Update backend screenshots (#1499)

--- a/README.rst
+++ b/README.rst
@@ -221,7 +221,7 @@ As an example, this is all it takes to create a "Hello, world!" plugin for Errbo
 
 This plugin will create the command "!hello" which, when issued, returns "Hello, world!"
 to you. For more info on everything you can do with plugins, see the
-`plugin development guide <https://errbot.readthedocs.io/en/latest/user_guide/plugin_development/index.html/>`_.
+`plugin development guide <https://errbot.io/en/latest/user_guide/plugin_development/>`_.
 
 Contribution to Errbot itself
 -----------------------------

--- a/README.rst
+++ b/README.rst
@@ -221,7 +221,7 @@ As an example, this is all it takes to create a "Hello, world!" plugin for Errbo
 
 This plugin will create the command "!hello" which, when issued, returns "Hello, world!"
 to you. For more info on everything you can do with plugins, see the
-`plugin development guide <http://errbot.io/user_guide/plugin_development/>`_.
+`plugin development guide <https://errbot.readthedocs.io/en/latest/user_guide/plugin_development/index.html/>`_.
 
 Contribution to Errbot itself
 -----------------------------


### PR DESCRIPTION
It looks like the href for "plugin development" in the README links to a dead page. I found the page and fixed the link.