### PR TITLE
Fix: Newlines replaced with spaces in botcmd args (#1716)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ fixes:
 - chore: bump jinja2 to 3.1.5 and requests to 2.32.0 (#1714)
 - Fix: situationally broken apropos command (#1711)
 - chore: bump requests to 2.32.3 (#1715)
+- Fix: Newlines replaced with spaces in botcmd args (#1716)
 
 
 v6.2.0 (2024-01-01)

--- a/errbot/core.py
+++ b/errbot/core.py
@@ -325,21 +325,25 @@ class ErrBot(Backend, StoreMixin):
             prefixed = True
 
         text = text.strip()
-        text_split = text.split()
         cmd = None
         command = None
         args = ""
         if not only_check_re_command:
-            i = len(text_split)
+            first = True
+            i = len(text.split())
             while cmd is None:
+                # maxsplit so we can preserve linebreaks and other whitespace in args
+                text_split = text.split(maxsplit=i)
                 command = "_".join(text_split[:i])
 
                 with self._gbl:
                     if command in self.commands:
                         cmd = command
-                        args = " ".join(text_split[i:])
+                        if not first:
+                            args = text_split[-1]
                     else:
                         i -= 1
+                        first = False
                 if i <= 0:
                     break
 

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -57,6 +57,16 @@ def test_echo(testbot):
     assert "foo" in testbot.exec_command("!echo foo")
 
 
+def test_echo_newline_args(testbot):
+    # https://github.com/errbotio/errbot/issues/1307
+    assert testbot.exec_command("!echo\nfoo\nbar").startswith("foo")
+
+
+def test_echo_newline_preserved(testbot):
+    # https://github.com/errbotio/errbot/issues/1716
+    assert "\n" in testbot.exec_command("!echo foo\nbar")
+
+
 def test_status_gc(testbot):
     assert "GC 0->" in testbot.exec_command("!status gc")
 


### PR DESCRIPTION
Original issue from https://github.com/errbotio/errbot/issues/1307 remains fixed, but preserves newlines in the args:
```
[@CHANGE_ME ➡ @errbot] >>> !hello
[@CHANGE_ME ➡ @errbot] [␍] line 1
[@CHANGE_ME ➡ @errbot] [␍] line 2
[@CHANGE_ME ➡ @errbot] [␍] 
cmd = 'hello'
args = 'line 1\nline 2'
Hello! You said: line 1
line 2

# new lines in the middle of a command also works:

[@CHANGE_ME ➡ @errbot] >>> !this is a
[@CHANGE_ME ➡ @errbot] [␍] very long
[@CHANGE_ME ➡ @errbot] [␍] command
[@CHANGE_ME ➡ @errbot] [␍] 
cmd = 'this_is_a_very_long_command'
args = ''


[@CHANGE_ME ➡ @errbot] >>> !this is a
[@CHANGE_ME ➡ @errbot] [␍] very long
[@CHANGE_ME ➡ @errbot] [␍] command
[@CHANGE_ME ➡ @errbot] [␍] test
[@CHANGE_ME ➡ @errbot] [␍] 
cmd = 'this_is_a_very_long_command'
args = 'test'


[@CHANGE_ME ➡ @errbot] >>> !this is a
[@CHANGE_ME ➡ @errbot] [␍] very long
[@CHANGE_ME ➡ @errbot] [␍] command
[@CHANGE_ME ➡ @errbot] [␍] with a lot
[@CHANGE_ME ➡ @errbot] [␍] of test
[@CHANGE_ME ➡ @errbot] [␍] 
cmd = 'this_is_a_very_long_command'
args = 'with a lot\nof test'

```