### PR TITLE
Include command arguments as part of the ACL.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ features:
 - core/plugin: method to append argparse options to Command object (#1394)
 - backends: Add identifier for room join and room leave callbacks (#1500)
 - backends/test: allow attachments to pytest messages as extras (#1489)
+- core/acl: Add allowargs / denyargs filters to ACL (#1509)
 
 fixes:
 

--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -778,7 +778,7 @@ class Stream(io.BufferedReader):
         )
 
     def ack_data(self, length: int) -> None:
-        """ Acknowledge data has been transfered. """
+        """Acknowledge data has been transfered."""
         self._transfered = length
 
 
@@ -824,26 +824,26 @@ class Backend(ABC):
         private: bool = False,
         threaded: bool = False,
     ):
-        """ Should be implemented by the backend """
+        """Should be implemented by the backend"""
 
     @abstractmethod
     def callback_presence(self, presence: Presence) -> None:
-        """ Implemented by errBot. """
+        """Implemented by errBot."""
         pass
 
     @abstractmethod
     def callback_room_joined(self, room: Room) -> None:
-        """ See :class:`~errbot.errBot.ErrBot` """
+        """See :class:`~errbot.errBot.ErrBot`"""
         pass
 
     @abstractmethod
     def callback_room_left(self, room: Room) -> None:
-        """ See :class:`~errbot.errBot.ErrBot` """
+        """See :class:`~errbot.errBot.ErrBot`"""
         pass
 
     @abstractmethod
     def callback_room_topic(self, room: Room) -> None:
-        """ See :class:`~errbot.errBot.ErrBot` """
+        """See :class:`~errbot.errBot.ErrBot`"""
         pass
 
     def serve_forever(self) -> None:
@@ -899,7 +899,7 @@ class Backend(ABC):
         self._reconnection_delay = 1
 
     def build_message(self, text: str) -> Message:
-        """ You might want to override this one depending on your backend """
+        """You might want to override this one depending on your backend"""
         return Message(body=text)
 
     # ##### HERE ARE THE SPECIFICS TO IMPLEMENT PER BACKEND
@@ -946,7 +946,7 @@ class Backend(ABC):
         )
 
     def connect(self) -> Any:
-        """Connects the bot to server or returns current connection """
+        """Connects the bot to server or returns current connection"""
 
     @abstractmethod
     def query_room(self, room: str) -> Room:

--- a/errbot/backends/hipchat.py
+++ b/errbot/backends/hipchat.py
@@ -627,7 +627,7 @@ class HipchatBackend(XMPPBackend):
         return stream
 
     def _hipchat_upload(self, stream):
-        """ Uploads file in a stream  """
+        """Uploads file in a stream"""
         try:
             stream.accept()
             room = self.query_room(str(stream.identifier)).room

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -1118,7 +1118,7 @@ class SlackBackend(ErrBot):
         return "slack"
 
     def query_room(self, room):
-        """ Room can either be a name or a channelid """
+        """Room can either be a name or a channelid"""
         if room.startswith("C") or room.startswith("G"):
             return SlackRoom(channelid=room, bot=self)
 

--- a/errbot/backends/slack_rtm.py
+++ b/errbot/backends/slack_rtm.py
@@ -1072,7 +1072,7 @@ class SlackRTMBackend(ErrBot):
         return "slack"
 
     def query_room(self, room):
-        """ Room can either be a name or a channelid """
+        """Room can either be a name or a channelid"""
         if room.startswith("C") or room.startswith("G"):
             return SlackRoom(webclient=self.webclient, channelid=room, bot=self)
 

--- a/errbot/backends/test.py
+++ b/errbot/backends/test.py
@@ -140,7 +140,7 @@ class TestRoom(Room):
         return self._occupants
 
     def find_croom(self):
-        """ find back the canonical room from a this room"""
+        """find back the canonical room from a this room"""
         for croom in self._bot._rooms:
             if croom == self:
                 return croom

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -289,7 +289,6 @@ BOT_ADMINS = ("gbin@localhost",)
 #                   'about': {'denyusers': ('*@evilhost',), 'allowrooms': ('room1@conference.localhost', 'room2@conference.localhost')},
 #                   'uptime': {'allowusers': BOT_ADMINS},
 #                   'help': {'allowmuc': False},
-#                   'help': {'allowmuc': False},
 #                   'ChatRoom:*': {'allowusers': BOT_ADMINS},
 #                  }
 

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -262,13 +262,15 @@ BOT_ADMINS = ("gbin@localhost",)
 #   denyusers: Deny command from these users
 #   allowrooms: Allow command only in these rooms (and direct messages)
 #   denyrooms: Deny command in these rooms
+#   allowargs: Allow a command's argument from these users only
+#   denyargs: Deny a command's argument from these users
 #   allowprivate: Allow command from direct messages to the bot
 #   allowmuc: Allow command inside rooms
 # Rules listed in ACCESS_CONTROLS_DEFAULT are applied by default and merged
 # with any commands found in ACCESS_CONTROLS.
 #
-# The options allowusers, denyusers, allowrooms and denyrooms support
-# unix-style globbing similar to BOT_ADMINS.
+# The options allowusers, denyusers, allowrooms and denyrooms, allowargs,
+# denyargs support unix-style globbing similar to BOT_ADMINS.
 #
 # Command names also support unix-style globs and can optionally be restricted
 # to a specific plugin by prefixing the command with the name of a plugin,

--- a/errbot/core_plugins/acls.py
+++ b/errbot/core_plugins/acls.py
@@ -74,8 +74,20 @@ class ACLS(BotPlugin):
                 break
 
         self.log.info(
-            "Matching ACL %s against username %s for command %s.", acl, usr, cmd_str
+            f"Matching ACL {acl} against username {usr} for command {cmd_str}."
         )
+        if "allowargs" in acl and not glob(args, acl["allowargs"]):
+            return self.access_denied(
+                msg,
+                "You're not allowed to access this command using the provided arguments",
+                dry_run,
+            )
+        if "denyargs" in acl and glob(args, acl["denyargs"]):
+            return self.access_denied(
+                msg,
+                "You're not allowed to access this command using the provided arguments",
+                dry_run,
+            )
 
         if "allowusers" in acl and not glob(usr, acl["allowusers"]):
             return self.access_denied(
@@ -118,7 +130,7 @@ class ACLS(BotPlugin):
                 dry_run,
             )
 
-        self.log.debug("Check if %s is admin only command.", cmd)
+        self.log.debug(f"Check if {cmd} is admin only command.")
         if f._err_command_admin_only:
             if not glob(get_acl_usr(msg), self.bot_config.BOT_ADMINS):
                 return self.access_denied(

--- a/errbot/core_plugins/backup.py
+++ b/errbot/core_plugins/backup.py
@@ -4,7 +4,7 @@ from errbot import BotPlugin, botcmd
 
 
 class Backup(BotPlugin):
-    """ Backup related commands. """
+    """Backup related commands."""
 
     @botcmd(admin_only=True)
     def backup(self, msg, args):

--- a/errbot/core_plugins/flows.py
+++ b/errbot/core_plugins/flows.py
@@ -144,7 +144,7 @@ class Flows(BotPlugin):
     @arg_botcmd("flow_name", type=str)
     @arg_botcmd("user", type=str)
     def flows_kill(self, _, user, flow_name):
-        """ Admin command to kill a specific flow."""
+        """Admin command to kill a specific flow."""
         flow = self._bot.flow_executor.stop_flow(flow_name, self.build_identifier(user))
         if flow:
             return flow.name + " killed."

--- a/errbot/core_plugins/health.py
+++ b/errbot/core_plugins/health.py
@@ -76,7 +76,7 @@ class Health(BotPlugin):
     # noinspection PyUnusedLocal
     @botcmd(admin_only=True)
     def restart(self, msg, args):
-        """ Restart the bot. """
+        """Restart the bot."""
         self.send(msg.frm, "Deactivating all the plugins...")
         self._bot.plugin_manager.deactivate_all_plugins()
         self.send(msg.frm, "Restarting")

--- a/errbot/rendering/ansiext.py
+++ b/errbot/rendering/ansiext.py
@@ -507,7 +507,7 @@ class AnsiPostprocessor(Postprocessor):
 # This is an adapted FencedBlockPreprocessor that doesn't insert <code><pre>
 class AnsiPreprocessor(FencedBlockPreprocessor):
     def run(self, lines):
-        """ Match and store Fenced Code Blocks in the HtmlStash. """
+        """Match and store Fenced Code Blocks in the HtmlStash."""
         text = "\n".join(lines)
         while 1:
             m = self.FENCED_BLOCK_RE.search(text)
@@ -521,7 +521,7 @@ class AnsiPreprocessor(FencedBlockPreprocessor):
         return text.split("\n")
 
     def _escape(self, txt):
-        """ basic html escaping """
+        """basic html escaping"""
         txt = txt.replace("&", "&amp;")
         txt = txt.replace("<", "&lt;")
         txt = txt.replace(">", "&gt;")

--- a/errbot/streaming.py
+++ b/errbot/streaming.py
@@ -26,21 +26,21 @@ def repeatfunc(func, times=None, *args):  # from the itertools receipes
 
 
 class Tee:
-    """ Tee implements a multi reader / single writer """
+    """Tee implements a multi reader / single writer"""
 
     def __init__(self, incoming_stream, clients):
-        """ clients is a list of objects implementing callback_stream """
+        """clients is a list of objects implementing callback_stream"""
         self.incoming_stream = incoming_stream
         self.clients = clients
 
     def start(self):
-        """ starts the transfer asynchronously """
+        """starts the transfer asynchronously"""
         t = Thread(target=self.run)
         t.start()
         return t
 
     def run(self):
-        """ streams to all the clients synchronously """
+        """streams to all the clients synchronously"""
         nb_clients = len(self.clients)
         pipes = [
             (io.open(r, "rb"), io.open(w, "wb"))

--- a/errbot/utils.py
+++ b/errbot/utils.py
@@ -21,7 +21,7 @@ PLUGINS_SUBDIR = "plugins"
 
 # noinspection PyPep8Naming
 class deprecated:
-    """ deprecated decorator. emits a warning on a call on an old method and call the new method anyway """
+    """deprecated decorator. emits a warning on a call on an old method and call the new method anyway"""
 
     def __init__(self, new=None):
         self.new = new

--- a/tests/base_backend_test.py
+++ b/tests/base_backend_test.py
@@ -890,6 +890,26 @@ def test_access_controls(dummy_backend):
             acl={"command": {"denyusers": ("*err",)}},
             expected_response="You're not allowed to access this command from this user",
         ),
+        dict(
+            message=makemessage(dummy_backend, "!command echo"),
+            acl={"command": {"allowargs": ("echo",)}},
+            expected_response="Regular command",
+        ),
+        dict(
+            message=makemessage(dummy_backend, "!command notallowed"),
+            acl={"command": {"allowargs": ("echo",)}},
+            expected_response="You're not allowed to access this command using the provided arguments",
+        ),
+        dict(
+            message=makemessage(dummy_backend, "!command echodeny"),
+            acl={"command": {"denyargs": ("echodeny",)}},
+            expected_response="You're not allowed to access this command using the provided arguments",
+        ),
+        dict(
+            message=makemessage(dummy_backend, "!command echo"),
+            acl={"command": {"denyargs": ("echodeny",)}},
+            expected_response="Regular command",
+        ),
         # ACCESS_CONTROLS scenarios WITH wildcards (>=4.0 format)
         dict(
             message=makemessage(dummy_backend, "!command"),
@@ -905,6 +925,21 @@ def test_access_controls(dummy_backend):
             message=makemessage(dummy_backend, "!command"),
             acl={"DummyBackendRealName:*": {"denyusers": ("noterr",)}},
             expected_response="You're not allowed to access this command from this user",
+        ),
+        dict(
+            message=makemessage(dummy_backend, "!command echo"),
+            acl={"command": {"allowargs": ("ec*",)}},
+            expected_response="Regular command",
+        ),
+        dict(
+            message=makemessage(dummy_backend, "!command notallowed"),
+            acl={"command": {"allowargs": ("e*",)}},
+            expected_response="You're not allowed to access this command using the provided arguments",
+        ),
+        dict(
+            message=makemessage(dummy_backend, "!command denied"),
+            acl={"command": {"denyargs": ("den*",)}},
+            expected_response="You're not allowed to access this command using the provided arguments",
         ),
         # Overlapping globs should use first match
         dict(

--- a/tests/borken_plugin/broken.py
+++ b/tests/borken_plugin/broken.py
@@ -6,5 +6,5 @@ from errbot import BotPlugin, botcmd
 class Broken(BotPlugin):
     @botcmd
     def hello(self, msg, args):
-        """ this command says hello """
+        """this command says hello"""
         return "Hello World !"


### PR DESCRIPTION
Access control lists are based on command but can't discriminate based on arguments supplied to a command.  This patch adds `denyargs` and `allowargs` lists that are evaluated by globbing, in the same way usernames and rooms are evaluated.

To provide an example of how argument ACLs work, here is a configuration that limits the `echo` command to `ACL_BOT_USER` in the `#test_channel` supplying the arguments `hello` or `hi*`:
```
ACL_BOT_USER = ["Uxxxxxxxx"]
ACL_EVERYONE = ["*"]
ACCESS_CONTROLS = {
    'echo':{
        'allowargs': ["hello", "hi*"],
        'allowrooms': ['#test_channel'],
        'allowusers': ACL_BOT_USER
    },
}
```

This results in the following behaviour:

```
Carlos  18:35
!echo hello

myerrbot APP  18:35
hello

Carlos  18:36
!echo hi everyone

myerrbot APP  18:36
hi everyone

Carlos  18:36
!echo goodbye

myerrbot APP  18:36
You're not allowed to access this command using the provided arguments
```

The configuration has been implemented to be non disruptive for existing bot configurations.  Security rules will be applied as before until a bot administrator explicitly adds the needed configuration for argument parsing.