### PR TITLE
chore: bump pyOpenSSL to 24.3.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ fixes:
 - chore: remove python 3.8 support (#1707)
 - chore: use ruff for formatting (#1706)
 - chore: bump setuptools to 75.7.0 (#1709)
+- chore: bump pyOpenSSL to 24.3.0 (#1710)
 
 v6.2.0 (2024-01-01)
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ deps = [
     "flask==2.3.3",
     "requests==2.31.0",
     "jinja2==3.1.3",
-    "pyOpenSSL==23.2.0",
+    "pyOpenSSL==24.3.0",
     "colorlog==6.7.0",
     "markdown==3.4.4",
     "ansi==0.3.6",


### PR DESCRIPTION
Bumping pyOpenSSL which depends on previously depended on cryptography>=38.0.0,<41,!=40.0.0,!=40.0.1. Now it depends on cryptography>=41.0.5,<45.