### PR TITLE
fix: typo in pinned dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,7 +25,7 @@ fixes:
 - backends: deprecate built-in Slack and SlackRTM (#1526)
 - chore: remove python 3.6 checks and test environment (#1540)
 - chore: add/update issue templates (#1554)
-- chore: pin all package dependencies (#1553)
+- chore: pin all package dependencies (#1553, #1559)
 - core/webserver: use errbot loglevel for consistent logging. (#1556)
 - fix/core: prevent infinite loop when only BOT_PREFIX is passed (#1557)
 

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ if __name__ == "__main__":
             "XMPP": [
                 "slixmpp==1.7.1",
                 "pyasn1==0.4.8",
-                "pyasn1-modules===0.2.8",
+                "pyasn1-modules==0.2.8",
             ],
             ':sys_platform!="win32"': ["daemonize==2.5.0"],
         },


### PR DESCRIPTION
Fixing typo in pinned dependency
```
pip._vendor.pkg_resources.RequirementParseError: Parse error at "'(===0.2.'": Expected stringEnd
```