### PR TITLE
Make example_plugin_dir using not directly base_dir

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ features:
 
 fixes:
 
+- core/cli: failure when passing relative directory during --init (#1511)
 - backend/xmpp: include message delayed for send/recieved messages (#1270)
 - backend/xmpp: "unexpected keyword argument 'wait'" when connecting (#1507)
 - docs: update broken readme link to plugin development docs (#1504)

--- a/errbot/cli.py
+++ b/errbot/cli.py
@@ -197,7 +197,11 @@ def main():
 
             import jinja2
 
-            base_dir = pathlib.Path.cwd() if args["init"] == "." else Path(args["init"]).resolve()
+            base_dir = (
+                pathlib.Path.cwd()
+                if args["init"] == "."
+                else Path(args["init"]).resolve()
+            )
 
             if not base_dir.exists():
                 print(f"Target directory {base_dir} must exist. Please create it.")

--- a/errbot/cli.py
+++ b/errbot/cli.py
@@ -204,7 +204,7 @@ def main():
 
             data_dir = base_dir / "data"
             extra_plugin_dir = base_dir / "plugins"
-            example_plugin_dir = base_dir / extra_plugin_dir / "err-example"
+            example_plugin_dir = extra_plugin_dir / "err-example"
             log_path = base_dir / "errbot.log"
 
             templates_dir = Path(os.path.dirname(__file__)) / "templates" / "initdir"

--- a/errbot/cli.py
+++ b/errbot/cli.py
@@ -197,7 +197,7 @@ def main():
 
             import jinja2
 
-            base_dir = pathlib.Path.cwd() if args["init"] == "." else Path(args["init"])
+            base_dir = pathlib.Path.cwd() if args["init"] == "." else Path(args["init"]).resolve()
 
             if not base_dir.exists():
                 print(f"Target directory {base_dir} must exist. Please create it.")


### PR DESCRIPTION
This is for fix to #1510.

Base thinking for fix (python repl):

```
>>> from pathlib import Path
>>> base_dir = Path("foo")
>>> extra_plugin_dir = base_dir / "plugins"

>>> example_plugin_dir = base_dir / extra_plugin_dir / "err-example"
>>> example_plugin_dir
PosixPath('foo/foo/plugins/err-example')

>>> example_plugin_dir = extra_plugin_dir / "err-example"
>>> example_plugin_dir
PosixPath('foo/plugins/err-example')
```