### PR TITLE
chore: bump setuptools version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ fixes:
 - chore: add python versions to test (#1705)
 - chore: remove python 3.8 support (#1707)
 - chore: use ruff for formatting (#1706)
+- chore: bump setuptools to 75.7.0 (#1709)
 
 v6.2.0 (2024-01-01)
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ VERSION_FILE = os.path.join("errbot", "version.py")
 
 deps = [
     "webtest==3.0.0",
-    "setuptools==68.1.2",
+    "setuptools==75.7.0",
     "flask==2.3.3",
     "requests==2.31.0",
     "jinja2==3.1.3",


### PR DESCRIPTION
Fixes this vulnerability: https://security.snyk.io/vuln/SNYK-PYTHON-SETUPTOOLS-7448482