### PR TITLE
Close and join thread pools between tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ fixes:
 - Fix: Newlines replaced with spaces in botcmd args (#1716)
 - chore: bump jinja2 to 3.1.6 (#1723)
 - chore: update errbot-backend-slackv3 version to 0.3.1 (#1725)
+- fix: Close and join thread pools between tests (#1724)
 
 
 v6.2.0 (2024-01-01)

--- a/errbot/backends/test.py
+++ b/errbot/backends/test.py
@@ -521,6 +521,10 @@ class TestBot:
         log.info("Main bot thread quits")
         self.bot.zap_queues()
         self.bot.reset_rooms()
+        self.bot.thread_pool.close()
+        self.bot.thread_pool.join()
+        self.bot.flow_executor._pool.close()
+        self.bot.flow_executor._pool.join()
         self.bot_thread = None
 
     def pop_message(self, timeout: int = 5, block: bool = True):

--- a/tests/base_backend_test.py
+++ b/tests/base_backend_test.py
@@ -257,8 +257,14 @@ class DummyBackend(ErrBot):
 
 
 @pytest.fixture
-def dummy_backend():
-    return DummyBackend()
+def dummy_backend(request):
+    def on_finish():
+        backend.flow_executor._pool.close()
+        backend.flow_executor._pool.join()
+
+    backend = DummyBackend()
+    request.addfinalizer(on_finish)
+    return backend
 
 
 def test_buildreply(dummy_backend):


### PR DESCRIPTION
https://bugs.debian.org/1103066 reported test failures on Debian's i386 architecture.  After some digging I found that tests were hitting `ENOMEM` depending on which other tests had been run previously, suggesting test isolation problems; i386 has a more limited address space than most other architectures so is more likely to run into this sort of thing.  Forcing thread pools to be shut down between tests seems to avoid this problem.