### PR TITLE
chore: update errbot-backend-slackv3 version to 0.3.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ fixes:
 - Fix: situationally broken apropos command (#1711)
 - chore: bump requests to 2.32.3 (#1715)
 - chore: bump jinja2 to 3.1.6 (#1723)
+- chore: update errbot-backend-slackv3 version to 0.3.1 (#1725)
 
 
 v6.2.0 (2024-01-01)

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ if __name__ == "__main__":
         },
         extras_require={
             "slack": [
-                "errbot-backend-slackv3==0.2.1",
+                "errbot-backend-slackv3==0.3.1",
             ],
             "discord": [
                 "err-backend-discord==3.0.1",


### PR DESCRIPTION
updating errbot-backend-slackv3 required version to 0.3.1