### PR TITLE
fix: circular dependencies error when there are none

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,7 @@ fixes:
 - fix: removed deprecated argument reconnection_interval for irc v20.0 (#1568)
 - docs: Add Gentoo packages (#1567)
 - chore: bump actions/setup-python from 3.1.0 to 3.1.2 (#1564)
+- fix: circular dependencies error when there are none (#1505)
 
 v6.1.8 (2021-06-21)
 -------------------

--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -421,7 +421,7 @@ class BotPluginManager(StoreMixin):
         """
         Activates all plugins that are not activated, respecting its dependencies.
 
-        :return: Empty string if no problem occured or a string explaining what went wrong.
+        :return: Empty string if no problem occurred or a string explaining what went wrong.
         """
         log.info("Activate bot plugins...")
         errors = ""

--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -469,7 +469,7 @@ class BotPluginManager(StoreMixin):
             name: set(info.dependencies) for name, info in self.plugin_infos.items()
         }
         plugins_in_cycle = set()
-        while 1:
+        while True:
             plugins_sorter = TopologicalSorter(plugins_graph)
             try:
                 # Return plugins which are part of a circular dependency at the end,

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ deps = [
 ]
 
 if py_version < (3, 9):
-    deps.append("graphlib-backport")
+    deps.append("graphlib-backport==1.0.3")
 
 src_root = os.curdir
 

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,9 @@ deps = [
     "deepmerge==1.0.1",
 ]
 
+if py_version < (3, 9):
+    deps.append("graphlib-backport")
+
 src_root = os.curdir
 
 

--- a/tests/circular_dependencies_test.py
+++ b/tests/circular_dependencies_test.py
@@ -6,9 +6,9 @@ extra_plugin_dir = os.path.join(
 pytest_plugins = ["errbot.backends.test"]
 
 
-# def test_if_all_loaded_circular_dependencies(testbot):
-#     """https://github.com/errbotio/errbot/issues/1397"""
-#     plug_names = testbot.bot.plugin_manager.get_all_active_plugin_names()
-#     assert "PluginA" in plug_names
-#     assert "PluginB" in plug_names
-#     assert "PluginC" in plug_names
+def test_if_all_loaded_circular_dependencies(testbot):
+    """https://github.com/errbotio/errbot/issues/1397"""
+    plug_names = testbot.bot.plugin_manager.get_all_active_plugin_names()
+    assert "PluginA" in plug_names
+    assert "PluginB" in plug_names
+    assert "PluginC" in plug_names

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -169,6 +169,10 @@ def test_broken_plugin(testbot):
         )
         assert "import borken  # fails" in testbot.pop_message()
         assert "as it did not load correctly." in testbot.pop_message()
+        assert (
+            "Error: Broken failed to activate: "
+            "'NoneType' object has no attribute 'is_activated'"
+        ) in testbot.pop_message()
         assert "Plugins reloaded." in testbot.pop_message()
     finally:
         rmtree(tempd)

--- a/tests/dependencies_test.py
+++ b/tests/dependencies_test.py
@@ -58,3 +58,10 @@ def test_indirect_circular_dependency(testbot):
     assert "Circular2" not in plug_names
     assert "Circular3" not in plug_names
     assert "Circular4" not in plug_names
+
+
+def test_chained_dependency(testbot):
+    plug_names = testbot.bot.plugin_manager.get_all_active_plugin_names()
+    assert "Chained1" in plug_names
+    assert "Chained2" in plug_names
+    assert "Chained3" in plug_names

--- a/tests/dependent_plugins/chained1.plug
+++ b/tests/dependent_plugins/chained1.plug
@@ -1,0 +1,3 @@
+[Core]
+Name = Chained1
+Module = chained1

--- a/tests/dependent_plugins/chained1.py
+++ b/tests/dependent_plugins/chained1.py
@@ -1,0 +1,5 @@
+from errbot import BotPlugin
+
+
+class Chained1(BotPlugin):
+    pass

--- a/tests/dependent_plugins/chained2.plug
+++ b/tests/dependent_plugins/chained2.plug
@@ -1,0 +1,4 @@
+[Core]
+Name = Chained2
+Module = chained2
+DependsOn = Chained1

--- a/tests/dependent_plugins/chained2.py
+++ b/tests/dependent_plugins/chained2.py
@@ -1,0 +1,5 @@
+from errbot import BotPlugin
+
+
+class Chained2(BotPlugin):
+    pass

--- a/tests/dependent_plugins/chained3.plug
+++ b/tests/dependent_plugins/chained3.plug
@@ -1,0 +1,4 @@
+[Core]
+Name = Chained3
+Module = chained3
+DependsOn = Chained2, Chained1

--- a/tests/dependent_plugins/chained3.py
+++ b/tests/dependent_plugins/chained3.py
@@ -1,0 +1,5 @@
+from errbot import BotPlugin
+
+
+class Chained3(BotPlugin):
+    pass


### PR DESCRIPTION
I have the same issue as the one reported in #1397. I'm not sure I can fix it, but I thought it would be helpful to at least write a test reproducing the issue. 

Fix #1397 

## Implementation note

I initially had:

- `chained1` depends on `chained2`, `chained3`
- `chained2` depends on `chained3`
- `chained3` depends on nothing

But this worked fine, there was no problem. It looks like the problem depends on the plugin names, I can reproduce with:

- `chained3` depends on `chained2` and `chained1`
- `chained2` depends on `chained1`
- `chained1` depends on nothing

## Checklist

- [x] Add a new test case reproducing the problem reported in #1397
- [x] Fix the problem