### PR TITLE
Prevent infinite loop when only BOT_PREFIX passed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,7 @@ fixes:
 - chore: add/update issue templates (#1554)
 - chore: pin all package dependencies (#1553)
 - core/webserver: use errbot loglevel for consistent logging. (#1556)
+- fix/core: prevent infinite loop when only BOT_PREFIX is passed (#1557)
 
 v6.1.8 (2021-06-21)
 -------------------

--- a/errbot/core.py
+++ b/errbot/core.py
@@ -350,7 +350,7 @@ class ErrBot(Backend, StoreMixin):
                         args = " ".join(text_split[i:])
                     else:
                         i -= 1
-                if i == 0:
+                if i <= 0:
                     break
 
             if (


### PR DESCRIPTION
I have hit an error in which a message that contains only my bot prefix causes the bot to become unresponsive to any further messages. After a bit of debugging, I believe the problem is that `text` here becomes an empty string, which makes the value of `i` start as 0, then decrement (because the empty string is not in `commands`), leading to an infinite loop where `i` decreases forever.

I have confirmed that changing the comparison operation to `<=` fixes this case, without breaking other commands as far as I can tell.