### PR TITLE
Add configurable aliases for commands and sub-commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 __pycache__
 .venv
+venv
 /.coafile
 /.idea
 /atlassian-ide-plugin.xml

--- a/errbot/bootstrap.py
+++ b/errbot/bootstrap.py
@@ -72,6 +72,8 @@ def bot_config_defaults(config: object) -> None:
         config.TEXT_COLOR_THEME = "light"
     if not hasattr(config, "BOT_ADMINS_NOTIFICATIONS"):
         config.BOT_ADMINS_NOTIFICATIONS = config.BOT_ADMINS
+    if not hasattr(config, "COMMAND_ALIASES"):
+        config.COMMAND_ALIASES = {}
 
 
 def setup_bot(

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -397,4 +397,4 @@ REVERSE_CHATROOM_RELAY = {}
 # SUPPRESS_CMD_NOT_FOUND = False
 
 # Define aliases and shortcuts for existing commands. Can match subcommands as well.
-# CMD_ALIASES = {"h": "help", "pstatus": "status plugins"}
+# COMMAND_ALIASES = {"h": "help", "pstatus": "status plugins"}

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -395,3 +395,6 @@ REVERSE_CHATROOM_RELAY = {}
 
 # Prevent ErrBot from saying anything if the command is unrecognized.
 # SUPPRESS_CMD_NOT_FOUND = False
+
+# Define aliases and shortcuts for existing commands. Can match subcommands as well.
+# CMD_ALIASES = {"h": "help", "pstatus": "status plugins"}

--- a/errbot/core.py
+++ b/errbot/core.py
@@ -61,9 +61,10 @@ class ErrBot(Backend, StoreMixin):
         self.re_commands = (
             {}
         )  # the dynamically populated list of regex-based commands available on the bot
-        self.command_aliases = (
-            {k: v.replace(" ", "_") for k, v in bot_config.COMMAND_ALIASES.items()}
-        )  # the list of aliases for commands on the bot
+        self.command_aliases = {
+            k.replace(" ", "_"): v.replace(" ", "_")
+            for k, v in bot_config.COMMAND_ALIASES.items()
+        }  # the list of aliases for commands on the bot
         self.command_filters = []  # the dynamically populated list of filters
         self.MSG_UNKNOWN_COMMAND = (
             'Unknown command: "%(command)s". '
@@ -351,9 +352,13 @@ class ErrBot(Backend, StoreMixin):
                     if command in self.commands:
                         cmd = command
                         args = " ".join(text_split[i:])
-                    elif command in self.command_aliases:  # check if they're using a command alias
+                    elif (
+                        command in self.command_aliases
+                    ):  # check if they're using a command alias
                         parent_cmd = self.command_aliases[command]
-                        if parent_cmd in self.commands:  # make sure the command alias is configured properly
+                        if (
+                            parent_cmd in self.commands
+                        ):  # make sure the command alias is configured properly
                             cmd = parent_cmd
                             args = " ".join(text_split[1:])
                     else:

--- a/errbot/core.py
+++ b/errbot/core.py
@@ -614,7 +614,7 @@ class ErrBot(Backend, StoreMixin):
         else:
             msg = f'Command "{cmd}" not found.'
         all_keys = list(self.commands.keys())
-        all_keys.extend(self.bot_config.CMD_ALIASES.keys())
+        all_keys.extend(self.bot_config.COMMAND_ALIASES.keys())
         ununderscore_keys = [m.replace("_", " ") for m in all_keys]
         matches = difflib.get_close_matches(cmd, ununderscore_keys)
         if full_cmd:

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -12,6 +12,7 @@ import pytest
 from mock import MagicMock
 
 extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)), "dummy_plugin")
+extra_config = {"COMMAND_ALIASES": {"h": "help", "pinfo": "plugin info"}}
 
 
 def test_root_help(testbot):
@@ -406,3 +407,8 @@ def test_plugin_info_command(testbot):
     assert "module: help" in output
     assert "help.py" in output
     assert "log level: NOTSET" in output
+
+
+def test_command_aliases(testbot):
+    testbot.assertInCommand("!h", "All commands")
+    testbot.assertInCommand("!pinfo Help", "name: Help")


### PR DESCRIPTION
Closes #1279.

This pull request adds a new field to the config for defining aliases to commands and sub-commands. These are helpful for users to add shortcuts for often-used actions. Aliases are checked after standard commands, to avoid overriding commands added from plugins. Correction suggestions incorporate aliases as well.

The `COMMAND_ALIASES` field in the config takes a dictionary of aliases to standard commands. `{"h": "help", "pinfo": "plugin info"}` would make it so running `!h` would return the result for `!help`, and running `!pinfo Help` would return the result for `!plugin info Help`.

Tests for Python 3.9 are currently failing on my machine, but this is likely an issue with my Python configuration as the Python 3.8 tests pass without issue. I'm going to verify the tests tomorrow on another computer.