### PR TITLE
fix: update module versions and build

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,7 @@ fixes:
 - chore: bump actions/checkout version (#1610)
 - docs: link to external Discord plugin documentation (#1615)
 - chore: add ARG to Dockerfile and add proper stop signal (#1613)
+- fix: update module versions and build (#1627)
 
 
 v6.1.9 (2022-06-11)

--- a/setup.py
+++ b/setup.py
@@ -32,13 +32,13 @@ deps = [
     "flask==2.0.2",
     "requests==2.27.1",
     "jinja2==3.0.3",
-    "pyOpenSSL==21.0.0",
+    "pyOpenSSL==23.0.0",
     "colorlog==6.6.0",
     "markdown==3.3.6",
     "ansi==0.2.0",
     "Pygments==2.11.2",
     "pygments-markdown-lexer==0.1.0.dev39",  # sytax coloring to debug md
-    "dulwich==0.20.31",  # python implementation of git
+    "dulwich==0.21.2",  # python implementation of git
     "deepmerge==1.0.1",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,8 @@ commands =
 deps =
   twine
 commands =
-  twine check {toxworkdir}/dist/*
+  python setup.py sdist
+  twine check {tox_root}/dist/*
 
 [testenv:sort]
 deps =


### PR DESCRIPTION
Update versions to address broken builds
* dulwich - fixing deprecation warning of `HTTPResponse.getheader()`
* pyOpenSSL- fixing error `module 'lib' has no attribute 'OpenSSL_add_all_algorithms'`

Fix build by addressing path changes in `dist-check`