### PR TITLE
Use collections.abc.Mapping

### DIFF
--- a/errbot/backends/slack.py
+++ b/errbot/backends/slack.py
@@ -375,7 +375,7 @@ class SlackBackend(ErrBot):
         if data is None:
             data = {}
         response = self.sc.api_call(method, **data)
-        if not isinstance(response, collections.Mapping):
+        if not isinstance(response, collections.abc.Mapping):
             # Compatibility with SlackClient < 1.0.0
             response = json.loads(response.decode("utf-8"))
 

--- a/errbot/cli.py
+++ b/errbot/cli.py
@@ -85,7 +85,7 @@ def _read_dict():
     import collections
 
     new_dict = ast.literal_eval(sys.stdin.read())
-    if not isinstance(new_dict, collections.Mapping):
+    if not isinstance(new_dict, collections.abc.Mapping):
         raise ValueError(
             f"A dictionary written in python is needed from stdin. "
             f"Type={type(new_dict)}, Value = {repr(new_dict)}."


### PR DESCRIPTION
Untested change to improve Python 3.10 support.

Latest release gives the following errors when run with Python 3.10:

```
2021-10-07 15:35:58,530 ERROR    errbot.backends.base      Exception occurred in serve_once:
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/errbot/backends/base.py", line 861, in serve_forever
    if self.serve_once():
  File "/usr/local/lib/python3.10/site-packages/errbot/backends/slack.py", line 421, in serve_once
    self.auth = self.api_call("auth.test", raise_errors=False)
  File "/usr/local/lib/python3.10/site-packages/errbot/backends/slack.py", line 378, in api_call
    if not isinstance(response, collections.Mapping):
AttributeError: module 'collections' has no attribute 'Mapping'
```

This change fixes the error, per the notice on https://docs.python.org/3.9/library/collections.html

