### PR TITLE
correctly import Mapping from collections.abc

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,7 @@ fixes:
 - fix: broken integration tests (#1668)
 - style: replace format() with f-strings (#1667)
 - migrate from external mock package to stdlib unittest.mock (#1673)
+- fix: import of Mapping from collections.abc (#1675)
 
 
 v6.1.9 (2022-06-11)

--- a/errbot/cli.py
+++ b/errbot/cli.py
@@ -83,10 +83,10 @@ def get_config(config_path: str):
 
 
 def _read_dict() -> dict:
-    import collections
+    from collections.abc import Mapping
 
     new_dict = ast.literal_eval(sys.stdin.read())
-    if not isinstance(new_dict, collections.Mapping):
+    if not isinstance(new_dict, Mapping):
         raise ValueError(
             f"A dictionary written in python is needed from stdin. "
             f"Type={type(new_dict)}, Value = {repr(new_dict)}."


### PR DESCRIPTION
Since python 3.10, Mapping is only available through `collections.abc.Mapping` and not through `collections.Mapping`

https://github.com/errbotio/errbot/pull/1562 was proposed including this change but it has been untouched for over a year.