### PR TITLE
Optimize Dockerfile

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ fixes:
 - chore: bump jinja to 3.1.3 (#1684)
 - chore: bump actions/setup-python version (#1686)
 - chore: bump actions/checkout version (#1696)
+- chore: optimize Dockerfile (#1679)
 
 v6.2.0 (2024-01-01)
 -------------------


### PR DESCRIPTION
Use a virtual environment to make copying packages from build stage to the final stage easier. It also reduces the image size by 94Mb.

I used `python:3-slim` as the final image. Previously we were using `python:3.9-slim`. I think using the newer python version is a good idea, but I can change it back if we don't want to use the newer version.

Size comparison:
```
REPOSITORY        TAG       IMAGE ID       CREATED         SIZE
errbotio/errbot   master    416f2383b24a   7 seconds ago   325MB
errbotio/errbot   new       0226c1a39cd1   2 minutes ago   231MB
```