### PR TITLE
Fix success handling for update_repos

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+v6.1.9 (unreleased)
+-------------------
+
+fixes:
+
+- core: success handling for update_repos (#1520)
+
 v6.1.8 (2021-06-21)
 -------------------
 

--- a/errbot/repo_manager.py
+++ b/errbot/repo_manager.py
@@ -298,11 +298,11 @@ class BotRepoManager(StoreMixin):
         names = set(self.get_installed_plugin_repos().keys()).intersection(set(repos))
 
         for d in (path.join(self.plugin_dir, name) for name in names):
-            success = 1
+            success = False
             try:
                 git_pull(d)
                 feedback = "Pulled remote"
-                success = 0
+                success = True
             except Exception as exception:
                 feedback = f"Error pulling remote {exception}"
                 pass


### PR DESCRIPTION
As part of the switch to python git, the success case handling was reversed even though `0` was still meant to indicate success (formerly used to represent process exited without error).

https://github.com/errbotio/errbot/commit/89bce02a836fdbf14f184ad54e3f9eb1a7becbb1#diff-b279f20d61152a2a99689009a59d70609c92039568c203da8c84bb56ceacd94fR287

This pull request fixes that issue and makes the code a bit more clear by using booleans rather than integers to represent the success state.