### PR TITLE
Update README to replace deprecated add-on

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ fixes:
 - backend/test: shutdown sequence to address test failure (#1535)
 - core: various minor logging improvements (#1536)
 - chore: various minor formatting improvements (#1541)
+- docs: update spark plugin reference (#1546)
 
 v6.1.8 (2021-06-21)
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Chat servers support
 **With add-ons**
 
 - `CampFire <https://campfirenow.com/>`_ (See `instructions <https://github.com/errbotio/err-backend-campfire>`__)
-- `Cisco Spark <https://www.ciscospark.com/>`_ (See `instructions <https://github.com/marksull/err-backend-cisco-spark>`__)
+- `Webex <https://www.webex.com/>`_ (See `instructions <https://github.com/marksull/err-backend-cisco-webex-teams>`__)
 - `Discord <https://www.discordapp.com/>`_ (See `instructions <https://github.com/gbin/err-backend-discord>`__)
 - `Gitter support <https://gitter.im/>`_ (See `instructions <https://github.com/errbotio/err-backend-gitter>`__)
 - `Mattermost <https://about.mattermost.com/>`_ (See `instructions <https://github.com/Vaelor/errbot-mattermost-backend>`__)


### PR DESCRIPTION
Cisco Spark has been rebranded to Webex and @marksull has deprecated the Cisco Spark add-on. 

This change would update the README to remove the reference to the deprecated add-on and replace it with a link to the replacement.