### PR TITLE
Deprecate the `SENTRY_TRANSPORT` option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ v9.9.9 (unreleased)
 breaking:
 
 - backend/slack: remove slack and slack_rtm built-in backends (#1581)
+- core/logging: deprecate SENTRY_TRANSPORT config (#1604)
 
 features:
 

--- a/docs/user_guide/sentry.rst
+++ b/docs/user_guide/sentry.rst
@@ -49,7 +49,6 @@ To setup Errbot with Sentry:
 * Open up your bot's config.py
 * Set **BOT_LOG_SENTRY** to *True* and fill in **SENTRY_DSN** with the DSN value obtained previously
 * Optionally adjust **SENTRY_LOGLEVEL** to the desired level
-* Optionally adjust **SENTRY_TRANSPORT** to the desired transport
 * Optionally adjust **SENTRY_OPTIONS** to customise the rest of the initialization.
 * Restart Errbot
 

--- a/errbot/bootstrap.py
+++ b/errbot/bootstrap.py
@@ -1,6 +1,7 @@
 import importlib
 import logging
 import sys
+import warnings
 from os import makedirs, path
 from typing import Callable, Optional
 
@@ -135,6 +136,10 @@ def setup_bot(
         if hasattr(config, "SENTRY_TRANSPORT") and isinstance(
             config.SENTRY_TRANSPORT, tuple
         ):
+            warnings.warn(
+                "SENTRY_TRANSPORT is deprecated. Please use SENTRY_OPTIONS instead.",
+                DeprecationWarning,
+            )
             try:
                 mod = importlib.import_module(config.SENTRY_TRANSPORT[1])
                 transport = getattr(mod, config.SENTRY_TRANSPORT[0])

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -134,12 +134,8 @@ SENTRY_DSN = ""
 SENTRY_LOGLEVEL = BOT_LOG_LEVEL
 SENTRY_EVENTLEVEL = BOT_LOG_LEVEL
 
-# Set an optional Sentry transport other than the default Threaded.
-# For more info, see https://docs.sentry.io/error-reporting/configuration/?platform=python#transport-options
-# SENTRY_TRANSPORT = ("RequestsHTTPTransport", "raven.transport.requests")
-
-# Any other options that can be passed to sentry_sdk.init() at initialization time
-# Note that dsn and transport should be specified via their dedicated setting,
+# Options that can be passed to sentry_sdk.init() at initialization time
+# Note that DSN should be specified via its dedicated config option
 # and that the 'integrations' setting cannot be set
 # e.g: SENTRY_OPTIONS = {"environment": "production"}
 SENTRY_OPTIONS = {}


### PR DESCRIPTION
This PR builds on top of #1597. Due to the addition of the `SENTRY_OPTIONS` setting, we no longer need a custom one for the transport option.

In the newer client `sentry-sdk`, [the transport option](https://docs.sentry.io/platforms/python/guides/airflow/configuration/options/#transport-options) has been simplified compared to the old Sentry client (Raven) which was [providing multiple transport classes](https://docs.sentry.io/clients/python/transports/). 

The SDK only ships with the base abstract `Transport` class and the default `HttpTransport` class as can be seen [here](https://github.com/getsentry/sentry-python/blob/master/sentry_sdk/transport.py).