### PR TITLE
Feature: plugins detection using entrypoints

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 v9.9.9 (unreleased)
 -------------------
 
+features:
+
+- core/plugins: detect plugins using entrypoints (#1590)
+
 fixes:
 
 - docs: add unreleased section (#1576)

--- a/docs/user_guide/administration.rst
+++ b/docs/user_guide/administration.rst
@@ -40,8 +40,19 @@ If you just wish to know more about a specific command you can issue::
 Installing plugins
 ------------------
 
-Errbot plugins are typically published to and installed from `GitHub <http://github.com/>`_.
-We periodically crawl GitHub for errbot plugin repositories and `publish the results <https://github.com/errbotio/errbot/wiki>`_ for people to browse.
+Errbot plugins can be installed via these methods
+
+* `!repos install` bot commnand
+* Cloning a `GitHub <http://github.com/>`_ repository
+* Extracting a tar/zip file
+
+
+Using a bot command
+^^^^^^^^^^^^^^^^^^^
+
+Plugins installed via the :code:`!repos` command are managed by errbot itself and stored inside the `BOT_DATA_DIR` you set in `config.py`.
+
+We periodically crawl GitHub for errbot plugin repositories and `publish the results <https://errbot.io/repos.json>`_ for people to browse.
 
 You can have your bot display the same list of repos by issuing::
 
@@ -72,6 +83,22 @@ This can be done with::
     !repos update all
 
 
+Cloning a repository or tar/zip install
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Using a git repository or tar/zip file to install plugins is setting up your plugins to be managed manually.
+
+Plugins installed from cloning a repository need to be placed inside the `BOT_EXTRA_PLUGIN_DIR` path specified in the `config.py` file.
+
+Assuming `BOT_EXTRA_PLUGIN_DIR` is set to `/opt/plugins`::
+
+    $ git clone https://github.com/errbotio/err-helloworld /opt/plugins/err-helloworld
+    $ tar -zxvf err-helloworld.tar.gz -C /opt/plugins/
+
+.. note::
+    If a repo is cloned and the git remote information is present, updating the plugin may be possible via `!repos update`
+
+
 Dependencies
 ^^^^^^^^^^^^
 
@@ -81,15 +108,6 @@ If the plugin contains a `requirements.txt` file then Errbot will automatically 
 Additionally, if you set :code:`AUTOINSTALL_DEPS` to :code:`True` in your **config.py**, Errbot will use pip to install any missing dependencies automatically.
 If you have installed Errbot in a virtualenv, this will run the equivalent of :code:`pip install -r requirements.txt`.
 If no virtualenv is detected, the equivalent of :code:`pip install --user -r requirements.txt` is used to ensure the package(s) is/are only installed for the user running Err.
-
-
-Extra plugin directory
-^^^^^^^^^^^^^^^^^^^^^^
-
-Plugins installed via the :code:`!repos` command are managed by errbot itself and stored inside the `BOT_DATA_DIR` you set in `config.py`.
-If you want to manage your plugins manually for any reason then errbot allows you to load additional plugins from a directory you specify.
-You can do so by specifying the setting `BOT_EXTRA_PLUGIN_DIR` in your `config.py` file.
-See the :download:`config-template.py` file for more details.
 
 
 .. _disabling_plugins:

--- a/docs/user_guide/administration.rst
+++ b/docs/user_guide/administration.rst
@@ -45,6 +45,7 @@ Errbot plugins can be installed via these methods
 * `!repos install` bot commnand
 * Cloning a `GitHub <http://github.com/>`_ repository
 * Extracting a tar/zip file
+* Using pip
 
 
 Using a bot command
@@ -97,6 +98,16 @@ Assuming `BOT_EXTRA_PLUGIN_DIR` is set to `/opt/plugins`::
 
 .. note::
     If a repo is cloned and the git remote information is present, updating the plugin may be possible via `!repos update`
+
+
+Using pip for plugins
+^^^^^^^^^^^^^^^^^^^^^
+
+Plugins published to to pypi.org can be installed using pip.::
+
+    $ pip install errbot-plugin-helloworld
+
+As part of the packaging configuration for the plugin, it should install all necessary dependencies for the plugin to work.
 
 
 Dependencies

--- a/docs/user_guide/plugin_development/basics.rst
+++ b/docs/user_guide/plugin_development/basics.rst
@@ -197,6 +197,33 @@ the function `invert_string()`, the `helloworld` plugin can import it and use it
             """Say hello to the world"""
             return invert_string("Hello, world!")
 
+Packaging
+---------
+
+A plugin can be packaged and distributed through pypi.org. The errbot plugin system uses entrypoints in setuptools to find available plugins.
+
+The two entrypoint avialable are
+
+* `errbot.plugins` - normal plugin and flows
+* `errbot.backend_plugins` - backend plugins for collaboration providers
+
+To get this setup, add this block of code to `setup.py`.
+
+.. code-block:: python
+
+    entry_points = {
+        "errbot.plugins": [
+            "helloworld = helloWorld:HelloWorld",
+        ]
+    }
+
+Optionally, you may need to include a `MANIFEST.in` to include files of the repo
+
+.. code-block:: python
+
+    include *.py *.plug
+
+
 Wrapping up
 -----------
 

--- a/errbot/backend_plugin_manager.py
+++ b/errbot/backend_plugin_manager.py
@@ -5,7 +5,7 @@ from typing import Any, Iterator, List, Type, Union
 
 from errbot.plugin_info import PluginInfo
 
-from .utils import collect_roots
+from .utils import collect_roots, entry_point_plugins
 
 log = logging.getLogger(__name__)
 
@@ -44,7 +44,8 @@ class BackendPluginManager:
         self._base_class = base_class
 
         self.plugin_info = None
-        all_plugins_paths = collect_roots((base_search_dir, extra_search_dirs))
+        ep = entry_point_plugins(group="errbot.backend_plugins")
+        all_plugins_paths = collect_roots((base_search_dir, extra_search_dirs, ep))
 
         for potential_plugin in enumerate_backend_plugins(all_plugins_paths):
             if potential_plugin.name == plugin_name:

--- a/errbot/cli.py
+++ b/errbot/cli.py
@@ -27,7 +27,7 @@ from typing import Optional, Union
 from errbot.bootstrap import CORE_BACKENDS
 from errbot.logs import root_logger
 from errbot.plugin_wizard import new_plugin_wizard
-from errbot.utils import collect_roots
+from errbot.utils import collect_roots, entry_point_plugins
 from errbot.version import VERSION
 
 log = logging.getLogger(__name__)
@@ -281,6 +281,8 @@ def main() -> None:
     extra_backend = getattr(config, "BOT_EXTRA_BACKEND_DIR", [])
     if isinstance(extra_backend, str):
         extra_backend = [extra_backend]
+    ep = entry_point_plugins(group="errbot.backend_plugins")
+    extra_backend.extend(ep)
 
     if args["list"]:
         from errbot.backend_plugin_manager import enumerate_backend_plugins

--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -19,7 +19,7 @@ from .core_plugins.wsview import route
 from .plugin_info import PluginInfo
 from .storage import StoreMixin
 from .templating import add_plugin_templates_path, remove_plugin_templates_path
-from .utils import collect_roots, version2tuple
+from .utils import collect_roots, entry_point_plugins, version2tuple
 from .version import VERSION
 
 PluginInstanceCallback = Callable[[str, Type[BotPlugin]], BotPlugin]
@@ -334,7 +334,8 @@ class BotPluginManager(StoreMixin):
         :param path_list: the path list where to search for plugins.
         :return: the feedback for any specific path in case of error.
         """
-        repo_roots = (CORE_PLUGINS, self._extra_plugin_dir, path_list)
+        ep = entry_point_plugins(group="errbot.plugins")
+        repo_roots = (CORE_PLUGINS, self._extra_plugin_dir, path_list, ep)
 
         all_roots = collect_roots(repo_roots)
 

--- a/errbot/utils.py
+++ b/errbot/utils.py
@@ -7,7 +7,12 @@ import re
 import sys
 import time
 from functools import wraps
-from importlib import metadata
+
+try:
+    from importlib.metadata import entry_points
+except ImportError:
+    from importlib_metadata import entry_points
+
 from platform import system
 from typing import List, Tuple, Union
 
@@ -199,7 +204,7 @@ def collect_roots(base_paths: List, file_sig: str = "*.plug") -> List:
 
 def entry_point_plugins(group):
     paths = []
-    for entry_point in metadata.entry_points().get(group, []):
+    for entry_point in entry_points().get(group, []):
         paths.append(entry_point.dist._path.parent)
     return paths
 

--- a/errbot/utils.py
+++ b/errbot/utils.py
@@ -7,11 +7,11 @@ import re
 import sys
 import time
 from functools import wraps
+from importlib import metadata
 from platform import system
 from typing import List, Tuple, Union
 
 from dulwich import porcelain
-from pkg_resources import iter_entry_points
 
 log = logging.getLogger(__name__)
 
@@ -199,8 +199,8 @@ def collect_roots(base_paths: List, file_sig: str = "*.plug") -> List:
 
 def entry_point_plugins(group):
     paths = []
-    for entry_point in iter_entry_points(group=group, name=None):
-        paths.append(entry_point.dist.location)
+    for entry_point in metadata.entry_points().get(group, []):
+        paths.append(entry_point.dist._path.parent)
     return paths
 
 

--- a/errbot/utils.py
+++ b/errbot/utils.py
@@ -11,6 +11,7 @@ from platform import system
 from typing import List, Tuple, Union
 
 from dulwich import porcelain
+from pkg_resources import iter_entry_points
 
 log = logging.getLogger(__name__)
 
@@ -194,6 +195,13 @@ def collect_roots(base_paths: List, file_sig: str = "*.plug") -> List:
         elif path_or_list is not None:
             result.extend(find_roots(path_or_list, file_sig))
     return list(collections.OrderedDict.fromkeys(result))
+
+
+def entry_point_plugins(group):
+    paths = []
+    for entry_point in iter_entry_points(group=group, name=None):
+        paths.append(entry_point.dist.location)
+    return paths
 
 
 def global_restart() -> None:

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,9 @@ deps = [
     "deepmerge==1.0.1",
 ]
 
+if py_version < (3, 8):
+    deps.append("importlib-metadata==4.12.0")
+
 if py_version < (3, 9):
     deps.append("graphlib-backport==1.0.3")
 

--- a/tests/plugin_management_test.py
+++ b/tests/plugin_management_test.py
@@ -9,7 +9,7 @@ import errbot.repo_manager
 from errbot import plugin_manager
 from errbot.plugin_info import PluginInfo
 from errbot.plugin_manager import IncompatiblePluginException
-from errbot.utils import collect_roots, find_roots
+from errbot.utils import collect_roots, entry_point_plugins, find_roots
 
 CORE_PLUGINS = plugin_manager.CORE_PLUGINS
 
@@ -143,3 +143,8 @@ def test_errbot_version_check():
             plugin_manager.check_errbot_version(pi)
     finally:
         plugin_manager.VERSION = real_version
+
+
+def test_entry_point_plugin():
+    no_plugins_found = entry_point_plugins("errbot.no_plugins")
+    assert [] == no_plugins_found


### PR DESCRIPTION
This feature should allow plugins to be detected using entrypoints when installed via pip.

The entrypoints are
* `errbot.plugins` - normal botcmd plugins
* `errbot.backend_plugins` - plugins related to communications systems (Slack, Gitter, etc)

A package would need to include this snippet in their `setup.py` to work.
Using, https://github.com/errbotio/err-helloworld as an example, we need to add

```
...
    entry_points = {
        "errbot.plugins": [
            "helloworld = helloWorld:HelloWorld",
        ]
    }
...
```

I would suggest, plugins use the naming convention of `errbot-plugin-$pluginName`