### PR TITLE
fix: update message that plugin config must be a single line

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ fixes:
 - chore: update errbot-backend-slackv3 version to 0.3.1 (#1725)
 - fix: Close and join thread pools between tests (#1724)
 - fix: type hints (#1698)
+- fix: update plugin config message (#1727)
 
 
 v6.2.0 (2024-01-01)

--- a/errbot/core_plugins/plugins.py
+++ b/errbot/core_plugins/plugins.py
@@ -167,7 +167,7 @@ class Plugins(BotPlugin):
 
         if len(args) == 1:
             response = (
-                f"Default configuration for this plugin (you can copy and paste this directly as a command):"
+                f"Default configuration for this plugin (you can copy and paste this directly as a single line command):"
                 f"\n\n```\n{self._bot.prefix}plugin config {plugin_name} {pformat(template_obj)}\n```"
             )
 

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -75,7 +75,7 @@ def test_config_cycle(testbot):
     testbot.push_message("!plugin config Webserver")
     m = testbot.pop_message()
     assert (
-        "Default configuration for this plugin (you can copy and paste this directly as a command)"
+        "Default configuration for this plugin (you can copy and paste this directly as a single line command)"
         in m
     )
     assert "Current configuration" not in m


### PR DESCRIPTION
Not a fix for https://github.com/errbotio/errbot/issues/1298, however, this should reduce confusing and frustration if using `!plugin config` with multiline configs.