### PR TITLE
feat: add new config `SENTRY_OPTIONS` for more flexible Sentry configuration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ breaking:
 features:
 
 - core/plugins: detect plugins using entrypoints (#1590)
+- core/logging: add new SENTRY_OPTIONS config (#1597)
 
 fixes:
 

--- a/docs/user_guide/sentry.rst
+++ b/docs/user_guide/sentry.rst
@@ -50,8 +50,9 @@ To setup Errbot with Sentry:
 * Set **BOT_LOG_SENTRY** to *True* and fill in **SENTRY_DSN** with the DSN value obtained previously
 * Optionally adjust **SENTRY_LOGLEVEL** to the desired level
 * Optionally adjust **SENTRY_TRANSPORT** to the desired transport
+* Optionally adjust **SENTRY_OPTIONS** to customise the rest of the initialization.
 * Restart Errbot
 
-You can find a list of `Sentry transport classes <https://docs.sentry.io/clients/python/transports/>`_.
+You can find a list of `Sentry options <https://docs.sentry.io/platforms/python/configuration/options/>`_.
 
 You should now see Exceptions and log messages show up in your Sentry stream.

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -138,6 +138,12 @@ SENTRY_EVENTLEVEL = BOT_LOG_LEVEL
 # For more info, see https://docs.sentry.io/error-reporting/configuration/?platform=python#transport-options
 # SENTRY_TRANSPORT = ("RequestsHTTPTransport", "raven.transport.requests")
 
+# Any other options that can be passed to sentry_sdk.init() at initialization time
+# Note that dsn and transport should be specified via their dedicated setting,
+# and that the 'integrations' setting cannot be set
+# e.g: SENTRY_OPTIONS = {"environment": "production"}
+SENTRY_OPTIONS = {}
+
 # Execute commands in asynchronous mode. In this mode, Errbot will spawn 10
 # separate threads to handle commands, instead of blocking on each
 # single command.


### PR DESCRIPTION
The Sentry SDK has several options, but right now we are limited by errbot as to which one can be configured.

This adds a new `SENTRY_OPTIONS` config, which enable users to specify any option supported by the SDK in the `sentry_sdk.init()` call.

Our use case is that we have 2 instances of a given bot running, one for testing changes to our plugins and one which we use (like staging & prod) and we use the [`environment` option](https://docs.sentry.io/platforms/python/configuration/options/#environment) to tell which bot caused the error. I assume some people might find the `release` option useful too.