### PR TITLE
Add pypi backends to setup.py as a convience when installing errbot.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ features:
 
 - core/plugins: detect plugins using entrypoints (#1590)
 - core/logging: add new SENTRY_OPTIONS config (#1597)
+- core/plugins: make slack, mattermost and discord backends available as install requirements (#1611)
 
 fixes:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /wheel
 COPY . .
 RUN apt update && apt install -y build-essential git
 RUN pip3 wheel --wheel-dir=/wheel \
-    wheel . .[${INSTALL_EXTRAS}] errbot-backend-slackv3
+    wheel . .[${INSTALL_EXTRAS}]
 
 FROM ${BASE_IMAGE} AS base
 ARG INSTALL_EXTRAS
@@ -16,7 +16,7 @@ RUN apt update && \
     apt install -y git && \
     cd /wheel && \
     pip3 -vv install --no-cache-dir --no-index --find-links /wheel \
-    errbot errbot[${INSTALL_EXTRAS}] errbot-backend-slackv3 && \
+    errbot errbot[${INSTALL_EXTRAS}] && \
     rm -rf /wheel /var/lib/apt/lists/*
 RUN useradd -m errbot
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=python:3.9-slim
-ARG INSTALL_EXTRAS=irc,XMPP,telegram
+ARG INSTALL_EXTRAS=irc,XMPP,telegram,slack
 
 FROM ${BASE_IMAGE} AS build
 ARG INSTALL_EXTRAS

--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,15 @@ if __name__ == "__main__":
             ],
         },
         extras_require={
+            "slack": [
+                "errbot-backend-slackv3==0.2.1",
+            ],
+            "discord": [
+                "err-backend-discord==3.0.1",
+            ],
+            "mattermost": [
+                "err-backend-mattermost==3.0.0",
+            ],
             "IRC": [
                 "irc==20.0.0",
             ],


### PR DESCRIPTION
The `slackv3`, `discord` and `mattermost` backends are available on pypi and are added as a convenience when installing errbot via `pip`.