### PR TITLE
URL not woking in README

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,9 @@ v9.9.9 (unreleased)
 -------------------
 
 fixes:
+
 - docs: add unreleased section (#1576)
+- docs: update broken URL for Markdown Extra (#1572)
 
 
 v6.1.9 (2022-06-11)

--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ Developer features
 - Presetup storage for every plugin i.e. ``self['foo'] = 'bar'`` persists the value.
 - Conversation flows to track conversation states from users.
 - Webhook callbacks support
-- supports `markdown extras <https://pythonhosted.org/Markdown/extensions/extra.html>`_ formatting with tables, embedded images, links etc.
+- supports `markdown extras <https://markdown-extra.readthedocs.io/>`_ formatting with tables, embedded images, links etc.
 - configuration helper to allow your plugin to be configured by chat
 - Text development/debug consoles
 - Self-documenting: your docstrings become help automatically


### PR DESCRIPTION
The link in 'supports markdown extras formatting' (https://pythonhosted.org/Markdown/extensions/extra.html) seems to be not woking.

I'm proposing the page https://markdown-extra.readthedocs.io/
not sure if it is ok.