### PR TITLE
Add deprecation notice to Slack and SlackRTM backends

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ fixes:
 - chore: various minor formatting improvements (#1541)
 - docs: update spark plugin reference (#1546)
 - fix: python 2 version references in docs and init template (#1543)
+- backends: deprecate built-in Slack and SlackRTM (#1526)
 
 v6.1.8 (2021-06-21)
 -------------------

--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -415,6 +415,12 @@ class SlackBackend(ErrBot):
         log.debug("Converted bot_alt_prefixes: %s", self.bot_config.BOT_ALT_PREFIXES)
 
     def serve_once(self):
+        log.warning(
+            "This backend is deprecated and will be removed in a future release."
+            " No future updates, bug fixes or enhancements will be included."
+            " We strongly advise migrating to SlackV3, which is available"
+            " at https://github.com/errbotio/err-backend-slackv3."
+        )
         self.sc = SlackClient(self.token, proxies=self.proxies)
 
         log.info("Verifying authentication token")

--- a/errbot/backends/slack_rtm.py
+++ b/errbot/backends/slack_rtm.py
@@ -427,6 +427,12 @@ class SlackRTMBackend(ErrBot):
             self._presence_change_event_handler(payload["web_client"], payload["data"])
 
     def serve_forever(self):
+        log.warning(
+            "This backend is deprecated and will be removed in a future release."
+            " No future updates, bug fixes or enhancements will be included."
+            " We strongly advise migrating to SlackV3, which is available"
+            " at https://github.com/errbotio/err-backend-slackv3."
+        )
         self.sc = RTMClient(token=self.token, proxy=self.proxies)
 
         @RTMClient.run_on(event="open")


### PR DESCRIPTION
Adding deprecation notices to these backends and suggesting the [SlackV3](https://github.com/errbotio/err-backend-slackv3) one.

In the logs, the message looks like
````
00:03:28 INFO     errbot                    webhooks:  Flag to bind /github to notification
00:03:28 INFO     errbot                    webhooks:  Flag to bind /test to test
00:03:28 WARNING  errbot.backends.slack     This backend is deprecated and will be removed in a future release. No future updates, bug fixes or enhancements will be included. We strongly advise migrating to SlackV3, which is available at https://github.com/errbotio/err-backend-slackv3
00:03:28 INFO     errbot.backends.slack     Verifying authentication token
00:03:28 INFO     errbot.backends.slack     Connecting to Slack real-time-messaging API
00:03:29 INFO     errbot.backends.slack     Connected
```