### PR TITLE
Rework Dockerfile and add proper stop signal

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,7 @@ fixes:
 - chore: fix Docker build to use local tree (#1608)
 - chore: bump actions/checkout version (#1610)
 - docs: link to external Discord plugin documentation (#1615)
+- chore: add ARG to Dockerfile and add proper stop signal (#1613)
 
 
 v6.1.9 (2022-06-11)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,22 @@
-FROM python:3.9-slim as build
+ARG BASE_IMAGE=python:3.9-slim
+ARG INSTALL_EXTRAS=irc,XMPP,telegram
+
+FROM ${BASE_IMAGE} AS build
+ARG INSTALL_EXTRAS
 WORKDIR /wheel
 COPY . .
 RUN apt update && apt install -y build-essential git
 RUN pip3 wheel --wheel-dir=/wheel \
-    wheel . .[irc,XMPP,telegram] errbot-backend-slackv3
+    wheel . .[${INSTALL_EXTRAS}] errbot-backend-slackv3
 
-FROM python:3.9-slim as base
+FROM ${BASE_IMAGE} AS base
+ARG INSTALL_EXTRAS
 COPY --from=build /wheel /wheel
 RUN apt update && \
     apt install -y git && \
     cd /wheel && \
     pip3 -vv install --no-cache-dir --no-index --find-links /wheel \
-    errbot errbot[irc,XMPP,telegram] errbot-backend-slackv3 && \
+    errbot errbot[${INSTALL_EXTRAS}] errbot-backend-slackv3 && \
     rm -rf /wheel /var/lib/apt/lists/*
 RUN useradd -m errbot
 
@@ -21,4 +26,5 @@ VOLUME /home/errbot
 WORKDIR /home/errbot
 USER errbot
 RUN errbot --init
+STOPSIGNAL SIGINT
 ENTRYPOINT [ "/usr/local/bin/errbot" ]


### PR DESCRIPTION
Recovering some changes from #1604 without major changes.

- Easy way to define extra dependencies for Errbot with `INSTALL_EXTRAS` (irc, xmpp, telegram, others)
- Define `BASE_IMAGE` argument to change base image at all stages
- Stop errbot with `SIGINT` signal (actual shutdown of application)