### PR TITLE
chore: remove python 3.9 support

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v6.0.2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,7 @@ fixes:
 - fix: allow webtest to work on python 3.13 (#1729)
 - fix: add command in logged when blocked by cmdfilter (#1631)
 - chore: bump pyasn1 version (#1752)
+- chore: remove python 3.9 support (#1755)
 
 
 v6.2.0 (2024-01-01)

--- a/README.rst
+++ b/README.rst
@@ -106,7 +106,7 @@ Installation
 Prerequisites
 ~~~~~~~~~~~~~
 
-Errbot runs under Python 3.6+ on Linux, Windows and Mac. For some chatting systems you'll need a key or a login for your bot to access it.
+Errbot runs under Python 3.10+ on Linux, Windows and Mac. For some chatting systems you'll need a key or a login for your bot to access it.
 
 Quickstart
 ~~~~~~~~~~

--- a/docs/user_guide/setup.rst
+++ b/docs/user_guide/setup.rst
@@ -4,7 +4,7 @@ Setup
 Prerequisites
 -------------
 
-Errbot runs under Python 3.6+ on Linux, Windows and Mac.
+Errbot runs under Python 3.10+ on Linux, Windows and Mac.
 
 Installation
 ------------

--- a/errbot/utils.py
+++ b/errbot/utils.py
@@ -200,27 +200,13 @@ def collect_roots(base_paths: List, file_sig: str = "*.plug") -> List:
 def entry_point_plugins(group):
     paths = set()
 
-    eps = importlib.metadata.entry_points()
-    try:
-        entry_points = eps.select(group=group)
-    except AttributeError:
-        # workaround to support python 3.9 and older
-        entry_points = eps.get(group, ())
-
-    for entry_point in entry_points:
-        try:
-            files = entry_point.dist.files
-        except AttributeError:
-            # workaround to support python 3.9 and older
-            try:
-                files = importlib.metadata.distribution(entry_point.name).files
-            except importlib.metadata.PackageNotFoundError:
-                # entrypoint is not a distribution, so let's skip looking for files
-                continue
-        for file in files:
-            if "__pycache__" not in file.parts:
-                parent = file.locate().absolute().resolve().parent
-                paths.add(str(parent))
+    for entry_point in importlib.metadata.entry_points(group=group):
+        files = entry_point.dist.files
+        if files:
+            for file in files:
+                if "__pycache__" not in file.parts:
+                    parent = file.locate().absolute().resolve().parent
+                    paths.add(str(parent))
     return list(paths)
 
 

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ from setuptools import find_packages, setup
 
 py_version = sys.version_info[:2]
 
-if py_version < (3, 9):
-    raise RuntimeError("Errbot requires Python 3.9 or later")
+if py_version < (3, 10):
+    raise RuntimeError("Errbot requires Python 3.10 or later")
 
 VERSION_FILE = os.path.join("errbot", "version.py")
 
@@ -146,9 +146,10 @@ if __name__ == "__main__":
             "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
             "Operating System :: OS Independent",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
+            "Programming Language :: Python :: 3.12",
+            "Programming Language :: Python :: 3.13",
         ],
         src_root=src_root,
         platforms="any",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39,py310,py311,py312,py313,codestyle,dist-check,security,docs
+envlist = py310,py311,py312,py313,codestyle,dist-check,security,docs
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Removing python 3.9 support as EOL was 2025-10-31.