### PR TITLE
chore: remove python 3.6

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ fixes:
 - docs: update spark plugin reference (#1546)
 - fix: python 2 version references in docs and init template (#1543)
 - backends: deprecate built-in Slack and SlackRTM (#1526)
+- chore: remove python 3.6 checks and test environment (#1540)
 
 v6.1.8 (2021-06-21)
 -------------------

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-python_classes=PyTest

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools import find_packages, setup
 
 py_version = sys.version_info[:2]
 
-if py_version < (3, 6):
+if py_version < (3, 7):
     raise RuntimeError("Errbot requires Python 3.6 or later")
 
 VERSION_FILE = os.path.join("errbot", "version.py")
@@ -121,9 +121,6 @@ if __name__ == "__main__":
                 "python-telegram-bot",
             ],
             "XMPP": ["slixmpp", "pyasn1", "pyasn1-modules"],
-            ':python_version<"3.7"': [
-                "dataclasses"
-            ],  # backward compatibility for 3.3->3.6 for dataclasses
             ':sys_platform!="win32"': ["daemonize"],
         },
         author="errbot.io",
@@ -141,7 +138,6 @@ if __name__ == "__main__":
             "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
             "Operating System :: OS Independent",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",

--- a/tests/backend_tests/slack_test.py
+++ b/tests/backend_tests/slack_test.py
@@ -40,7 +40,6 @@ try:
             m.name = user
             return m
 
-
 except SystemExit:
     log.exception("Can't import backends.slack for testing")
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,codestyle,dist-check,sort,security
+envlist = py37,py38,py39,codestyle,dist-check,sort,security
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Remove python 3.6 as its EOL.

https://endoflife.date/python

Related to https://github.com/errbotio/errbot/pull/1539