### PR TITLE
fix: broken integration tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,7 @@ fixes:
 - fix: use template file for webserver plugin echo output (#1654)
 - chore: update repos.json (#1660)
 - docs: add readthedocs yaml config (#1661)
+- fix: broken integration tests (#1668)
 
 
 v6.1.9 (2022-06-11)

--- a/docs/html_extras/repos.json
+++ b/docs/html_extras/repos.json
@@ -21,6 +21,17 @@
       "score": -100.84
     }
   },
+  "errbotio/err-helloworld": {
+    "HelloWorld": {
+      "path": "helloWorld.plug",
+      "repo": "https://github.com/errbotio/err-helloworld",
+      "documentation": "let's say hello !",
+      "name": "HelloWorld",
+      "python": "2+",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/15802630?v=4",
+      "score": -60.88
+    }
+  },
   "drsm79/err-memeon": {
     "MemeOn": {
       "path": "meme.plug",


### PR DESCRIPTION
Re-add missing err-helloworld entry, which was removed in #1660.

This entry is needed for ci and integration tests.