### PR TITLE
Adjust python version of plugins for current specs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ fixes:
 - core: various minor logging improvements (#1536)
 - chore: various minor formatting improvements (#1541)
 - docs: update spark plugin reference (#1546)
+- fix: python 2 version references in docs and init template (#1543)
 
 v6.1.8 (2021-06-21)
 -------------------

--- a/docs/user_guide/flow_development/basics.rst
+++ b/docs/user_guide/flow_development/basics.rst
@@ -16,7 +16,7 @@ They are defined by a ``.flow`` file, similar to the plugin ones:
     Description = my documentation.
 
     [Python]
-    Version = 2+
+    Version = 3
 
 
 Now in the ``myflows.py`` file you will have pretty familiar structure with a ``BotFlow`` as type and @botflow

--- a/docs/user_guide/plugin_development/basics.rst
+++ b/docs/user_guide/plugin_development/basics.rst
@@ -127,7 +127,7 @@ Lets go ahead and create ours. Place the following in a file called
     Module = helloworld
 
     [Python]
-    Version = 2+
+    Version = 3
 
     [Documentation]
     Description = Example "Hello, world!" plugin

--- a/errbot/templates/initdir/example.plug
+++ b/errbot/templates/initdir/example.plug
@@ -6,4 +6,4 @@ Module = example
 Description = This is a simple plugin example to get you started.
 
 [Python]
-Version = 2+
+Version = 3


### PR DESCRIPTION
Errbot of current version has not support python 2.x.
This PR is dropping describe about python 2 for plugins in reference to [`plugin_wizard.py`](https://github.com/errbotio/errbot/blob/master/errbot/plugin_wizard.py)

-  Template of `errbot --init`
- Documentation for plugin development