### PR TITLE
chore: bump setuptools version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,7 @@ fixes:
 - docs: link to external Discord plugin documentation (#1615)
 - chore: add ARG to Dockerfile and add proper stop signal (#1613)
 - fix: update module versions and build (#1627)
+- chore: update setuptools version (#1628)
 
 
 v6.1.9 (2022-06-11)

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ VERSION_FILE = os.path.join("errbot", "version.py")
 
 deps = [
     "webtest==3.0.0",
-    "setuptools==60.5.0",
+    "setuptools==65.5.1",
     "flask==2.0.2",
     "requests==2.27.1",
     "jinja2==3.0.3",


### PR DESCRIPTION
Update setuptools for CVE-2022-40897