### PR TITLE
Add get_acl_room support

### DIFF
--- a/errbot/core_plugins/acls.py
+++ b/errbot/core_plugins/acls.py
@@ -7,12 +7,21 @@ BLOCK_COMMAND = (None, None, None)
 
 
 def get_acl_usr(msg):
-    """Return the ACL attribute of the sender of the given message"""
-    if hasattr(
-        msg.frm, "aclattr"
-    ):  # if the identity requires a special field to be used for acl
+    """
+    Return the ACL attribute of the sender of the given message.
+    """
+    if hasattr(msg.frm, "aclattr"):
         return msg.frm.aclattr
-    return msg.frm.person  # default
+    return msg.frm.person
+
+
+def get_acl_room(msg):
+    """
+    Return the ACL attribute for a given room.
+    """
+    if hasattr(msg.frm.room, "aclattr"):
+        return msg.frm.room.aclattr
+    return str(msg.frm.room)
 
 
 def glob(text, patterns):
@@ -91,18 +100,22 @@ class ACLS(BotPlugin):
 
         if "allowusers" in acl and not glob(usr, acl["allowusers"]):
             return self.access_denied(
-                msg, "You're not allowed to access this command from this user", dry_run
+                msg,
+                "You're not allowed to access this command from this user",
+                dry_run,
             )
         if "denyusers" in acl and glob(usr, acl["denyusers"]):
             return self.access_denied(
-                msg, "You're not allowed to access this command from this user", dry_run
+                msg,
+                "You're not allowed to access this command from this user",
+                dry_run,
             )
         if msg.is_group:
             if not isinstance(msg.frm, RoomOccupant):
                 raise Exception(
                     f"msg.frm is not a RoomOccupant. Class of frm: {msg.frm.__class__}"
                 )
-            room = str(msg.frm.room)
+            room = get_acl_room(msg)
             if "allowmuc" in acl and acl["allowmuc"] is False:
                 return self.access_denied(
                     msg,

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ deps = [
     "ansi",
     "Pygments>=2.0.2",
     "pygments-markdown-lexer>=0.1.0.dev39",  # sytax coloring to debug md
-    "dulwich>=0.19.16",  # python implementation of git
+    "dulwich<0.20.29",  # python implementation of git
     "deepmerge>=0.1.0",
 ]
 


### PR DESCRIPTION
This PR is to use the `aclattr` for Room objects when available.  If the `aclattr` is unavilable, the default behaviour is maintained by return the string representation of the Room object.

This patch is required by https://github.com/errbotio/err-backend-slackv3/pull/62