### PR TITLE
fix: missing py 3.13 version in tox

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,7 @@ fixes:
 - fix: update plugin config message (#1727)
 - docs: add example on how to use threaded replies (#1728)
 - fix: add extra_plugin_dir support to FullStackTest (#1726)
+- fix: add missing py 3.13 in tox (#1731)
 
 
 v6.2.0 (2024-01-01)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39,py310,py311,py312,py312,codestyle,dist-check,security,docs
+envlist = py39,py310,py311,py312,py313,codestyle,dist-check,security,docs
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Python version 3.13 was missing from top config.