### PR TITLE
Rework Dockerfile and prepare for SlackV3 Backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,33 @@
-FROM python:3.9-slim as build
+# syntax=docker/dockerfile:1.4
+
+ARG BASE_IMAGE=python:3.9-slim
+FROM ${BASE_IMAGE} AS build
 WORKDIR /wheel
 COPY . .
 RUN apt update && apt install -y build-essential git
 RUN cd /tmp && \
     git clone https://github.com/errbotio/err-backend-slackv3 slackv3
 RUN pip3 wheel --wheel-dir=/wheel . \
-    -r /tmp/slackv3/requirements.txt wheel \
-    errbot errbot[irc] errbot[XMPP] errbot[telegram] && \
+      -r /tmp/slackv3/requirements.txt wheel \
+      errbot errbot[irc] errbot[XMPP] errbot[telegram] && \
     cp /tmp/slackv3/requirements.txt /wheel/slackv3-requirements.txt
 
-FROM python:3.9-slim as base
-COPY --from=build /wheel /wheel
-RUN apt update && \
-    apt install -y git && \
+FROM ${BASE_IMAGE} AS base
+RUN --mount=type=bind,from=build,source=/wheel,target=/wheell,rw \
+    apt update && \
+    apt install --no-install-recommends -y git && \
     cd /wheel && \
     pip3 -vv install --no-cache-dir --no-index --find-links /wheel . \
-    -r /wheel/slackv3-requirements.txt \
-    errbot errbot[irc] errbot[XMPP] errbot[telegram] && \
-    rm -rf /wheel /var/lib/apt/lists/*
-RUN useradd -m errbot
+      -r /wheel/slackv3-requirements.txt \
+      errbot errbot[irc] errbot[XMPP] errbot[telegram] && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/* && \
+    useradd -m errbot
 
 FROM base
 EXPOSE 3141 3142
 VOLUME /home/errbot
 WORKDIR /home/errbot
 USER errbot
-RUN errbot --init
-RUN git clone https://github.com/errbotio/err-backend-slackv3 backend-plugins/slackv3
+RUN errbot --init && \
+    git clone --depth=1 https://github.com/errbotio/err-backend-slackv3 backend-plugins/slackv3
 ENTRYPOINT [ "/usr/local/bin/errbot" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,5 @@ WORKDIR /home/errbot
 USER errbot
 RUN errbot --init && \
     git clone --depth=1 https://github.com/errbotio/err-backend-slackv3 backend-plugins/slackv3
+STOPSIGNAL SIGINT
 ENTRYPOINT [ "/usr/local/bin/errbot" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,26 +2,32 @@
 
 ARG BASE_IMAGE=python:3.9-slim
 ARG INSTALL_EXTRAS=irc,XMPP,telegram
+ARG SLACKV3_VERSION=0.2.1
 
 FROM ${BASE_IMAGE} AS build
 ARG INSTALL_EXTRAS
+ARG SLACKV3_VERSION
 WORKDIR /wheel
 COPY . .
 RUN apt update && apt install -y build-essential git
 RUN cd /tmp && \
-    git clone --depth=1 https://github.com/errbotio/err-backend-slackv3 slackv3
+    git clone --depth=1 -b v${SLACKV3_VERSION} https://github.com/errbotio/err-backend-slackv3 slackv3
 RUN pip3 wheel --wheel-dir=/wheel . \
       -e /tmp/slackv3 wheel \
       errbot errbot[${INSTALL_EXTRAS}]
 
 FROM ${BASE_IMAGE} AS base
 ARG INSTALL_EXTRAS
+ARG SLACKV3_VERSION
 RUN --mount=type=bind,from=build,source=/wheel,target=/wheel,rw \
     apt update && \
     apt install --no-install-recommends -y git && \
     cd /wheel && \
     pip3 -vv install --no-cache-dir --no-index --find-links /wheel . \
-      errbot errbot[${INSTALL_EXTRAS}] && \
+      errbot errbot[${INSTALL_EXTRAS}] errbot-backend-slackv3 && \
+    git clone --depth=1 -b v${SLACKV3_VERSION} \
+      https://github.com/errbotio/err-backend-slackv3 \
+      /usr/local/lib/python3.9/site-packages/errbot/backends/slackv3 && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/* && \
     useradd -m errbot
 
@@ -30,7 +36,6 @@ EXPOSE 3141 3142
 VOLUME /home/errbot
 WORKDIR /home/errbot
 USER errbot
-RUN errbot --init && \
-    git clone --depth=1 https://github.com/errbotio/err-backend-slackv3 backend-plugins/slackv3
+RUN errbot --init
 STOPSIGNAL SIGINT
 ENTRYPOINT [ "/usr/local/bin/errbot" ]


### PR DESCRIPTION
This is a major rework of the Dockerfile , mainly requires using **buildx** to mount the wheel packages instead of copying them to the image.

⚠️ ~NOTE: As of https://github.com/errbotio/err-backend-slackv3/commit/908d8229761e09004a843173487d99992f019b62 , **slackv3** dependencies cannot be installed - feel free to contribute back with this.~

- Easy way to define extra dependencies for Errbot (irc, xmpp, telegram, others)
- Define BASE_IMAGE
- Use `git clone depth` to reduce git size
- Stop errbot with `SIGINT` (actual shutdown of application)
- Compact layers by using less RUN statements