### PR TITLE
Update slackv3 configuration/installation and development documentation

### DIFF
--- a/docs/user_guide/configuration/slackv3.rst
+++ b/docs/user_guide/configuration/slackv3.rst
@@ -19,7 +19,7 @@ installed in a python virtual environment (adjust the command to your errbot's i
 
     git clone https://github.com/errbotio/err-backend-slackv3.git
     source /opt/errbot/bin/activate
-    /opt/errbot/bin/pip install -r /opt/errbot/backends/err-backend-slackv3/requirements.txt
+    /opt/errbot/bin/pip install .
 
 Connection Methods
 ------------------------------------------------------------------------

--- a/docs/user_guide/configuration/slackv3.rst
+++ b/docs/user_guide/configuration/slackv3.rst
@@ -1,5 +1,5 @@
 Slack v3 Backend
-================
+========================================================================
 
 This backend lets you connect to the `Slack <https://slack.com/>`_ messaging service using the
 Real-time Messaging Protocol, Events Request-URL or Events Socket mode.
@@ -11,7 +11,7 @@ Real-time Messaging Protocol, Events Request-URL or Events Socket mode.
 To select this backend, set `BACKEND = 'SlackV3'`.
 
 Dependencies
-------------
+------------------------------------------------------------------------
 
 You need to install Slackv3 dependencies before using Errbot with Slack.  In the below example,
 it is assumed slackv3 has been download to the /opt/errbot/backends directory and errbot has been
@@ -22,15 +22,18 @@ installed in a python virtual environment (adjust the command to your errbot's i
     /opt/errbot/bin/pip install -r /opt/errbot/backends/err-backend-slackv3/requirements.txt
 
 Connection Methods
-------------------
+------------------------------------------------------------------------
 
-Over the years, Slack has changed to their OAuth and API architecture that can be a source of confusion.  No
-matter which OAuth bot token you're using or the API architecture in your environment, slackv3 can handle it.
+Slack's OAuth and API architecture has evolved and caused some confusion.  No matter which OAuth bot token you're using or the API architecture in your environment, slackv3 will support it.
 
 The backend will automatically detect which token and architecture you have and start listening for Slack events in the right way:
 
+ - Legacy tokens (OAuthv1) with Real Time Messaging (RTM) API
+ - Current token (OAuthv2) with Event API using the Event Subscriptions and Request URL.
+ - Current token (Oauthv2) with Event API using the Socket-mode client.
+
 Legacy tokens (OAuthv1) with Real Time Messaging (RTM) API
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When the following oauth scopes are detected, the RTM protocol will be used.  These scopes are automatically present when using a legacy token.
 
@@ -49,7 +52,7 @@ When the following oauth scopes are detected, the RTM protocol will be used.  Th
 - Current token (OAuthv2) with Event API using the Socket-mode client.
 
 Backend Installation
---------------------
+------------------------------------------------------------------------
 
 These instructions are for errbot running inside a Python virtual environment.  You will need to adapt these steps to your own errbot instance setup.
 The virtual environment is created in `/opt/errbot/virtualenv` and errbot initialised in `/opt/errbot`.  The extra backend directory is in `/opt/errbot/backend`.
@@ -59,7 +62,7 @@ The virtual environment is created in `/opt/errbot/virtualenv` and errbot initia
 .. code::
 
     mkdir -p /opt/errbot/backend
-    virtualenv --python=python3 /opt/errbot/virtualenv
+    python3 -m venv /opt/errbot/virtualenv
 
 2. Install and initialise errbot. `See here for details <https://errbot.readthedocs.io/en/latest/user_guide/setup.html>`_
 
@@ -83,7 +86,9 @@ The virtual environment is created in `/opt/errbot/virtualenv` and errbot initia
 
     cd /opt/errbot/backend
     git clone https://github.com/errbotio/err-backend-slackv3
-    pip install -r /opt/errbot/backend/err-backend-slackv3/requirements.txt
+    # to get a specific release use `--branch <release-tag>`, e.g. `--branch v0.1.0`
+    git clone --depth 1 https://github.com/errbotio/err-backend-slackv3
+    pip install .
 
 5. Configure the slack bot token, signing secret (Events API with Request URLs) and/or app token (Events API with Socket-mode).  Located in `/opt/errbot/config.py`
 
@@ -97,22 +102,22 @@ The virtual environment is created in `/opt/errbot/virtualenv` and errbot initia
 
 
 Setting up Slack application
-----------------------------
+------------------------------------------------------------------------
 
 Legacy token with RTM
-^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This was the original method for connecting a bot to Slack.  Create a bot token, configure errbot with it and start using Slack.
 Pay attention when reading `real time messaging <https://github.com/slackapi/python-slack-sdk/blob/main/docs-src/real_time_messaging.rst>`_ explaining how to create a "classic slack application".  Slack does not allow Legacy bot tokens to use the Events API.
 
 Current token with Events Request URLs
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This is by far the most complex method of having errbot communicate with Slack.  The architecture involves server to client communication over HTTP.  This means the Slack server must be able to reach errbot's `/slack/events` endpoint via the internet using a valid SSL connection.
 How to set up such an architecture is outside the scope of this readme and is left as an exercise for the reader.  Read `slack events api document <https://github.com/slackapi/python-slack-events-api>`_ for details on how to configure the Slack app and request URL.
 
 Current token with Events Socket-mode client
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Create a current bot token, enable socket mode.  Configure errbot to use the bot and app tokens and start using Slack.
 Read `socket-mode <https://github.com/slackapi/python-slack-sdk/blob/main/docs-src/socket-mode/index.rst>`_ for instructions on setting up Socket-mode.
@@ -124,3 +129,11 @@ Ensure the bot is also subscribed to the following events:
 - `message.channels`
 - `message.groups`
 - `message.im`
+
+Bot Admins
+------------------------------------------------------------------------
+Slack changed the way users are uniquely identified from display name ``@some_name`` to user id ``Uxxxxxx``. Errbot configuration will need to be updated before administrators can be correctly identified aginst the ACL sets.
+
+The UserID is in plain text format. It can be found in the the Slack full profile page or using the ``!whoami`` command (``person`` field).
+
+Because BOT_ADMINS is defined as plain text User IDs, they can not be used to send notifications. The mention format ``<@Uxxxxx>`` must be used in the BOT_ADMINS_NOTIFICATIONS configuration setting for errbot to initiate message to bot administrators.

--- a/docs/user_guide/plugin_development/backend_specifics.rst
+++ b/docs/user_guide/plugin_development/backend_specifics.rst
@@ -1,5 +1,5 @@
 Backend-specifics
-=================
+========================================================================
 
 Errbot uses external libraries for most backends, which may offer additional
 functionality not exposed by Errbot in a generic, backend-agnostic fashion.
@@ -18,7 +18,7 @@ to control Errbot in highly specific ways that may not be officially supported.
 
 
 Getting to the bot object
--------------------------
+------------------------------------------------------------------------
 
 From within a plugin, you may access `self._bot` in order to get to the instance of the currently running bot class.
 For example, with the Telegram backend this would be an instance of :class:`~errbot.backends.telegram.TelegramBackend`:
@@ -38,7 +38,7 @@ The following table lists all the values for `mode` for the official backends:
 Backend                                       Mode value
 ============================================  ==========
 :class:`~errbot.backends.irc`                 irc
-:class:`~errbot.backends.slack`               slack
+:class:`~errbot.backends.slackv3`             slackv3
 :class:`~errbot.backends.telegram_messenger`  telegram
 :class:`~errbot.backends.test`                test
 :class:`~errbot.backends.text`                text
@@ -69,7 +69,7 @@ that will take a long time to reply fully to.
 
 
 Getting to the underlying client library
-----------------------------------------
+------------------------------------------------------------------------
 
 Most of the backends use a third-party library in order to connect to their respective network.
 These libraries often support additional features which Errbot doesn't expose in a generic
@@ -79,17 +79,75 @@ Backends set their own attribute(s) to point to the underlying libraries' client
 The following table lists these attributes for the official backends, along with the library used by the backend:
 
 
-============================================  =========================  ================================================
-Backend                                       Library                    Attribute(s)
-============================================  =========================  ================================================
-:class:`~errbot.backends.irc`                 `irc`_                     ``self._bot.conn`` ``self._bot.conn.connection``
-:class:`~errbot.backends.slack`               `slackclient`_             ``self._bot.sc``
-:class:`~errbot.backends.telegram_messenger`  `telegram-python-bot`_     ``self._bot.telegram``
-:class:`~errbot.backends.xmpp`                `slixmpp`_                 ``self._bot.conn``
-============================================  =========================  ================================================
+============================================  ===============================  ====================================================
+Backend                                       Library                          Attribute(s)
+============================================  ===============================  ====================================================
+:class:`~errbot.backends.irc`                 `irc`_                           ``self._bot.conn`` ``self._bot.conn.connection``
+:class:`~errbot.backends.slackv3`             `slacksdk`_, `_slackeventsapi`_  ``self._bot.slack_sdk`` ``self._bot.slackeventsapi``
+:class:`~errbot.backends.telegram_messenger`  `telegram-python-bot`_           ``self._bot.telegram``
+:class:`~errbot.backends.xmpp`                `slixmpp`_                       ``self._bot.conn``
+============================================  ===============================  ====================================================
 
-.. _hypchat: https://pypi.org/project/hypchat/
 .. _irc: https://pypi.org/project/irc/
 .. _`telegram-python-bot`: https://pypi.org/project/python-telegram-bot
-.. _slackclient: https://pypi.org/project/slackclient/
+.. _slacksdk: https://slack.dev/python-slack-sdk/
+.. _slackeventsapi: https://github.com/slackapi/python-slack-events-api
 .. _slixmpp: https://pypi.org/project/slixmpp
+
+
+Slack v3 Backend
+========================================================================
+
+.. Note::
+
+    Slack provides advanced features above and beyond simple text messaging in the form of Slack Applications and Workflows.  These features cross into the domain of application development and use
+    specialised events and data structures.  Support for these features is asked for by plugin developers, and for good reasons as their ChatOps requirements grow.  It is at this level of sophistication
+    that errbot's framework becomes a hinderance rather than a help because errbot's design goal is to be backend agnostic to ensure portability between chat service providers.  For advanced use cases
+    as mentioned early, it is strongly recommended to use (Slack's Bolt Application Framework)[https://slack.dev/bolt-python/concepts] to write complex application/workflows in Slack.
+
+The Slack v3 backend provides some advanced formatting through direct access to the underlying python module functionality.
+Below are examples of how to make use of Slack specific features.
+
+Slack attachments and block
+------------------------------------------------------------------------
+
+It is possible to pass additional payload data along with the message.  When this extra information is present, the slack python module will process it.
+The below example shows how to send attachments (deprecated) or blocks for advanced text message formatting.
+
+.. code-block:: python
+
+    from slack_sdk.models.blocks import SectionBlock, TextObject
+    from errbot.backends.base import Message
+
+    @botcmd
+    def hello(self, msg, args):
+        """Say hello to someone"""
+        msg.body = "Using the sent message to shorten the code example"
+        msg.extras['attachments'] = [{
+            'color': '5F4B48',
+            'fallback': 'Help text for: Bot plugin',
+            'footer': 'For these commands: `help Bot`',
+            'text': 'General commands to do with the ChatOps bot',
+            'title': 'Bot'
+        },{
+            'color': 'FAF5F5',
+            'fallback': 'Help text for: Example plugin',
+            'footer': 'For these commands: `help Example`',
+            'text': 'This is a very basic plugin to try out your new installation and get you started.\n Feel free to tweak me to experiment with Errbot.\n You can find me in your init directory in the subdirectory plugins.',
+            'title': 'Example'
+        }]
+
+        self._bot.send_message(msg)
+
+
+        # Example with the blocks SDK
+        msg = Message()
+        msg.extras['blocks'] = [
+            SectionBlock(
+                text=TextObject(
+                    text="Welcome to Slack! :wave: We're so glad you're here. :blush:\n\n",
+                    type="mrkdwn"
+                )
+            ).to_dict()
+        ]
+        self._bot.send_message(msg)


### PR DESCRIPTION
To ease the burden of maintaining documentation for the backends, the slackv3 README will no longer have explicit documentation for configuration/installation but provide links to the official errbot documentation.