### PR TITLE
chore: update Dockerfile to use py 3.12

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,7 @@ fixes:
 - refactor: use importlib to find plugins in entry_points (#1669, #1733)
 - chore: bump setuptools to >=78.1.1 (#1734)
 - docs: update tox chat server URLs (#1739)
+- chore: update Dockerfile python version (#1744)
 
 
 v6.2.0 (2024-01-01)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG INSTALL_EXTRAS=irc,XMPP,telegram,slack
 
-FROM python:3.9 AS build
+FROM python:3.12 AS build
 ARG INSTALL_EXTRAS
 
 WORKDIR /wheel
@@ -8,7 +8,7 @@ WORKDIR /wheel
 COPY . .
 RUN pip wheel --wheel-dir=/wheel wheel . .[${INSTALL_EXTRAS}]
 
-FROM python:3.9-slim
+FROM python:3.12-slim
 ARG INSTALL_EXTRAS
 
 RUN --mount=from=build,source=/wheel,target=/wheel \


### PR DESCRIPTION
This version should match the same version we run active tests on.