### PR TITLE
fix: remove campfire references

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ fixes:
 - chore: ci improvements (#1577, #1583)
 - chore: add docs build to ci (#1582)
 - backend/xmpp: fix forward type references (#1578)
+- chore: remove campfire references (#1584)
 
 
 v6.1.9 (2022-06-11)

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,6 @@ Chat servers support
 
 **With add-ons**
 
-- `CampFire <https://campfirenow.com/>`_ (See `instructions <https://github.com/errbotio/err-backend-campfire>`__)
 - `Webex <https://www.webex.com/>`_ (See `instructions <https://github.com/marksull/err-backend-cisco-webex-teams>`__)
 - `Discord <https://www.discordapp.com/>`_ (See `instructions <https://github.com/gbin/err-backend-discord>`__)
 - `Gitter support <https://gitter.im/>`_ (See `instructions <https://github.com/errbotio/err-backend-gitter>`__)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,7 +79,6 @@ release = VERSION
 exclude_patterns = [
     '_build',
     'error_pages/*',
-    'errbot.backends.campfire.rst',  # Broken on Python 3
     'errbot.backends.tox.rst',  # Also quite a pain to build at this stage
     '_gh-pages',
 ]

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -10,7 +10,6 @@ Currently, the following networks are supported:
   * Slack_
   * Telegram_
   * `Bot Framework`_ (maintained `separately <https://github.com/vasilcovsky/errbot-backend-botframework>`__)
-  * CampFire_ (maintained `separately <https://github.com/errbotio/err-backend-campfire>`__)
   * `Cisco Webex Teams`_ (maintained `separately <https://github.com/marksull/err-backend-cisco-webex-teams>`__)
   * Discord_ (maintained `separately <https://github.com/gbin/err-backend-discord>`__)
   * Gitter_ (maintained `separately <https://github.com/errbotio/err-backend-gitter>`__)
@@ -60,7 +59,6 @@ Extensive plugin framework
 * And a templating framework to display fancy HTML messages. Automatic conversion from HTML to plaintext when the backend doesn't support HTML means you don't have to make separate text and HTML versions of your command output yourself
 
 .. _Bot Framework: https://botframework.com/
-.. _Campfire: https://campfirenow.com/
 .. _Cisco Webex Teams: https://www.webex.com/
 .. _Discord: https://www.discordapp.com/
 .. _Gitter: http://gitter.im/

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,6 @@ sphinx-autodoc-annotation
 -e .
 slixmpp
 irc
-pyfire
 python-telegram-bot
 slackclient
 hypchat

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -31,7 +31,6 @@ import logging
 # "Text"     - on the text console
 
 # Commercial backends:
-# "Campfire" - see https://campfirenow.com/ (follow instructions from https://github.com/errbotio/err-backend-campfire)
 # "Slack"    - see https://slack.com/
 # "Gitter"   - see https://gitter.im/ (follow instructions from https://github.com/errbotio/err-backend-gitter)
 


### PR DESCRIPTION
Removing campfire references, as
* campfire has been moved to basecamp3
* backend does not support py3
* backend repo is no longer maintained
