### PR TITLE
fix(plugin_manager): is_activated error during startup

### DIFF
--- a/errbot/plugin_manager.py
+++ b/errbot/plugin_manager.py
@@ -271,9 +271,6 @@ class BotPluginManager(StoreMixin):
                     log.warning("Plugin %s already loaded.", name)
                     continue
 
-                # save the plugin_info for ref.
-                dest_info_dict[name] = plugin_info
-
                 # Skip the core plugins not listed in CORE_PLUGINS if CORE_PLUGINS is defined.
                 if (
                     self.core_plugins
@@ -301,6 +298,9 @@ class BotPluginManager(StoreMixin):
                 # instantiate the plugin object.
                 _, clazz = plugin_classes[0]
                 dest_dict[name] = self._plugin_instance_callback(name, clazz)
+
+                # save the plugin_info for ref.
+                dest_info_dict[name] = plugin_info
 
             except Exception:
                 feedback[path] = traceback.format_exc()


### PR DESCRIPTION
Despite correct configuration of errbot, the errbot was throwing errors related to activation of core plugins that were not defined in the `CORE_PLUGINS` variable.

The issue was (IMHO) in the `activate_non_started_plugins` method which is activating plugins based on info about plugins which shouldn't be activated (based on the `CORE_PLUGINS` variable). So `dest_info_dict` and `dest_dict` dictionaries should be in sync.

environment:
Apple M1 Pro, Ventura 13.6
Python 3.11.2
errbot                   6.2.0
errbot-backend-slackv3   0.2.1

configuration
```
CORE_PLUGINS = ("Help", "Health")
PLUGINS_CALLBACK_ORDER = (None,)
BACKEND = 'SlackV3'
BOT_EXTRA_BACKEND_DIR = '/Users/tkratky/five/err-backend-slackv3'
BOT_EXTRA_PLUGIN_DIR  = '/Users/tkratky/five/plugins'
BOT_DATA_DIR          = '/Users/tkratky/five/data'

BOT_LOG_FILE  = None
BOT_LOG_LEVEL = logging.getLevelName(os.environ.get("LOG_LEVEL", "INFO").upper())
BOT_ADMINS =  ()

# Configurables below
BOT_PREFIX = "? "

BOT_IDENTITY = {
    'token': get_variable('SLACK_BOT_TOKEN', True),
    'app_token': get_variable('SLACK_APP_TOKEN', True)
}
```

errors
```

13:20:01 ERROR    errbot.plugin_manager     Error loading ACLs.
Traceback (most recent call last):
  File "/Users/tkratky/five/.venv/lib/python3.11/site-packages/errbot/plugin_manager.py", line 445, in activate_non_started_plugins
    if not plugin.is_activated:
           ^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'is_activated'
13:20:01 ERROR    errbot.plugin_manager     Error loading Flows.
Traceback (most recent call last):
  File "/Users/tkratky/five/.venv/lib/python3.11/site-packages/errbot/plugin_manager.py", line 445, in activate_non_started_plugins
    if not plugin.is_activated:
           ^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'is_activated'
13:20:01 ERROR    errbot.plugin_manager     Error loading CommandNotFoundFilter.
Traceback (most recent call last):
  File "/Users/tkratky/five/.venv/lib/python3.11/site-packages/errbot/plugin_manager.py", line 445, in activate_non_started_plugins
    if not plugin.is_activated:
           ^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'is_activated'
13:20:01 INFO     errbot.plugin_manager     Activate plugin: Health.
13:20:01 INFO     errbot.core_plugins.wsvie Checking Health for webhooks
13:20:01 ERROR    errbot.plugin_manager     Error loading Backup.
Traceback (most recent call last):
  File "/Users/tkratky/five/.venv/lib/python3.11/site-packages/errbot/plugin_manager.py", line 445, in activate_non_started_plugins
    if not plugin.is_activated:
           ^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'is_activated'
13:20:01 ERROR    errbot.plugin_manager     Error loading Webserver.
Traceback (most recent call last):
  File "/Users/tkratky/five/.venv/lib/python3.11/site-packages/errbot/plugin_manager.py", line 445, in activate_non_started_plugins
    if not plugin.is_activated:
           ^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'is_activated'
13:20:01 ERROR    errbot.plugin_manager     Error loading TextCmds.
Traceback (most recent call last):
  File "/Users/tkratky/five/.venv/lib/python3.11/site-packages/errbot/plugin_manager.py", line 445, in activate_non_started_plugins
    if not plugin.is_activated:
           ^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'is_activated'
13:20:01 ERROR    errbot.plugin_manager     Error loading VersionChecker.
Traceback (most recent call last):
  File "/Users/tkratky/five/.venv/lib/python3.11/site-packages/errbot/plugin_manager.py", line 445, in activate_non_started_plugins
    if not plugin.is_activated:
           ^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'is_activated'
13:20:01 ERROR    errbot.plugin_manager     Error loading Plugins.
Traceback (most recent call last):
  File "/Users/tkratky/five/.venv/lib/python3.11/site-packages/errbot/plugin_manager.py", line 445, in activate_non_started_plugins
    if not plugin.is_activated:
           ^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'is_activated'
13:20:01 INFO     errbot.plugin_manager     Activate plugin: Help.
13:20:01 INFO     errbot.core_plugins.wsvie Checking Help for webhooks
13:20:01 ERROR    errbot.plugin_manager     Error loading ChatRoom.
Traceback (most recent call last):
  File "/Users/tkratky/five/.venv/lib/python3.11/site-packages/errbot/plugin_manager.py", line 445, in activate_non_started_plugins
    if not plugin.is_activated:
           ^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'is_activated'
13:20:01 ERROR    errbot.plugin_manager     Error loading Utils.
Traceback (most recent call last):
  File "/Users/tkratky/five/.venv/lib/python3.11/site-packages/errbot/plugin_manager.py", line 445, in activate_non_started_plugins
    if not plugin.is_activated:
           ^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'is_activated'
```

warning
```
13:20:01 WARNING  errbot.core               Error: ACLs failed to activate: 'NoneType' object has no attribute 'is_activated'.
Error: Flows failed to activate: 'NoneType' object has no attribute 'is_activated'.
Error: CommandNotFoundFilter failed to activate: 'NoneType' object has no attribute 'is_activated'.
Error: Backup failed to activate: 'NoneType' object has no attribute 'is_activated'.
Error: Webserver failed to activate: 'NoneType' object has no attribute 'is_activated'.
Error: TextCmds failed to activate: 'NoneType' object has no attribute 'is_activated'.
Error: VersionChecker failed to activate: 'NoneType' object has no attribute 'is_activated'.
Error: Plugins failed to activate: 'NoneType' object has no attribute 'is_activated'.
Error: ChatRoom failed to activate: 'NoneType' object has no attribute 'is_activated'.
Error: Utils failed to activate: 'NoneType' object has no attribute 'is_activated'.

13:20:01 INFO     errbot.core               Error: ACLs failed to activate: 'NoneType' object has no attribute 'is_activated'.
Error: Flows failed to activate: 'NoneType' object has no attribute 'is_activated'.
Error: CommandNotFoundFilter failed to activate: 'NoneType' object has no attribute 'is_activated'.
Error: Backup failed to activate: 'NoneType' object has no attribute 'is_activated'.
Error: Webserver failed to activate: 'NoneType' object has no attribute 'is_activated'.
Error: TextCmds failed to activate: 'NoneType' object has no attribute 'is_activated'.
Error: VersionChecker failed to activate: 'NoneType' object has no attribute 'is_activated'.
Error: Plugins failed to activate: 'NoneType' object has no attribute 'is_activated'.
Error: ChatRoom failed to activate: 'NoneType' object has no attribute 'is_activated'.
Error: Utils failed to activate: 'NoneType' object has no attribute 'is_activated'.
```

