### PR TITLE
Update Gentoo package manager support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,7 @@ fixes:
 - fix/core: prevent infinite loop when only BOT_PREFIX is passed (#1557)
 - chore: bump actions/setup-python from 2 to 3.1.0 (#1563)
 - fix: removed deprecated argument reconnection_interval for irc v20.0 (#1568)
+- docs: Add Gentoo packages (#1567)
 
 v6.1.8 (2021-06-21)
 -------------------

--- a/docs/user_guide/setup.rst
+++ b/docs/user_guide/setup.rst
@@ -20,7 +20,7 @@ Example of packaged versions of Errbot:
 
 * Arch: https://aur.archlinux.org/packages/python-err/
 * Docker: https://hub.docker.com/r/errbotio/errbot
-
+* Gentoo: https://packages.gentoo.org/packages/net-im/err
 
 Option 2: Installing Errbot in a virtualenv (preferred)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
I'm a new proxy maintainer of errbot in Gentoo. So I hope you can add the gentoo support in docs. Now in gentoo supports 6.1.7 and 6.1.8. Thanks!