### PR TITLE
refactor: Set default backend to Text

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 v6.1.9 (unreleased)
 -------------------
 
+features:
+- core: set default backend to Text (#1522)
+
 fixes:
 
 - core: success handling for update_repos (#1520)

--- a/errbot/backends/text.py
+++ b/errbot/backends/text.py
@@ -103,11 +103,19 @@ class TextRoom(Room):
         self.name = name
         self._bot = bot
 
+        # get the bot username
+        bot_config = self._bot.bot_config
+        default_bot_name = "@errbot"
+        if hasattr(bot_config, "BOT_IDENTITY"):
+            bot_name = bot_config.BOT_IDENTITY.get("username", default_bot_name)
+        else:
+            bot_name = default_bot_name
+
         # fill up the room with a coherent set of identities.
         self._occupants = [
             TextOccupant("somebody", self),
             TextOccupant(TextPerson(bot.bot_config.BOT_ADMINS[0]), self),
-            TextOccupant(bot.bot_identifier, self),
+            TextOccupant(bot_name, self),
         ]
 
     def join(self, username=None, password=None):
@@ -426,7 +434,6 @@ class TextBackend(ErrBot):
             self._rooms.insert(0, self._rooms.pop(self._rooms.index(text_room)))
         return text_room
 
-    @property
     def rooms(self):
         return self._rooms
 

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -43,7 +43,7 @@ import logging
 # 'Telegram' - cloud-based mobile and desktop messaging app with a focus
 #              on security and speed. (https://telegram.org/)
 
-# BACKEND = 'XMPP'  # defaults to XMPP
+# BACKEND = 'Text'  # defaults to Text
 
 # STORAGE selection.
 # This configures the type of persistence you wish to use Errbot with.
@@ -154,9 +154,11 @@ SENTRY_EVENTLEVEL = BOT_LOG_LEVEL
 
 # The identity, or credentials, used to connect to a server
 BOT_IDENTITY = {
-    # XMPP (Jabber) mode
-    "username": "err@localhost",  # The JID of the user you have created for the bot
-    "password": "changeme",  # The corresponding password for this user
+    ## Text mode
+    "username": "@errbot",  # The name for the bot
+    ## XMPP (Jabber) mode
+    # "username": "err@localhost",  # The JID of the user you have created for the bot
+    # "password": "changeme",  # The corresponding password for this user
     # 'server': ('host.domain.tld',5222), # server override
     ## HipChat mode (Comment the above if using this mode)
     # 'username': '12345_123456@chat.hipchat.com',


### PR DESCRIPTION
We should set the default backend to something more neutral.

Also fixes https://github.com/errbotio/errbot/issues/1285