### PR TITLE
refactor: use importlib instead of pkg_resources

### DIFF
--- a/errbot/repo_manager.py
+++ b/errbot/repo_manager.py
@@ -93,7 +93,7 @@ def check_dependencies(req_path: Path) -> Tuple[Optional[str], Sequence[str]]:
     log.debug("check dependencies of %s", req_path)
     # noinspection PyBroadException
     try:
-        from pkg_resources import get_distribution
+        from importlib.metadata import distribution
 
         missing_pkg = []
 
@@ -110,7 +110,7 @@ def check_dependencies(req_path: Path) -> Tuple[Optional[str], Sequence[str]]:
 
                 # noinspection PyBroadException
                 try:
-                    get_distribution(stripped)
+                    distribution(stripped)
                 except Exception:
                     missing_pkg.append(stripped)
         if missing_pkg:

--- a/errbot/utils.py
+++ b/errbot/utils.py
@@ -1,8 +1,10 @@
 import collections
 import fnmatch
+import importlib.metadata
 import inspect
 import logging
 import os
+import pathlib
 import re
 import sys
 import time
@@ -10,7 +12,6 @@ from functools import wraps
 from platform import system
 from typing import List, Tuple, Union
 
-import pkg_resources
 from dulwich import porcelain
 
 log = logging.getLogger(__name__)
@@ -199,9 +200,15 @@ def collect_roots(base_paths: List, file_sig: str = "*.plug") -> List:
 
 def entry_point_plugins(group):
     paths = []
-    for entry_point in pkg_resources.iter_entry_points(group):
-        ep = next(pkg_resources.iter_entry_points(group, entry_point.name))
-        paths.append(f"{ep.dist.module_path}/{entry_point.module_name}")
+
+    eps = importlib.metadata.entry_points()
+    for entry_point in eps.select(group=group):
+        module_name = entry_point.module
+        file_name = module_name.replace(".", "/") + ".py"
+        for f in entry_point.dist.files:
+            if file_name == str(f):
+                parent = str(pathlib.Path(f).resolve().parent)
+                paths.append(f"{parent}/{module_name}")
     return paths
 
 


### PR DESCRIPTION
Another attempt to use importlib vs pkg_resources for processing packages as plugins.