### PR TITLE
doc: fix url in README for TOX chat server

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,7 @@ fixes:
 - fix: add filter to tar extract (#1730)
 - refactor: use importlib to find plugins in entry_points (#1669, #1733)
 - chore: bump setuptools to >=78.1.1 (#1734)
+- docs: update tox chat server URLs (#1739)
 
 
 v6.2.0 (2024-01-01)

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Chat servers support
 - `Mattermost <https://about.mattermost.com/>`_ (See `instructions <https://github.com/Vaelor/errbot-mattermost-backend>`__)
 - `RocketChat <https://rocket.chat/>`_ (See `instructions <https://github.com/cardoso/errbot-rocketchat>`__)
 - `Skype <https://www.skype.com/>`_ (See `instructions <https://github.com/errbotio/errbot-backend-skype>`__)
-- `TOX <https://tox.im/>`_ (See `instructions <https://github.com/errbotio/err-backend-tox>`__)
+- `TOX <https://tox.chat/>`_ (See `instructions <https://github.com/errbotio/err-backend-tox>`__)
 - `VK <https://vk.com/>`_ (See `instructions <https://github.com/Ax3Effect/errbot-vk>`__)
 - `Zulip <https://zulipchat.com/>`_ (See `instructions <https://github.com/zulip/errbot-backend-zulip>`__)
 

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -67,7 +67,7 @@ Extensive plugin framework
 .. _Skype: http://www.skype.com/en/
 .. _Slack: http://slack.com/
 .. _Telegram: https://telegram.org/
-.. _Tox: https://tox.im/
+.. _Tox: https://tox.chat/
 .. _VK: https://vk.com/
 .. _Zulip: https://zulipchat.com/
 .. _`logged to Sentry`: https://github.com/errbotio/errbot/wiki/Logging-with-Sentry

--- a/errbot/config-template.py
+++ b/errbot/config-template.py
@@ -35,7 +35,7 @@ import logging
 # "Gitter"   - see https://gitter.im/ (follow instructions from https://github.com/errbotio/err-backend-gitter)
 
 # Open protocols:
-# "TOX"      - see https://tox.im/ (follow instructions from https://github.com/errbotio/err-backend-tox)
+# "TOX"      - see https://tox.chat/ (follow instructions from https://github.com/errbotio/err-backend-tox)
 # "IRC"      - for classic IRC or bridged services like https://gitter.im
 # "XMPP"     - the Extensible Messaging and Presence Protocol (https://xmpp.org/)
 # "Telegram" - cloud-based mobile and desktop messaging app with a focus


### PR DESCRIPTION
I don't know when this domain changed hands, but it's now advertising a totally unrelated service. Update all references to point at the relevant chat server's homepage.