### PR TITLE
Add python 3.10 to automated testing

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ features:
 - core: set default backend to Text (#1522)
 - core: option to divert all commands to private or thread (#1528)
 - core: add type hints to core and backend functions (#1542)
+- core: add Python 3.10 to automated tests (#1539)
 
 fixes:
 

--- a/errbot/backends/irc.py
+++ b/errbot/backends/irc.py
@@ -412,7 +412,7 @@ class IRCConnection(SingleServerIRCBot):
         # from the ChatRoom plugin joining channels from CHATROOM_PRESENCE
         # ends up blocking on connect.
         t = threading.Thread(target=self.bot.connect_callback)
-        t.setDaemon(True)
+        t.daemon = True
         t.start()
 
     def _pubmsg(self, e, notice: bool = False) -> None:

--- a/errbot/backends/test.py
+++ b/errbot/backends/test.py
@@ -49,6 +49,8 @@ class TestPerson(Person):
     methods exposed by this class.
     """
 
+    __test__ = False
+
     def __init__(self, person, client=None, nick=None, fullname=None, email=None):
         self._person = person
         self._client = client
@@ -107,6 +109,8 @@ class TestOccupant(TestPerson, RoomOccupant):
     DO NOT USE THIS DIRECTLY AS IT IS NOT COMPATIBLE WITH MOST BACKENDS,
     """
 
+    __test__ = False
+
     def __init__(self, person, room):
         super().__init__(person)
         self._room = room
@@ -125,6 +129,8 @@ class TestOccupant(TestPerson, RoomOccupant):
 
 
 class TestRoom(Room):
+    __test__ = False
+
     def invite(self, *args):
         pass
 

--- a/errbot/botplugin.py
+++ b/errbot/botplugin.py
@@ -305,8 +305,8 @@ class BotPluginBase(StoreMixin):
             },
         )
         self.current_timers.append(t)  # save the timer to be able to kill it
-        t.setName(f"Poller thread for {type(method.__self__).__name__}")
-        t.setDaemon(True)  # so it is not locking on exit
+        t.name = f"Poller thread for {type(method.__self__).__name__}"
+        t.daemon = True  # so it is not locking on exit
         t.start()
 
     def poller(

--- a/setup.py
+++ b/setup.py
@@ -141,6 +141,7 @@ if __name__ == "__main__":
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
         ],
         src_root=src_root,
         platforms="any",

--- a/tests/backend_tests/slack_test.py
+++ b/tests/backend_tests/slack_test.py
@@ -14,6 +14,8 @@ try:
     from errbot.backends import slack
 
     class TestSlackBackend(slack.SlackBackend):
+        __test__ = False
+
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
             self.test_msgs = []

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,codestyle,dist-check,sort,security
+envlist = py37,py38,py39,py310,codestyle,dist-check,sort,security
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
This PR adds Python 3.10 to tox tests and github actions tests.  The tests are passing with a few deprecation warnings.