### PR TITLE
Removing py37 support

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v3.5.3

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ breaking:
 
 - backend/slack: remove slack and slack_rtm built-in backends (#1581)
 - core/logging: deprecate SENTRY_TRANSPORT config (#1604)
+- core: removing py37 support (#1652)
 
 features:
 

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ from setuptools import find_packages, setup
 
 py_version = sys.version_info[:2]
 
-if py_version < (3, 7):
-    raise RuntimeError("Errbot requires Python 3.7 or later")
+if py_version < (3, 8):
+    raise RuntimeError("Errbot requires Python 3.8 or later")
 
 VERSION_FILE = os.path.join("errbot", "version.py")
 
@@ -148,7 +148,6 @@ if __name__ == "__main__":
             "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
             "Operating System :: OS Independent",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310,codestyle,dist-check,sort,security,docs
+envlist = py38,py39,py310,codestyle,dist-check,sort,security,docs
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Python 3.7 is EOL and will no longer be actively supported nor code tested against.