### PR TITLE
Several logging fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ features:
 - backends: Add identifier for room join and room leave callbacks (#1500)
 - backends/test: allow attachments to pytest messages as extras (#1489)
 - core/acl: Add allowargs / denyargs filters to ACL (#1509)
+- core/bootstrap: Small logging fixes to BOT_LOG_FILE and FORMATTER (#1513)
 
 fixes:
 

--- a/errbot/bootstrap.py
+++ b/errbot/bootstrap.py
@@ -84,7 +84,7 @@ def setup_bot(backend_name: str, logger, config, restore=None) -> ErrBot:
     else:
         format_logs(theme_color=config.TEXT_COLOR_THEME)
 
-    if config.BOT_LOG_FILE:
+    if hasattr(config, "BOT_LOG_FILE") and config.BOT_LOG_FILE:
         hdlr = logging.FileHandler(config.BOT_LOG_FILE)
         hdlr.setFormatter(
             logging.Formatter("%(asctime)s %(levelname)-8s %(name)-25s %(message)s")

--- a/errbot/bootstrap.py
+++ b/errbot/bootstrap.py
@@ -84,12 +84,12 @@ def setup_bot(backend_name: str, logger, config, restore=None) -> ErrBot:
     else:
         format_logs(theme_color=config.TEXT_COLOR_THEME)
 
-        if config.BOT_LOG_FILE:
-            hdlr = logging.FileHandler(config.BOT_LOG_FILE)
-            hdlr.setFormatter(
-                logging.Formatter("%(asctime)s %(levelname)-8s %(name)-25s %(message)s")
-            )
-            logger.addHandler(hdlr)
+    if config.BOT_LOG_FILE:
+        hdlr = logging.FileHandler(config.BOT_LOG_FILE)
+        hdlr.setFormatter(
+            logging.Formatter("%(asctime)s %(levelname)-8s %(name)-25s %(message)s")
+        )
+        logger.addHandler(hdlr)
 
     if hasattr(config, "BOT_LOG_SENTRY") and config.BOT_LOG_SENTRY:
         sentry_integrations = []


### PR DESCRIPTION
Several small fixes for logging-related bugs.

* Fix: Setting a custom BOT_LOG_FORMATTER no longer stops logging to a file 
* Fix: Check that the BOT_LOG_FILE attribute exists in config before trying to use it (don't break bot-startup if not set)