### PR TITLE
Type hints Fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ fixes:
 - chore: bump jinja2 to 3.1.6 (#1723)
 - chore: update errbot-backend-slackv3 version to 0.3.1 (#1725)
 - fix: Close and join thread pools between tests (#1724)
+- fix: type hints (#1698)
 
 
 v6.2.0 (2024-01-01)

--- a/errbot/cli.py
+++ b/errbot/cli.py
@@ -19,10 +19,10 @@ import ast
 import logging
 import os
 import sys
+from collections.abc import Mapping
 from os import W_OK, access, getcwd, path, sep
 from pathlib import Path
 from platform import system
-from collections.abc import Mapping
 
 from errbot.bootstrap import CORE_BACKENDS
 from errbot.logs import root_logger
@@ -65,7 +65,7 @@ def get_config(config_path: str):
         log.error(f"I cannot find the config file {config_path}.")
         log.error("You can change this path with the -c parameter see --help")
         log.info(
-            f'You can use the template {os.path.realpath(os.path.join(__file__, os.pardir, "config-template.py"))}'
+            f"You can use the template {os.path.realpath(os.path.join(__file__, os.pardir, 'config-template.py'))}"
             f" as a base and copy it to {config_path}."
         )
         log.info("You can then customize it.")
@@ -83,7 +83,6 @@ def get_config(config_path: str):
 
 
 def _read_dict() -> Mapping:
-
     new_dict = ast.literal_eval(sys.stdin.read())
     if not isinstance(new_dict, Mapping):
         raise ValueError(

--- a/errbot/cli.py
+++ b/errbot/cli.py
@@ -22,6 +22,7 @@ import sys
 from os import W_OK, access, getcwd, path, sep
 from pathlib import Path
 from platform import system
+from collections.abc import Mapping
 
 from errbot.bootstrap import CORE_BACKENDS
 from errbot.logs import root_logger
@@ -81,8 +82,7 @@ def get_config(config_path: str):
         exit(-1)
 
 
-def _read_dict() -> dict:
-    from collections.abc import Mapping
+def _read_dict() -> Mapping:
 
     new_dict = ast.literal_eval(sys.stdin.read())
     if not isinstance(new_dict, Mapping):


### PR DESCRIPTION
## Description
Fix type check warning reported by Pyre@Google, which was outdated after code modification.
## Detail
update the return type of  function `_read_dict()` from `dict` to `Mapping`, since the condition check of the return `new_dict` and type `Mapping` after commit 9193b1fd3d6a629da707fce4344a10606c0404ba