### PR TITLE
ClientXMPP.process() is not available since slixmpp-1.9.0 (XMPP backend broken)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ v9.9.9 (unreleased)
 - chore: add releases script (#1767)
 - refactor: remove webtest dependency (#1769)
 - feat: support editable installed entrypoint plugins (#1766)
+- fix: XMPP backend referencing invalid method (#1768)
 
 
 v6.2.1 (2026-06-06)

--- a/errbot/backends/xmpp.py
+++ b/errbot/backends/xmpp.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import sys
 from datetime import datetime
@@ -396,7 +397,7 @@ class XMPPConnection:
         self.connected = False
 
     def serve_forever(self) -> None:
-        self.client.process()
+        asyncio.get_event_loop().run_forever()
 
     def add_event_handler(self, name: str, cb: Callable) -> None:
         self.client.add_event_handler(name, cb)


### PR DESCRIPTION
XMPP backend is broken at the moment, ClientXMPP.process() is not available since slixmpp-1.9.0 https://codeberg.org/poezio/slixmpp/releases/tag/slix-1.9.0

Using asyncio like in the official example https://slixmpp.readthedocs.io/en/latest/#here-s-your-first-slixmpp-bot