### PR TITLE
fix: update tar extract filter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,7 @@ fixes:
 - docs: add example on how to use threaded replies (#1728)
 - fix: add extra_plugin_dir support to FullStackTest (#1726)
 - fix: add missing py 3.13 in tox (#1731)
+- fix: add filter to tar extract (#1730)
 
 
 v6.2.0 (2024-01-01)

--- a/errbot/repo_manager.py
+++ b/errbot/repo_manager.py
@@ -274,7 +274,7 @@ class BotRepoManager(StoreMixin):
         if repo_url.endswith("tar.gz"):
             fo = urlopen(repo_url)  # nosec
             tar = tarfile.open(fileobj=fo, mode="r:gz")
-            tar.extractall(path=self.plugin_dir)
+            tar.extractall(path=self.plugin_dir, filter="data")
             s = repo_url.split(":")[-1].split("/")[-1]
             human_name = s[: -len(".tar.gz")]
         else:


### PR DESCRIPTION
This fixes deprecation warnings in more recent python versions.