### PR TITLE
chore: ci improvements (python, docker build)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,27 @@
+name: build docker image
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+
+    - name: build and push docker image
+      uses: mr-smithers-excellent/docker-build-push@v5
+      with:
+        image: errbotio/errbot
+        tags: latest
+        registry: docker.io
+        dockerfile: Dockerfile
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -41,21 +41,21 @@ jobs:
         tox -e py
 
     - name: Check Distribution
-      if: ${{ matrix.python-version == '3.8' }}
+      if: ${{ matrix.python-version == '3.9' }}
       run: |
         tox -e dist-check
 
     - name: Codestyle
-      if: ${{ matrix.python-version == '3.8' }}
+      if: ${{ matrix.python-version == '3.9' }}
       run: |
         tox -e codestyle
 
     - name: Lint - sort
-      if: ${{ matrix.python-version == '3.8' }}
+      if: ${{ matrix.python-version == '3.9' }}
       run: |
         tox -e sort
 
     - name: Security
-      if: ${{ matrix.python-version == '3.8' }}
+      if: ${{ matrix.python-version == '3.9' }}
       run: |
         tox -e security

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ fixes:
 - docs: update broken URL for Markdown Extra (#1572)
 - chore: bump actions/setup-python version (#1575)
 - backend/telegram: fix missing imports (#1574)
+- chore: ci improvements (#1577)
 
 
 v6.1.9 (2022-06-11)


### PR DESCRIPTION
Improving CI workflows

* set python 3.9 as default ci version
* build docker images from master, tagged as `latest`