### PR TITLE
fix: xmpp dependencies on python 3.10

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ v9.9.9 (unreleased)
 - refactor: remove webtest dependency (#1769)
 - feat: support editable installed entrypoint plugins (#1766)
 - fix: XMPP backend referencing invalid method (#1768)
+- fix: XMPP support on python 3.10 (#1771)
 
 
 v6.2.1 (2026-06-06)

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,6 @@ def read(fname, encoding="ascii"):
 
 
 if __name__ == "__main__":
-
     VERSION = read_version()
 
     args = set(sys.argv)
@@ -124,7 +123,12 @@ if __name__ == "__main__":
                 # held at 13.15: v20+ is fully async; backend would need a rewrite
                 "python-telegram-bot==13.15",
             ],
-            "XMPP": [
+            "XMPP:python_version < '3.11'": [
+                "slixmpp==1.12.0",
+                "pyasn1==0.6.3",
+                "pyasn1-modules==0.4.2",
+            ],
+            "XMPP:python_version >= '3.11'": [
                 "slixmpp==1.15.0",
                 "pyasn1==0.6.3",
                 "pyasn1-modules==0.4.2",


### PR DESCRIPTION
Fixing dependency issue with XMPP on python 3.10

This should address issue reported in https://github.com/errbotio/errbot/issues/1770.