### PR TITLE
chore: bump requests version to 2.32.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ deps = [
     "webtest==3.0.0",
     "setuptools==75.7.0",
     "flask==2.3.3",
-    "requests==2.32.0",
+    "requests==2.32.3",
     "jinja2==3.1.5",
     "pyOpenSSL==24.3.0",
     "colorlog==6.7.0",


### PR DESCRIPTION
Bumping up requests to version 2.32.3