### PR TITLE
chore: bump jinja2 to 3.1.6

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ fixes:
 - chore: bump jinja2 to 3.1.5 and requests to 2.32.0 (#1714)
 - Fix: situationally broken apropos command (#1711)
 - chore: bump requests to 2.32.3 (#1715)
+- chore: bump requests to 2.32.3 (#1723)
 
 
 v6.2.0 (2024-01-01)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,7 @@ fixes:
 - chore: bump jinja2 to 3.1.5 and requests to 2.32.0 (#1714)
 - Fix: situationally broken apropos command (#1711)
 - chore: bump requests to 2.32.3 (#1715)
-- chore: bump requests to 2.32.3 (#1723)
+- chore: bump jinja2 to 2.32.3 (#1723)
 
 
 v6.2.0 (2024-01-01)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,7 @@ fixes:
 - chore: bump jinja2 to 3.1.5 and requests to 2.32.0 (#1714)
 - Fix: situationally broken apropos command (#1711)
 - chore: bump requests to 2.32.3 (#1715)
-- chore: bump jinja2 to 2.32.3 (#1723)
+- chore: bump jinja2 to 3.1.6 (#1723)
 
 
 v6.2.0 (2024-01-01)

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ deps = [
     "setuptools==75.7.0",
     "flask==2.3.3",
     "requests==2.32.3",
-    "jinja2==3.1.5",
+    "jinja2==3.1.6",
     "pyOpenSSL==24.3.0",
     "colorlog==6.7.0",
     "markdown==3.4.4",


### PR DESCRIPTION
Bump jinja2 version to 3.1.6