### PR TITLE
docs: Fix a few typos

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ fixes:
 - backend/xmpp: fix forward type references (#1578)
 - chore: remove campfire references (#1584)
 - chore/setup: fix exception when installing on python <3.7 (#1585)
+- docs: typos (#1589)
 
 
 v6.1.9 (2022-06-11)

--- a/docs/_static/fancybox/jquery.fancybox.js
+++ b/docs/_static/fancybox/jquery.fancybox.js
@@ -881,7 +881,7 @@
                 coming.scrolling = 'scroll';
             }
 
-            // Build the neccessary markup
+            // Build the necessary markup
             coming.wrap = $(coming.tpl.wrap).addClass('fancybox-' + (isTouch ? 'mobile' : 'desktop') + ' fancybox-type-' + type + ' fancybox-tmp ' + coming.wrapCSS).appendTo(coming.parent || 'body');
 
             $.extend(coming, {

--- a/docs/user_guide/configuration/slackv3.rst
+++ b/docs/user_guide/configuration/slackv3.rst
@@ -118,7 +118,7 @@ Current token with Events Socket-mode client
 Create a current bot token, enable socket mode.  Configure errbot to use the bot and app tokens and start using Slack.
 Read `socket-mode <https://github.com/slackapi/python-slack-sdk/blob/main/docs-src/socket-mode/index.rst>`_ for instructions on setting up Socket-mode.
 
-Ensure the bot is also subscrbed to the following events:
+Ensure the bot is also subscribed to the following events:
 
 - `file_created`
 - `file_public`

--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -76,7 +76,7 @@ def install_packages(req_path: Path):
     log.info('Installing packages from "%s".', req_path)
     # use sys.executable explicitly instead of just 'pip' because depending on how the bot is deployed
     # 'pip' might not be available on PATH: for example when installing errbot on a virtualenv and
-    # starting it with systemclt pointing directly to the executable:
+    # starting it with systemctl pointing directly to the executable:
     # [Service]
     # ExecStart=/home/errbot/.env/bin/errbot
     pip_cmdline = [sys.executable, "-m", "pip"]


### PR DESCRIPTION
There are small typos in:
- docs/_static/fancybox/jquery.fancybox.js
- docs/user_guide/configuration/slackv3.rst
- errbot/plugin_manager.py

Fixes:
- Should read `systemctl` rather than `systemclt`.
- Should read `subscribed` rather than `subscrbed`.
- Should read `necessary` rather than `neccessary`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md