### PR TITLE
Fix cascade dependency plugins

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ v6.1.9 (unreleased)
 fixes:
 
 - core: success handling for update_repos (#1520)
+- core/plugins: cascade dependency plugins (#1519)
 
 v6.1.8 (2021-06-21)
 -------------------

--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -552,7 +552,8 @@ class BotPluginManager(StoreMixin):
                     dep_name,
                     dep_name,
                 )
-                self._activate_plugin_dependencies(dep_name, dep_track)
+                sub_depends_on = self._activate_plugin_dependencies(dep_name, dep_track)
+                dep_plugin.dependencies = sub_depends_on
                 self._activate_plugin(dep_plugin, dep_plugin_info)
         return depends_on
 

--- a/tests/cascade_dependencies_test.py
+++ b/tests/cascade_dependencies_test.py
@@ -12,10 +12,10 @@ orig_path_glob = pathlib.Path.glob
 
 def reordered_plugin_files(self, pattern):
     if self.name == 'cascade_dependent_plugins':
-        yield pathlib.Path(extra_plugin_dir + '/Parent2.plug')
-        yield pathlib.Path(extra_plugin_dir + '/Child1.plug')
-        yield pathlib.Path(extra_plugin_dir + '/Child2.plug')
-        yield pathlib.Path(extra_plugin_dir + '/Parent1.plug')
+        yield pathlib.Path(extra_plugin_dir + '/parent2.plug')
+        yield pathlib.Path(extra_plugin_dir + '/child1.plug')
+        yield pathlib.Path(extra_plugin_dir + '/child2.plug')
+        yield pathlib.Path(extra_plugin_dir + '/parent1.plug')
         return
     yield from orig_path_glob(self, pattern)
 

--- a/tests/cascade_dependencies_test.py
+++ b/tests/cascade_dependencies_test.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+
 import mock
 import pytest
 
@@ -11,18 +12,18 @@ orig_path_glob = pathlib.Path.glob
 
 
 def reordered_plugin_files(self, pattern):
-    if self.name == 'cascade_dependent_plugins':
-        yield pathlib.Path(extra_plugin_dir + '/parent2.plug')
-        yield pathlib.Path(extra_plugin_dir + '/child1.plug')
-        yield pathlib.Path(extra_plugin_dir + '/child2.plug')
-        yield pathlib.Path(extra_plugin_dir + '/parent1.plug')
+    if self.name == "cascade_dependent_plugins":
+        yield pathlib.Path(extra_plugin_dir + "/parent2.plug")
+        yield pathlib.Path(extra_plugin_dir + "/child1.plug")
+        yield pathlib.Path(extra_plugin_dir + "/child2.plug")
+        yield pathlib.Path(extra_plugin_dir + "/parent1.plug")
         return
     yield from orig_path_glob(self, pattern)
 
 
 @pytest.fixture
 def mock_before_bot_load():
-    patcher = mock.patch.object(pathlib.Path, 'glob', reordered_plugin_files)
+    patcher = mock.patch.object(pathlib.Path, "glob", reordered_plugin_files)
     patcher.start()
     yield
     patcher.stop()

--- a/tests/cascade_dependencies_test.py
+++ b/tests/cascade_dependencies_test.py
@@ -1,0 +1,34 @@
+import os
+import pathlib
+import mock
+import pytest
+
+extra_plugin_dir = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), "cascade_dependent_plugins"
+)
+
+orig_path_glob = pathlib.Path.glob
+
+
+def reordered_plugin_files(self, pattern):
+    if self.name == 'cascade_dependent_plugins':
+        yield pathlib.Path(extra_plugin_dir + '/Parent2.plug')
+        yield pathlib.Path(extra_plugin_dir + '/Child1.plug')
+        yield pathlib.Path(extra_plugin_dir + '/Child2.plug')
+        yield pathlib.Path(extra_plugin_dir + '/Parent1.plug')
+        return
+    yield from orig_path_glob(self, pattern)
+
+
+@pytest.fixture
+def mock_before_bot_load():
+    patcher = mock.patch.object(pathlib.Path, 'glob', reordered_plugin_files)
+    patcher.start()
+    yield
+    patcher.stop()
+
+
+def test_dependency_commands(mock_before_bot_load, testbot):
+    assert "Hello from Child1" in testbot.exec_command("!parent1 to child1")
+    assert "Hello from Child2" in testbot.exec_command("!parent1 to child2")
+    assert "Hello from Parent1" in testbot.exec_command("!parent2 to parent1")

--- a/tests/cascade_dependent_plugins/child1.plug
+++ b/tests/cascade_dependent_plugins/child1.plug
@@ -1,0 +1,3 @@
+[Core]
+Name = Child1
+Module = child1

--- a/tests/cascade_dependent_plugins/child1.py
+++ b/tests/cascade_dependent_plugins/child1.py
@@ -1,0 +1,6 @@
+from errbot import BotPlugin, botcmd
+
+
+class Child1(BotPlugin):
+    def shared_function(self):
+        return "Hello from Child1"

--- a/tests/cascade_dependent_plugins/child2.plug
+++ b/tests/cascade_dependent_plugins/child2.plug
@@ -1,0 +1,3 @@
+[Core]
+Name = Child2
+Module = child2

--- a/tests/cascade_dependent_plugins/child2.py
+++ b/tests/cascade_dependent_plugins/child2.py
@@ -1,0 +1,6 @@
+from errbot import BotPlugin, botcmd
+
+
+class Child2(BotPlugin):
+    def shared_function(self):
+        return "Hello from Child2"

--- a/tests/cascade_dependent_plugins/parent1.plug
+++ b/tests/cascade_dependent_plugins/parent1.plug
@@ -1,0 +1,4 @@
+[Core]
+Name = Parent1
+Module = parent1
+DependsOn = Child1, Child2

--- a/tests/cascade_dependent_plugins/parent1.py
+++ b/tests/cascade_dependent_plugins/parent1.py
@@ -1,0 +1,14 @@
+from errbot import BotPlugin, botcmd
+
+
+class Parent1(BotPlugin):
+    @botcmd
+    def parent1_to_child1(self, msg, args):
+        return self.get_plugin("Child1").shared_function()
+
+    @botcmd
+    def parent1_to_child2(self, msg, args):
+        return self.get_plugin("Child2").shared_function()
+
+    def shared_function(self):
+        return "Hello from Parent1"

--- a/tests/cascade_dependent_plugins/parent2.plug
+++ b/tests/cascade_dependent_plugins/parent2.plug
@@ -1,0 +1,4 @@
+[Core]
+Name = Parent2
+Module = parent2
+DependsOn = Parent1

--- a/tests/cascade_dependent_plugins/parent2.py
+++ b/tests/cascade_dependent_plugins/parent2.py
@@ -1,0 +1,7 @@
+from errbot import BotPlugin, botcmd
+
+
+class Parent2(BotPlugin):
+    @botcmd
+    def parent2_to_parent1(self, msg, args):
+        return self.get_plugin("Parent1").shared_function()

--- a/tests/circular_dependencies_test.py
+++ b/tests/circular_dependencies_test.py
@@ -1,12 +1,14 @@
 import os
 
-extra_plugin_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'circular_dependent_plugins')
-pytest_plugins = ['errbot.backends.test']
+extra_plugin_dir = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), "circular_dependent_plugins"
+)
+pytest_plugins = ["errbot.backends.test"]
 
 
 def test_if_all_loaded_by_default(testbot):
-    """ https://github.com/errbotio/errbot/issues/1397 """
+    """https://github.com/errbotio/errbot/issues/1397"""
     plug_names = testbot.bot.plugin_manager.get_all_active_plugin_names()
-    assert 'PluginA' in plug_names
-    assert 'PluginB' in plug_names
-    assert 'PluginC' in plug_names
+    assert "PluginA" in plug_names
+    assert "PluginB" in plug_names
+    assert "PluginC" in plug_names

--- a/tests/circular_dependencies_test.py
+++ b/tests/circular_dependencies_test.py
@@ -1,0 +1,12 @@
+import os
+
+extra_plugin_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'circular_dependent_plugins')
+pytest_plugins = ['errbot.backends.test']
+
+
+def test_if_all_loaded_by_default(testbot):
+    """ https://github.com/errbotio/errbot/issues/1397 """
+    plug_names = testbot.bot.plugin_manager.get_all_active_plugin_names()
+    assert 'PluginA' in plug_names
+    assert 'PluginB' in plug_names
+    assert 'PluginC' in plug_names

--- a/tests/circular_dependent_plugins/pluginA.plug
+++ b/tests/circular_dependent_plugins/pluginA.plug
@@ -1,0 +1,4 @@
+[Core]
+Name = PluginA
+Module = pluginA
+DependsOn = PluginB, PluginC

--- a/tests/circular_dependent_plugins/pluginA.py
+++ b/tests/circular_dependent_plugins/pluginA.py
@@ -1,0 +1,5 @@
+from errbot import BotPlugin
+
+
+class PluginA(BotPlugin):
+    pass

--- a/tests/circular_dependent_plugins/pluginB.plug
+++ b/tests/circular_dependent_plugins/pluginB.plug
@@ -1,0 +1,4 @@
+[Core]
+Name = PluginB
+Module = pluginB
+DependsOn = PluginC

--- a/tests/circular_dependent_plugins/pluginB.py
+++ b/tests/circular_dependent_plugins/pluginB.py
@@ -1,0 +1,5 @@
+from errbot import BotPlugin
+
+
+class PluginB(BotPlugin):
+    pass

--- a/tests/circular_dependent_plugins/pluginC.plug
+++ b/tests/circular_dependent_plugins/pluginC.plug
@@ -1,0 +1,3 @@
+[Core]
+Name = PluginC
+Module = pluginC

--- a/tests/circular_dependent_plugins/pluginC.py
+++ b/tests/circular_dependent_plugins/pluginC.py
@@ -1,0 +1,5 @@
+from errbot import BotPlugin
+
+
+class PluginC(BotPlugin):
+    pass


### PR DESCRIPTION
## Bug reproduce
Complicated plugin structure.
```
Parent2 
   |
   V
Parent1
    /\
   /  \----> Child2
  V
Child1
```
It works correctly after load on my MacBook. But didn't after deploy & run in Docker on a Linux machine.
Plugin "Parent1" can't find Childs plugins, by method `get_plugin`.

## Research
This behavior depends on a file system. Method `pathlib.Path.glob` works differently on Linux & Mac.  Bot load plugins depending on the order of the files.
PluginManager can activate plugins by direct load, or if the plugin is DependOn. So if the plugin activates by the second way, the plugin doesn't set depends list.

## Merge request
1. Rreproduced bug by unit tests. 
2. Fixed `_activate_plugin_dependencies` in `PluginManager`.