### PR TITLE
fix: import entrypoint module lookup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ fixes:
 - chore/setup: fix exception when installing on python <3.7 (#1585)
 - docs: typos (#1589, #1594)
 - chore: simplify isort config using black (#1595)
+- fix: detecting entrypoint module paths (#1603)
 
 
 v6.1.9 (2022-06-11)

--- a/errbot/utils.py
+++ b/errbot/utils.py
@@ -7,6 +7,7 @@ import re
 import sys
 import time
 from functools import wraps
+from importlib.util import find_spec
 
 try:
     from importlib.metadata import entry_points
@@ -205,7 +206,8 @@ def collect_roots(base_paths: List, file_sig: str = "*.plug") -> List:
 def entry_point_plugins(group):
     paths = []
     for entry_point in entry_points().get(group, []):
-        paths.append(entry_point.dist._path.parent)
+        lib_paths = find_spec(entry_point.module).submodule_search_locations
+        paths.extend(lib_paths)
     return paths
 
 


### PR DESCRIPTION
This uses a more appropriate approach to find the plugins file location.