### PR TITLE
Update exception if installing on Python <3.7

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ fixes:
 - chore: add docs build to ci (#1582)
 - backend/xmpp: fix forward type references (#1578)
 - chore: remove campfire references (#1584)
+- chore/setup: fix exception when installing on python <3.7 (#1585)
 
 
 v6.1.9 (2022-06-11)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ from setuptools import find_packages, setup
 py_version = sys.version_info[:2]
 
 if py_version < (3, 7):
-    raise RuntimeError("Errbot requires Python 3.6 or later")
+    raise RuntimeError("Errbot requires Python 3.7 or later")
 
 VERSION_FILE = os.path.join("errbot", "version.py")
 


### PR DESCRIPTION
Python 3.6 was dropped in https://github.com/errbotio/errbot/pull/1540 but the exception was missed, leaving a misleading error message.