### PR TITLE
Use errbot log level with webserver for consistent logging

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,7 @@ fixes:
 - chore: remove python 3.6 checks and test environment (#1540)
 - chore: add/update issue templates (#1554)
 - chore: pin all package dependencies (#1553)
+- core/webserver: use errbot loglevel for consistent logging. (#1555)
 
 v6.1.8 (2021-06-21)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,7 +26,7 @@ fixes:
 - chore: remove python 3.6 checks and test environment (#1540)
 - chore: add/update issue templates (#1554)
 - chore: pin all package dependencies (#1553)
-- core/webserver: use errbot loglevel for consistent logging. (#1555)
+- core/webserver: use errbot loglevel for consistent logging. (#1556)
 
 v6.1.8 (2021-06-21)
 -------------------

--- a/errbot/core.py
+++ b/errbot/core.py
@@ -825,7 +825,7 @@ class ErrBot(Backend, StoreMixin):
         if self.prefix == "!":
             return command.__doc__
         ununderscore_keys = (m.replace("_", " ") for m in self.all_commands.keys())
-        pat = re.compile(fr'!({"|".join(ununderscore_keys)})')
+        pat = re.compile(rf'!({"|".join(ununderscore_keys)})')
         return re.sub(pat, self.prefix + "\1", command.__doc__)
 
     @staticmethod

--- a/errbot/core_plugins/webserver.py
+++ b/errbot/core_plugins/webserver.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import logging
 from json import loads
 from random import randrange
 from threading import Thread
@@ -127,6 +128,8 @@ class Webserver(BotPlugin):
                 flask_app,
                 ssl_context=ssl_context,
             )
+            wsgi_log = logging.getLogger("werkzeug")
+            wsgi_log.setLevel(self.bot_config.BOT_LOG_LEVEL)
             self.server.serve_forever()
             self.log.debug("Webserver stopped")
         except KeyboardInterrupt:

--- a/errbot/core_plugins/webserver.py
+++ b/errbot/core_plugins/webserver.py
@@ -1,6 +1,6 @@
+import logging
 import os
 import sys
-import logging
 from json import loads
 from random import randrange
 from threading import Thread

--- a/tests/webhooks_test.py
+++ b/tests/webhooks_test.py
@@ -185,14 +185,11 @@ def test_generate_certificate_creates_usable_cert(webhook_testbot):
         requests.packages.urllib3.exceptions.InsecureRequestWarning
     )
 
-    assert (
-        requests.post(
-            "https://localhost:{}/webhook1".format(WEBSERVER_SSL_PORT),
-            JSONOBJECT,
-            verify=False,
-        ).text
-        == repr(json.loads(JSONOBJECT))
-    )
+    assert requests.post(
+        "https://localhost:{}/webhook1".format(WEBSERVER_SSL_PORT),
+        JSONOBJECT,
+        verify=False,
+    ).text == repr(json.loads(JSONOBJECT))
 
 
 def test_custom_headers_and_status_codes(webhook_testbot):


### PR DESCRIPTION
This patch will take errbot's log level configuration and pass it to werkzeug for consistent logging.

fixes #1555 