### PR TITLE
refactor: remove webtest for flask test_client

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 v9.9.9 (unreleased)
 -------------------
 - chore: add releases script (#1767)
+- refactor: remove webtest dependency (#1769)
 
 
 v6.2.1 (2026-06-06)

--- a/errbot/core_plugins/templates/plugin_info.md
+++ b/errbot/core_plugins/templates/plugin_info.md
@@ -19,13 +19,15 @@ log destination: {{ plugin.log.name }}
 
 log level: {{ logging.getLevelName(plugin.log.level) }}
 
-{% if plugin.keys %}
+{% if plugin.is_activated %}
+{% if plugin.keys() %}
 **storage content**
 
 Key                  | Value
 -------------------- | -----------------------
 {% for key, value in plugin.items() %}{{ key.ljust(20) }} | `{{ value }}`
 {% endfor %}
+{% endif %}
 {% endif %}
 
 {% if plugin.config  %}

--- a/errbot/core_plugins/webserver.py
+++ b/errbot/core_plugins/webserver.py
@@ -73,14 +73,14 @@ class Webserver(BotPlugin):
 
     def check_configuration(self, configuration):
         # it is a pain, just assume a default config if SSL is absent or set to None
+        ssl_template = self.get_configuration_template()["SSL"]
         if configuration.get("SSL", None) is None:
-            configuration["SSL"] = {
-                "enabled": False,
-                "host": "0.0.0.0",
-                "port": 3142,
-                "certificate": "",
-                "key": "",
-            }
+            configuration["SSL"] = ssl_template
+        else:
+            # fill in missing keys from template if they are absent
+            for k, v in ssl_template.items():
+                if k not in configuration["SSL"]:
+                    configuration["SSL"][k] = v
         super().check_configuration(configuration)
 
     def activate(self):

--- a/errbot/core_plugins/webserver.py
+++ b/errbot/core_plugins/webserver.py
@@ -7,7 +7,6 @@ from threading import Thread
 from urllib.request import unquote
 
 from OpenSSL import crypto
-from webtest import TestApp
 from werkzeug.serving import ThreadedWSGIServer
 
 from errbot import BotPlugin, botcmd, webhook
@@ -57,7 +56,6 @@ class Webserver(BotPlugin):
         self.server = None
         self.server_thread = None
         self.ssl_context = None
-        self.test_app = TestApp(flask_app)
         super().__init__(*args, **kwargs)
 
     def get_configuration_template(self):
@@ -180,7 +178,9 @@ class Webserver(BotPlugin):
 
         self.log.debug("Detected your post as : %s.", contenttype)
 
-        response = self.test_app.post(url, params=content, content_type=contenttype)
+        with flask_app.test_client() as client:
+            response = client.post(url, data=content, content_type=contenttype)
+
         return {
             "url": url,
             "content": content,

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ if py_version < (3, 10):
 VERSION_FILE = os.path.join("errbot", "version.py")
 
 deps = [
-    "webtest==3.0.7",
     "setuptools>=78.1.1",
     "flask==3.1.3",
     "requests==2.32.5",
@@ -40,7 +39,6 @@ deps = [
     "pygments-markdown-lexer==0.1.0.dev39",  # syntax coloring to debug md
     "dulwich==1.2.1",  # python implementation of git
     "deepmerge==2.0",
-    "legacy-cgi==2.6.4; python_version >= '3.13'",  # stopgap fix for webtest after cgi dropped from stdlib in 3.13
 ]
 
 src_root = os.curdir
@@ -90,7 +88,7 @@ if __name__ == "__main__":
             ]
         },
         install_requires=deps,
-        tests_require=["nose", "webtest", "requests"],
+        tests_require=["nose", "requests"],
         package_data={
             "errbot": [
                 "backends/*.plug",


### PR DESCRIPTION
The refactor removes webtest as a package dependency and leaves all existing functionality intact.