### PR TITLE
Reload all repo plugins when updating a repo

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ fixes:
 
 - core: success handling for update_repos (#1520)
 - core/plugins: cascade dependency plugins (#1519)
+- core/plugins: reload all repo plugins when updating a repo (#1521)
 
 v6.1.8 (2021-06-21)
 -------------------

--- a/errbot/core_plugins/plugins.py
+++ b/errbot/core_plugins/plugins.py
@@ -127,15 +127,15 @@ class Plugins(BotPlugin):
             if success:
                 yield f"Update of {d} succeeded...\n\n{feedback}\n\n"
 
-                plugin = self._bot.plugin_manager.get_plugin_by_path(d)
-                if hasattr(plugin, "is_activated") and plugin.is_activated:
-                    name = plugin.name
-                    yield f"/me is reloading plugin {name}"
-                    try:
-                        self._bot.plugin_manager.reload_plugin_by_name(plugin.name)
-                        yield f"Plugin {plugin.name} reloaded."
-                    except PluginActivationException as pae:
-                        yield f"Error reactivating plugin {plugin.name}: {pae}"
+                for plugin in self._bot.plugin_manager.get_plugins_by_path(d):
+                    if hasattr(plugin, "is_activated") and plugin.is_activated:
+                        name = plugin.name
+                        yield f"/me is reloading plugin {name}"
+                        try:
+                            self._bot.plugin_manager.reload_plugin_by_name(plugin.name)
+                            yield f"Plugin {plugin.name} reloaded."
+                        except PluginActivationException as pae:
+                            yield f"Error reactivating plugin {plugin.name}: {pae}"
             else:
                 yield f"Update of {d} failed...\n\n{feedback}"
 

--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -370,6 +370,11 @@ class BotPluginManager(StoreMixin):
             if str(pi.location.parent) == path:
                 return self.plugins[name]
 
+    def get_plugins_by_path(self, path):
+        for name, pi in self.plugin_infos.items():
+            if str(pi.location.parent) == path:
+                yield self.plugins[name]
+
     def deactivate_all_plugins(self):
         for name in self.get_all_active_plugin_names():
             self.deactivate_plugin(name)


### PR DESCRIPTION
`get_plugin_by_path` would only return the first plugin encountered in a
repository. This change adds the method `get_plugins_by_path` which yields
plugins as they are found.

For backwards compatibility, I have not deleted the original
`get_plugin_by_path` method, lest anyone use that method directly outside of
this package.