### PR TITLE
Don't use str(room) for acl matches

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ features:
 - core: add type hints to core and backend functions (#1542)
 - docs: add ACL and numerous backends to official documentation (#1552)
 - core: add Python 3.10 to automated tests (#1539)
+- core: add room acl attribute (#1530)
 
 fixes:
 

--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -140,6 +140,13 @@ class Room(Identifier):
         )
 
     @property
+    def aclattr(self) -> str:
+        """
+        :return: returns the unique identifier that will be used for ACL matches.
+        """
+        return str(self)
+
+    @property
     def exists(self) -> bool:
         """
         Boolean indicating whether this room already exists or not.

--- a/errbot/backends/test.py
+++ b/errbot/backends/test.py
@@ -244,6 +244,18 @@ class TestRoom(Room):
         return self._name == other._name
 
 
+class TestRoomAcl(TestRoom):
+    def __init__(self, name, occupants=None, topic=None, bot=None):
+        super().__init__(name, occupants, topic, bot)
+
+    @property
+    def aclattr(self):
+        return self._name
+
+    def __str__(self):
+        return "not room name"
+
+
 class TestBackend(ErrBot):
     def change_presence(self, status: str = ONLINE, message: str = "") -> None:
         pass

--- a/errbot/core_plugins/acls.py
+++ b/errbot/core_plugins/acls.py
@@ -17,7 +17,7 @@ def get_acl_usr(msg):
 def get_acl_room(room):
     """Return the ACL attribute of the room used for a given message"""
     if hasattr(
-        msg.frm, "aclattr"
+        room, "aclattr"
     ):
         return room.aclattr
     return str(room) # old behaviour

--- a/errbot/core_plugins/acls.py
+++ b/errbot/core_plugins/acls.py
@@ -14,6 +14,13 @@ def get_acl_usr(msg):
         return msg.frm.aclattr
     return msg.frm.person  # default
 
+def get_acl_room(room):
+    """Return the ACL attribute of the room used for a given message"""
+    if hasattr(
+        msg.frm, "aclattr"
+    ):
+        return room.aclattr
+    return str(room) # old behaviour
 
 def glob(text, patterns):
     """
@@ -102,7 +109,7 @@ class ACLS(BotPlugin):
                 raise Exception(
                     f"msg.frm is not a RoomOccupant. Class of frm: {msg.frm.__class__}"
                 )
-            room = str(msg.frm.room)
+            room = get_acl_room(msg.frm.room)
             if "allowmuc" in acl and acl["allowmuc"] is False:
                 return self.access_denied(
                     msg,

--- a/errbot/core_plugins/acls.py
+++ b/errbot/core_plugins/acls.py
@@ -14,13 +14,13 @@ def get_acl_usr(msg):
         return msg.frm.aclattr
     return msg.frm.person  # default
 
+
 def get_acl_room(room):
     """Return the ACL attribute of the room used for a given message"""
-    if hasattr(
-        room, "aclattr"
-    ):
+    if hasattr(room, "aclattr"):
         return room.aclattr
-    return str(room) # old behaviour
+    return str(room)  # old behaviour
+
 
 def glob(text, patterns):
     """

--- a/tests/base_backend_test.py
+++ b/tests/base_backend_test.py
@@ -14,7 +14,13 @@ import pytest
 from errbot import arg_botcmd, botcmd, re_botcmd, templating  # noqa
 from errbot.backend_plugin_manager import BackendPluginManager
 from errbot.backends.base import ONLINE, Identifier, Message, Room
-from errbot.backends.test import ShallowConfig, TestOccupant, TestPerson, TestRoom
+from errbot.backends.test import (
+    ShallowConfig,
+    TestOccupant,
+    TestPerson,
+    TestRoom,
+    TestRoomAcl,
+)
 from errbot.bootstrap import CORE_STORAGE, bot_config_defaults
 from errbot.core import ErrBot
 from errbot.core_plugins.acls import ACLS
@@ -814,6 +820,16 @@ def test_access_controls(dummy_backend):
             message=makemessage(
                 dummy_backend,
                 "!command",
+                from_=TestOccupant("someone", "room"),
+                to=TestRoomAcl("room", bot=dummy_backend),
+            ),
+            acl={"command": {"allowrooms": ("room",)}},
+            expected_response="Regular command",
+        ),
+        dict(
+            message=makemessage(
+                dummy_backend,
+                "!command",
                 from_=TestOccupant("someone", "room_1"),
                 to=TestRoom("room1", bot=dummy_backend),
             ),
@@ -826,6 +842,16 @@ def test_access_controls(dummy_backend):
                 "!command",
                 from_=TestOccupant("someone", "room"),
                 to=TestRoom("room", bot=dummy_backend),
+            ),
+            acl={"command": {"allowrooms": ("anotherroom@localhost",)}},
+            expected_response="You're not allowed to access this command from this room",
+        ),
+        dict(
+            message=makemessage(
+                dummy_backend,
+                "!command",
+                from_=TestOccupant("someone", "room"),
+                to=TestRoomAcl("room", bot=dummy_backend),
             ),
             acl={"command": {"allowrooms": ("anotherroom@localhost",)}},
             expected_response="You're not allowed to access this command from this room",


### PR DESCRIPTION
While fixing the documentation, I noticed that rooms are using str(room)
for acl matches. `__str__` is meant to be a human-readable object
representation which could be something other than the room ID -
although as no one spotted this I guess that in most cases it is.

This commit makes it so that rooms have an aclattr, just like people do.
This can then be used to store a suitable version of the room for ACL
matches.

I've tried to maintain backwards compatibility in two ways:

  1. aclattr defaults to the old behaviour str(self)
  2. the getter can detect if the room (Occupant) is a room or a str,
     and if it's a str use that instead. I know for the Matrix backend
     I'd incorrectly been returning a string and it still worked - if
     other backends are doing that it'll throw an exception without this
     mitigation.

I've checked using tox, and it passed the tests :).

```
class MatrixRoom(MatrixIdentifier, backend.Room):
    """Representation of a matrix room.

    Provides a way to do room-related things. We need to be careful because this is one of the main places
    that the async and sync code mixes.
    """

    def __init__(self, mxid: str):
        super().__init__(mxid)
        self.mxid = mxid

   @property
    def aclattr(self) -> str:
        return self.mxid
  
    def __str__(self):
        return "{} ({})".format(self.display_name, self.machine_name)
```

in terms of bot usage differences, there shouldn't be any vs the original room-string based approach.