### PR TITLE
Add repos_branch command

### DIFF
--- a/errbot/core_plugins/plugins.py
+++ b/errbot/core_plugins/plugins.py
@@ -4,7 +4,7 @@ import shutil
 from ast import literal_eval
 from pprint import pformat
 
-from errbot import BotPlugin, botcmd
+from errbot import BotPlugin, arg_botcmd, botcmd
 from errbot.plugin_manager import (
     PluginActivationException,
     PluginConfigurationException,
@@ -97,6 +97,14 @@ class Plugins(BotPlugin):
             )
 
         return repos
+
+    @arg_botcmd("branch", type=str)
+    @arg_botcmd("repo", admin_only=True, type=str)
+    def repos_branch(self, message, repo, branch):
+        """Change the branch of a given repository.
+        for example a git url : !repos branch gbin/plugin branch1
+        """
+        yield from self._bot.repo_manager.checkout_branch(branch=branch, repo=repo)
 
     @botcmd(template="repos2")
     def repos_search(self, _, args):

--- a/errbot/repo_manager.py
+++ b/errbot/repo_manager.py
@@ -16,7 +16,7 @@ from urllib.request import Request, urlopen
 from errbot.storage import StoreMixin
 from errbot.storage.base import StoragePluginBase
 
-from .utils import ON_WINDOWS, git_clone, git_pull
+from .utils import ON_WINDOWS, git_checkout, git_clone, git_pull
 
 log = logging.getLogger(__name__)
 
@@ -288,6 +288,13 @@ class BotRepoManager(StoreMixin):
 
         self.add_plugin_repo(human_name, repo_url)
         return os.path.join(self.plugin_dir, human_name)
+
+    def checkout_branch(self, *, branch, repo) -> Generator[str, None, None]:
+        if repo not in self.get_installed_plugin_repos():
+            yield f"{repo!r} is not installed."
+            return
+
+        yield from git_checkout(path.join(self.plugin_dir, repo), branch)
 
     def update_repos(self, repos) -> Generator[Tuple[str, int, str], None, None]:
         """


### PR DESCRIPTION
The method for doing the checkout is likely not the most efficient as it deletes everything in the working tree, and relies upon `reset_index` to restore all the files. Nevertheless, it appears to get the job done.

Usage:

    !repos branch REPO BRANCHNAME

Note: Just like `repos update`, which also relies upon the same `pull` command, it does not support pulling in history-rewriting updates.